### PR TITLE
Expand test coverage for cumulative and derived offset metrics

### DIFF
--- a/metricflow/test/integration/test_cases/itest_cumulative_metric.yaml
+++ b/metricflow/test/integration/test_cases/itest_cumulative_metric.yaml
@@ -310,3 +310,34 @@ integration_test:
     ON b.created_at <= a.ds
     GROUP BY a.ds
     ORDER by a.ds
+---
+integration_test:
+  name: cumulative_metric_with_non_adjustable_filter
+  description: Query a cumulative metric that has a time filter which cannot be adapted to cover the full input range
+  model: SIMPLE_MODEL
+  metrics: ["every_two_days_bookers"]
+  group_bys: ["metric_time__day"]
+  order_bys: ["metric_time__day"]
+  where_filter: |
+    {{ render_time_dimension_template('metric_time', 'day') }} = '2019-12-20'
+      or {{ render_time_dimension_template('metric_time', 'day') }} = '2020-01-04'
+  check_query: |
+    SELECT
+      COUNT (DISTINCT(b.guest_id)) as every_two_days_bookers
+      , a.ds AS metric_time__day
+    FROM (
+      SELECT ds
+      FROM {{ mf_time_spine_source }}
+      WHERE {{ render_time_constraint("ds", "2019-12-19", "2020-01-04") }}
+    ) a
+    INNER JOIN (
+        SELECT
+          guest_id
+          , ds
+        FROM {{ source_schema }}.fct_bookings
+    ) b
+    ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.DAY) }}
+    WHERE {{ render_time_constraint("a.ds", "2019-12-20", "2019-12-20") }}
+      OR {{ render_time_constraint("a.ds", "2020-01-04", "2020-01-04") }}
+    GROUP BY a.ds
+    ORDER BY a.ds

--- a/metricflow/test/query_rendering/test_cumulative_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_cumulative_metric_rendering.py
@@ -30,7 +30,7 @@ def test_cumulative_metric(
     consistent_id_object_repository: ConsistentIdObjectRepository,
     sql_client: SqlClient,
 ) -> None:
-    """Tests converting a dataflow plan to a SQL query plan where there is a cumulative metric to compute."""
+    """Tests rendering a basic cumulative metric query."""
     dataflow_plan = dataflow_plan_builder.build_plan(
         MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="trailing_2_months_revenue"),),
@@ -63,7 +63,12 @@ def test_cumulative_metric_with_time_constraint(
     consistent_id_object_repository: ConsistentIdObjectRepository,
     sql_client: SqlClient,
 ) -> None:
-    """Tests converting a dataflow plan to a SQL query plan where there is a cumulative metric to compute."""
+    """Tests rendering a cumulative metric query with an adjustable time constraint.
+
+    Not all query inputs with time constraint filters allow us to adjust the time constraint to include the full
+    span of input data for a cumulative metric, but when we receive a time constraint filter expression we can
+    automatically adjust it should render a query similar to this one.
+    """
     dataflow_plan = dataflow_plan_builder.build_plan(
         MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="trailing_2_months_revenue"),),
@@ -99,7 +104,7 @@ def test_cumulative_metric_no_ds(
     consistent_id_object_repository: ConsistentIdObjectRepository,
     sql_client: SqlClient,
 ) -> None:
-    """Tests converting a dataflow plan to a SQL query plan where there is a cumulative metric to compute."""
+    """Tests rendering a cumulative metric with no time dimension specified."""
     dataflow_plan = dataflow_plan_builder.build_plan(
         MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="trailing_2_months_revenue"),),
@@ -126,7 +131,7 @@ def test_cumulative_metric_no_window(
     consistent_id_object_repository: ConsistentIdObjectRepository,
     sql_client: SqlClient,
 ) -> None:
-    """Tests converting a dataflow plan to a SQL query plan where there is a windowless cumulative metric to compute."""
+    """Tests rendering a query where there is a windowless cumulative metric to compute."""
     dataflow_plan = dataflow_plan_builder.build_plan(
         MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="revenue_all_time"),),
@@ -159,7 +164,7 @@ def test_cumulative_metric_no_window_with_time_constraint(
     consistent_id_object_repository: ConsistentIdObjectRepository,
     sql_client: SqlClient,
 ) -> None:
-    """Tests converting a dataflow plan to a SQL query plan where there is a windowless cumulative metric to compute."""
+    """Tests rendering a query for a windowless cumulative metric query with an adjustable time constraint."""
     dataflow_plan = dataflow_plan_builder.build_plan(
         MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="revenue_all_time"),),
@@ -195,7 +200,7 @@ def test_cumulative_metric_grain_to_date(
     consistent_id_object_repository: ConsistentIdObjectRepository,
     sql_client: SqlClient,
 ) -> None:
-    """Tests converting a dataflow plan to a SQL query plan where grain_to_date cumulative metric to compute."""
+    """Tests rendering a query against a grain_to_date cumulative metric."""
     dataflow_plan = dataflow_plan_builder.build_plan(
         MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="revenue_mtd"),),

--- a/metricflow/test/query_rendering/test_derived_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_derived_metric_rendering.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 import pytest
 from _pytest.fixtures import FixtureRequest
+from dbt_semantic_interfaces.implementations.filters.where_filter import PydanticWhereFilter
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
+from metricflow.specs.column_assoc import ColumnAssociationResolver
 from metricflow.specs.specs import (
     MetricFlowQuerySpec,
     MetricSpec,
 )
+from metricflow.specs.where_filter_transform import WhereSpecFactory
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.query_rendering.compare_rendered_query import convert_and_check
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_QUARTER, MTD_SPEC_WEEK, MTD_SPEC_YEAR
@@ -77,6 +80,41 @@ def test_derived_metric_with_offset_window(  # noqa: D
         MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks"),),
             time_dimension_specs=(MTD_SPEC_DAY,),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    column_association_resolver: ColumnAssociationResolver,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+            where_constraint=WhereSpecFactory(
+                column_association_resolver=column_association_resolver,
+            ).create_from_where_filter(
+                PydanticWhereFilter(
+                    where_sql_template=(
+                        "{{ TimeDimension('metric_time', 'day') }} = '2020-01-01' "
+                        "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-14'"
+                    )
+                ),
+            ),
         )
     )
 

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -1,0 +1,335 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , subq_7.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_6.metric_time__day
+    , COUNT(DISTINCT subq_6.bookers) AS bookers
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_5.metric_time__day
+      , subq_5.bookers
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookers', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookers
+      FROM (
+        -- Join Self Over Time Range
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          (
+            subq_1.metric_time__day <= subq_2.metric_time__day
+          ) AND (
+            subq_1.metric_time__day > DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 2 day)
+          )
+      ) subq_4
+    ) subq_5
+    WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+  ) subq_6
+  GROUP BY
+    metric_time__day
+) subq_7

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -1,0 +1,26 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  SELECT
+    subq_11.ds AS metric_time__day
+    , bookings_source_src_10001.guest_id AS bookers
+  FROM ***************************.mf_time_spine subq_11
+  INNER JOIN
+    ***************************.fct_bookings bookings_source_src_10001
+  ON
+    (
+      DATE_TRUNC(bookings_source_src_10001.ds, day) <= subq_11.ds
+    ) AND (
+      DATE_TRUNC(bookings_source_src_10001.ds, day) > DATE_SUB(CAST(subq_11.ds AS DATETIME), INTERVAL 2 day)
+    )
+) subq_13
+WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+GROUP BY
+  metric_time__day

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,130 +1,190 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements:
-    --   ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements:
+      --   ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.company__ds__day
-        , subq_1.company__ds__week
-        , subq_1.company__ds__month
-        , subq_1.company__ds__quarter
-        , subq_1.company__ds__year
-        , subq_1.company__ds__extract_year
-        , subq_1.company__ds__extract_quarter
-        , subq_1.company__ds__extract_month
-        , subq_1.company__ds__extract_day
-        , subq_1.company__ds__extract_dow
-        , subq_1.company__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.company__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.company__ds__day
-          , subq_0.company__ds__week
-          , subq_0.company__ds__month
-          , subq_0.company__ds__quarter
-          , subq_0.company__ds__year
-          , subq_0.company__ds__extract_year
-          , subq_0.company__ds__extract_quarter
-          , subq_0.company__ds__extract_month
-          , subq_0.company__ds__extract_day
-          , subq_0.company__ds__extract_dow
-          , subq_0.company__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.company__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.company__ds__day AS company__ds__day
+          , subq_2.company__ds__week AS company__ds__week
+          , subq_2.company__ds__month AS company__ds__month
+          , subq_2.company__ds__quarter AS company__ds__quarter
+          , subq_2.company__ds__year AS company__ds__year
+          , subq_2.company__ds__extract_year AS company__ds__extract_year
+          , subq_2.company__ds__extract_quarter AS company__ds__extract_quarter
+          , subq_2.company__ds__extract_month AS company__ds__extract_month
+          , subq_2.company__ds__extract_day AS company__ds__extract_day
+          , subq_2.company__ds__extract_dow AS company__ds__extract_dow
+          , subq_2.company__ds__extract_doy AS company__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.company__user AS company__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Date Spine
           SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , DATE_TRUNC(revenue_src_10006.created_at, day) AS ds__day
-            , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
-            , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
-            , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
-            , DATE_TRUNC(revenue_src_10006.created_at, year) AS ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
-            , IF(EXTRACT(dayofweek FROM revenue_src_10006.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_10006.created_at) - 1) AS ds__extract_dow
-            , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , DATE_TRUNC(revenue_src_10006.created_at, day) AS company__ds__day
-            , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
-            , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
-            , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter
-            , DATE_TRUNC(revenue_src_10006.created_at, year) AS company__ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
-            , IF(EXTRACT(dayofweek FROM revenue_src_10006.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_10006.created_at) - 1) AS company__ds__extract_dow
-            , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS company__ds__extract_doy
-            , revenue_src_10006.user_id AS user
-            , revenue_src_10006.user_id AS company__user
-          FROM ***************************.fct_revenue revenue_src_10006
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.company__ds__day
+            , subq_1.company__ds__week
+            , subq_1.company__ds__month
+            , subq_1.company__ds__quarter
+            , subq_1.company__ds__year
+            , subq_1.company__ds__extract_year
+            , subq_1.company__ds__extract_quarter
+            , subq_1.company__ds__extract_month
+            , subq_1.company__ds__extract_day
+            , subq_1.company__ds__extract_dow
+            , subq_1.company__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.company__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.company__ds__day
+              , subq_0.company__ds__week
+              , subq_0.company__ds__month
+              , subq_0.company__ds__quarter
+              , subq_0.company__ds__year
+              , subq_0.company__ds__extract_year
+              , subq_0.company__ds__extract_quarter
+              , subq_0.company__ds__extract_month
+              , subq_0.company__ds__extract_day
+              , subq_0.company__ds__extract_dow
+              , subq_0.company__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.company__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10006.revenue AS txn_revenue
+                , DATE_TRUNC(revenue_src_10006.created_at, day) AS ds__day
+                , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS ds__week
+                , DATE_TRUNC(revenue_src_10006.created_at, month) AS ds__month
+                , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS ds__quarter
+                , DATE_TRUNC(revenue_src_10006.created_at, year) AS ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM revenue_src_10006.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_10006.created_at) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS ds__extract_doy
+                , DATE_TRUNC(revenue_src_10006.created_at, day) AS company__ds__day
+                , DATE_TRUNC(revenue_src_10006.created_at, isoweek) AS company__ds__week
+                , DATE_TRUNC(revenue_src_10006.created_at, month) AS company__ds__month
+                , DATE_TRUNC(revenue_src_10006.created_at, quarter) AS company__ds__quarter
+                , DATE_TRUNC(revenue_src_10006.created_at, year) AS company__ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM revenue_src_10006.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_10006.created_at) - 1) AS company__ds__extract_dow
+                , EXTRACT(dayofyear FROM revenue_src_10006.created_at) AS company__ds__extract_doy
+                , revenue_src_10006.user_id AS user
+                , revenue_src_10006.user_id AS company__user
+              FROM ***************************.fct_revenue revenue_src_10006
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (
+            subq_2.metric_time__day <= subq_3.metric_time__day
+          ) AND (
+            subq_2.metric_time__day > DATE_SUB(CAST(subq_3.metric_time__day AS DATETIME), INTERVAL 2 month)
+          )
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    ds__month
-) subq_4
+    metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,14 +1,36 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+-- Join Self Over Time Range
 -- Pass Only Elements:
---   ['txn_revenue', 'ds__month']
+--   ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC(created_at, month) AS ds__month
-  , SUM(revenue) AS trailing_2_months_revenue
-FROM ***************************.fct_revenue revenue_src_10006
-WHERE DATE_TRUNC(created_at, day) BETWEEN '2019-12-01' AND '2020-01-01'
+  subq_11.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
+FROM (
+  -- Date Spine
+  SELECT
+    ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC(created_at, day) AS metric_time__day
+    , DATE_TRUNC(created_at, month) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10006
+  WHERE DATE_TRUNC(created_at, day) BETWEEN '2019-12-01' AND '2020-01-01'
+) subq_11
+ON
+  (
+    subq_11.metric_time__day <= subq_12.metric_time__day
+  ) AND (
+    subq_11.metric_time__day > DATE_SUB(CAST(subq_12.metric_time__day AS DATETIME), INTERVAL 2 month)
+  )
+WHERE subq_11.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  ds__month
+  metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -1,0 +1,335 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , subq_7.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_6.metric_time__day
+    , COUNT(DISTINCT subq_6.bookers) AS bookers
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_5.metric_time__day
+      , subq_5.bookers
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookers', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookers
+      FROM (
+        -- Join Self Over Time Range
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          (
+            subq_1.metric_time__day <= subq_2.metric_time__day
+          ) AND (
+            subq_1.metric_time__day > DATEADD(day, -2, subq_2.metric_time__day)
+          )
+      ) subq_4
+    ) subq_5
+    WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+  ) subq_6
+  GROUP BY
+    subq_6.metric_time__day
+) subq_7

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -1,0 +1,26 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  SELECT
+    subq_11.ds AS metric_time__day
+    , bookings_source_src_10001.guest_id AS bookers
+  FROM ***************************.mf_time_spine subq_11
+  INNER JOIN
+    ***************************.fct_bookings bookings_source_src_10001
+  ON
+    (
+      DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_11.ds
+    ) AND (
+      DATE_TRUNC('day', bookings_source_src_10001.ds) > DATEADD(day, -2, subq_11.ds)
+    )
+) subq_13
+WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+GROUP BY
+  metric_time__day

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,130 +1,190 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements:
-    --   ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements:
+      --   ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.company__ds__day
-        , subq_1.company__ds__week
-        , subq_1.company__ds__month
-        , subq_1.company__ds__quarter
-        , subq_1.company__ds__year
-        , subq_1.company__ds__extract_year
-        , subq_1.company__ds__extract_quarter
-        , subq_1.company__ds__extract_month
-        , subq_1.company__ds__extract_day
-        , subq_1.company__ds__extract_dow
-        , subq_1.company__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.company__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.company__ds__day
-          , subq_0.company__ds__week
-          , subq_0.company__ds__month
-          , subq_0.company__ds__quarter
-          , subq_0.company__ds__year
-          , subq_0.company__ds__extract_year
-          , subq_0.company__ds__extract_quarter
-          , subq_0.company__ds__extract_month
-          , subq_0.company__ds__extract_day
-          , subq_0.company__ds__extract_dow
-          , subq_0.company__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.company__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.company__ds__day AS company__ds__day
+          , subq_2.company__ds__week AS company__ds__week
+          , subq_2.company__ds__month AS company__ds__month
+          , subq_2.company__ds__quarter AS company__ds__quarter
+          , subq_2.company__ds__year AS company__ds__year
+          , subq_2.company__ds__extract_year AS company__ds__extract_year
+          , subq_2.company__ds__extract_quarter AS company__ds__extract_quarter
+          , subq_2.company__ds__extract_month AS company__ds__extract_month
+          , subq_2.company__ds__extract_day AS company__ds__extract_day
+          , subq_2.company__ds__extract_dow AS company__ds__extract_dow
+          , subq_2.company__ds__extract_doy AS company__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.company__user AS company__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Date Spine
           SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_10006.created_at) AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS company__ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_10006.created_at) AS company__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10006.created_at) AS company__ds__extract_doy
-            , revenue_src_10006.user_id AS user
-            , revenue_src_10006.user_id AS company__user
-          FROM ***************************.fct_revenue revenue_src_10006
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.company__ds__day
+            , subq_1.company__ds__week
+            , subq_1.company__ds__month
+            , subq_1.company__ds__quarter
+            , subq_1.company__ds__year
+            , subq_1.company__ds__extract_year
+            , subq_1.company__ds__extract_quarter
+            , subq_1.company__ds__extract_month
+            , subq_1.company__ds__extract_day
+            , subq_1.company__ds__extract_dow
+            , subq_1.company__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.company__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.company__ds__day
+              , subq_0.company__ds__week
+              , subq_0.company__ds__month
+              , subq_0.company__ds__quarter
+              , subq_0.company__ds__year
+              , subq_0.company__ds__extract_year
+              , subq_0.company__ds__extract_quarter
+              , subq_0.company__ds__extract_month
+              , subq_0.company__ds__extract_day
+              , subq_0.company__ds__extract_dow
+              , subq_0.company__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.company__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10006.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_10006.created_at) AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
+                , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
+                , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10006.created_at) AS company__ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_10006.created_at) AS company__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10006.created_at) AS company__ds__extract_doy
+                , revenue_src_10006.user_id AS user
+                , revenue_src_10006.user_id AS company__user
+              FROM ***************************.fct_revenue revenue_src_10006
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (
+            subq_2.metric_time__day <= subq_3.metric_time__day
+          ) AND (
+            subq_2.metric_time__day > DATEADD(month, -2, subq_3.metric_time__day)
+          )
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,14 +1,36 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+-- Join Self Over Time Range
 -- Pass Only Elements:
---   ['txn_revenue', 'ds__month']
+--   ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS trailing_2_months_revenue
-FROM ***************************.fct_revenue revenue_src_10006
-WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
+  subq_11.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
+FROM (
+  -- Date Spine
+  SELECT
+    ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('day', created_at) AS metric_time__day
+    , DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10006
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
+) subq_11
+ON
+  (
+    subq_11.metric_time__day <= subq_12.metric_time__day
+  ) AND (
+    subq_11.metric_time__day > DATEADD(month, -2, subq_12.metric_time__day)
+  )
+WHERE subq_11.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_11.metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -1,0 +1,335 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , subq_7.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_6.metric_time__day
+    , COUNT(DISTINCT subq_6.bookers) AS bookers
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_5.metric_time__day
+      , subq_5.bookers
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookers', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookers
+      FROM (
+        -- Join Self Over Time Range
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          (
+            subq_1.metric_time__day <= subq_2.metric_time__day
+          ) AND (
+            subq_1.metric_time__day > subq_2.metric_time__day - INTERVAL 2 day
+          )
+      ) subq_4
+    ) subq_5
+    WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+  ) subq_6
+  GROUP BY
+    subq_6.metric_time__day
+) subq_7

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -1,0 +1,26 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  SELECT
+    subq_11.ds AS metric_time__day
+    , bookings_source_src_10001.guest_id AS bookers
+  FROM ***************************.mf_time_spine subq_11
+  INNER JOIN
+    ***************************.fct_bookings bookings_source_src_10001
+  ON
+    (
+      DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_11.ds
+    ) AND (
+      DATE_TRUNC('day', bookings_source_src_10001.ds) > subq_11.ds - INTERVAL 2 day
+    )
+) subq_13
+WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+GROUP BY
+  metric_time__day

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,130 +1,190 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements:
-    --   ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements:
+      --   ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.company__ds__day
-        , subq_1.company__ds__week
-        , subq_1.company__ds__month
-        , subq_1.company__ds__quarter
-        , subq_1.company__ds__year
-        , subq_1.company__ds__extract_year
-        , subq_1.company__ds__extract_quarter
-        , subq_1.company__ds__extract_month
-        , subq_1.company__ds__extract_day
-        , subq_1.company__ds__extract_dow
-        , subq_1.company__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.company__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.company__ds__day
-          , subq_0.company__ds__week
-          , subq_0.company__ds__month
-          , subq_0.company__ds__quarter
-          , subq_0.company__ds__year
-          , subq_0.company__ds__extract_year
-          , subq_0.company__ds__extract_quarter
-          , subq_0.company__ds__extract_month
-          , subq_0.company__ds__extract_day
-          , subq_0.company__ds__extract_dow
-          , subq_0.company__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.company__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.company__ds__day AS company__ds__day
+          , subq_2.company__ds__week AS company__ds__week
+          , subq_2.company__ds__month AS company__ds__month
+          , subq_2.company__ds__quarter AS company__ds__quarter
+          , subq_2.company__ds__year AS company__ds__year
+          , subq_2.company__ds__extract_year AS company__ds__extract_year
+          , subq_2.company__ds__extract_quarter AS company__ds__extract_quarter
+          , subq_2.company__ds__extract_month AS company__ds__extract_month
+          , subq_2.company__ds__extract_day AS company__ds__extract_day
+          , subq_2.company__ds__extract_dow AS company__ds__extract_dow
+          , subq_2.company__ds__extract_doy AS company__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.company__user AS company__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Date Spine
           SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
-            , EXTRACT(isodow FROM revenue_src_10006.created_at) AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS company__ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
-            , EXTRACT(isodow FROM revenue_src_10006.created_at) AS company__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10006.created_at) AS company__ds__extract_doy
-            , revenue_src_10006.user_id AS user
-            , revenue_src_10006.user_id AS company__user
-          FROM ***************************.fct_revenue revenue_src_10006
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.company__ds__day
+            , subq_1.company__ds__week
+            , subq_1.company__ds__month
+            , subq_1.company__ds__quarter
+            , subq_1.company__ds__year
+            , subq_1.company__ds__extract_year
+            , subq_1.company__ds__extract_quarter
+            , subq_1.company__ds__extract_month
+            , subq_1.company__ds__extract_day
+            , subq_1.company__ds__extract_dow
+            , subq_1.company__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.company__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.company__ds__day
+              , subq_0.company__ds__week
+              , subq_0.company__ds__month
+              , subq_0.company__ds__quarter
+              , subq_0.company__ds__year
+              , subq_0.company__ds__extract_year
+              , subq_0.company__ds__extract_quarter
+              , subq_0.company__ds__extract_month
+              , subq_0.company__ds__extract_day
+              , subq_0.company__ds__extract_dow
+              , subq_0.company__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.company__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10006.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
+                , EXTRACT(isodow FROM revenue_src_10006.created_at) AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
+                , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
+                , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10006.created_at) AS company__ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
+                , EXTRACT(isodow FROM revenue_src_10006.created_at) AS company__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10006.created_at) AS company__ds__extract_doy
+                , revenue_src_10006.user_id AS user
+                , revenue_src_10006.user_id AS company__user
+              FROM ***************************.fct_revenue revenue_src_10006
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (
+            subq_2.metric_time__day <= subq_3.metric_time__day
+          ) AND (
+            subq_2.metric_time__day > subq_3.metric_time__day - INTERVAL 2 month
+          )
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,14 +1,36 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+-- Join Self Over Time Range
 -- Pass Only Elements:
---   ['txn_revenue', 'ds__month']
+--   ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS trailing_2_months_revenue
-FROM ***************************.fct_revenue revenue_src_10006
-WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
+  subq_11.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
+FROM (
+  -- Date Spine
+  SELECT
+    ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('day', created_at) AS metric_time__day
+    , DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10006
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
+) subq_11
+ON
+  (
+    subq_11.metric_time__day <= subq_12.metric_time__day
+  ) AND (
+    subq_11.metric_time__day > subq_12.metric_time__day - INTERVAL 2 month
+  )
+WHERE subq_11.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_11.metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -1,0 +1,335 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , subq_7.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_6.metric_time__day
+    , COUNT(DISTINCT subq_6.bookers) AS bookers
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_5.metric_time__day
+      , subq_5.bookers
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookers', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookers
+      FROM (
+        -- Join Self Over Time Range
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          (
+            subq_1.metric_time__day <= subq_2.metric_time__day
+          ) AND (
+            subq_1.metric_time__day > subq_2.metric_time__day - MAKE_INTERVAL(days => 2)
+          )
+      ) subq_4
+    ) subq_5
+    WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+  ) subq_6
+  GROUP BY
+    subq_6.metric_time__day
+) subq_7

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -1,0 +1,26 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  SELECT
+    subq_11.ds AS metric_time__day
+    , bookings_source_src_10001.guest_id AS bookers
+  FROM ***************************.mf_time_spine subq_11
+  INNER JOIN
+    ***************************.fct_bookings bookings_source_src_10001
+  ON
+    (
+      DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_11.ds
+    ) AND (
+      DATE_TRUNC('day', bookings_source_src_10001.ds) > subq_11.ds - MAKE_INTERVAL(days => 2)
+    )
+) subq_13
+WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+GROUP BY
+  metric_time__day

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,130 +1,190 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements:
-    --   ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements:
+      --   ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.company__ds__day
-        , subq_1.company__ds__week
-        , subq_1.company__ds__month
-        , subq_1.company__ds__quarter
-        , subq_1.company__ds__year
-        , subq_1.company__ds__extract_year
-        , subq_1.company__ds__extract_quarter
-        , subq_1.company__ds__extract_month
-        , subq_1.company__ds__extract_day
-        , subq_1.company__ds__extract_dow
-        , subq_1.company__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.company__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.company__ds__day
-          , subq_0.company__ds__week
-          , subq_0.company__ds__month
-          , subq_0.company__ds__quarter
-          , subq_0.company__ds__year
-          , subq_0.company__ds__extract_year
-          , subq_0.company__ds__extract_quarter
-          , subq_0.company__ds__extract_month
-          , subq_0.company__ds__extract_day
-          , subq_0.company__ds__extract_dow
-          , subq_0.company__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.company__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.company__ds__day AS company__ds__day
+          , subq_2.company__ds__week AS company__ds__week
+          , subq_2.company__ds__month AS company__ds__month
+          , subq_2.company__ds__quarter AS company__ds__quarter
+          , subq_2.company__ds__year AS company__ds__year
+          , subq_2.company__ds__extract_year AS company__ds__extract_year
+          , subq_2.company__ds__extract_quarter AS company__ds__extract_quarter
+          , subq_2.company__ds__extract_month AS company__ds__extract_month
+          , subq_2.company__ds__extract_day AS company__ds__extract_day
+          , subq_2.company__ds__extract_dow AS company__ds__extract_dow
+          , subq_2.company__ds__extract_doy AS company__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.company__user AS company__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Date Spine
           SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
-            , EXTRACT(isodow FROM revenue_src_10006.created_at) AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS company__ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
-            , EXTRACT(isodow FROM revenue_src_10006.created_at) AS company__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10006.created_at) AS company__ds__extract_doy
-            , revenue_src_10006.user_id AS user
-            , revenue_src_10006.user_id AS company__user
-          FROM ***************************.fct_revenue revenue_src_10006
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.company__ds__day
+            , subq_1.company__ds__week
+            , subq_1.company__ds__month
+            , subq_1.company__ds__quarter
+            , subq_1.company__ds__year
+            , subq_1.company__ds__extract_year
+            , subq_1.company__ds__extract_quarter
+            , subq_1.company__ds__extract_month
+            , subq_1.company__ds__extract_day
+            , subq_1.company__ds__extract_dow
+            , subq_1.company__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.company__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.company__ds__day
+              , subq_0.company__ds__week
+              , subq_0.company__ds__month
+              , subq_0.company__ds__quarter
+              , subq_0.company__ds__year
+              , subq_0.company__ds__extract_year
+              , subq_0.company__ds__extract_quarter
+              , subq_0.company__ds__extract_month
+              , subq_0.company__ds__extract_day
+              , subq_0.company__ds__extract_dow
+              , subq_0.company__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.company__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10006.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
+                , EXTRACT(isodow FROM revenue_src_10006.created_at) AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
+                , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
+                , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10006.created_at) AS company__ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
+                , EXTRACT(isodow FROM revenue_src_10006.created_at) AS company__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10006.created_at) AS company__ds__extract_doy
+                , revenue_src_10006.user_id AS user
+                , revenue_src_10006.user_id AS company__user
+              FROM ***************************.fct_revenue revenue_src_10006
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (
+            subq_2.metric_time__day <= subq_3.metric_time__day
+          ) AND (
+            subq_2.metric_time__day > subq_3.metric_time__day - MAKE_INTERVAL(months => 2)
+          )
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,14 +1,36 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+-- Join Self Over Time Range
 -- Pass Only Elements:
---   ['txn_revenue', 'ds__month']
+--   ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS trailing_2_months_revenue
-FROM ***************************.fct_revenue revenue_src_10006
-WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
+  subq_11.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
+FROM (
+  -- Date Spine
+  SELECT
+    ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('day', created_at) AS metric_time__day
+    , DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10006
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
+) subq_11
+ON
+  (
+    subq_11.metric_time__day <= subq_12.metric_time__day
+  ) AND (
+    subq_11.metric_time__day > subq_12.metric_time__day - MAKE_INTERVAL(months => 2)
+  )
+WHERE subq_11.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_11.metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -1,0 +1,335 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , subq_7.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_6.metric_time__day
+    , COUNT(DISTINCT subq_6.bookers) AS bookers
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_5.metric_time__day
+      , subq_5.bookers
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookers', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookers
+      FROM (
+        -- Join Self Over Time Range
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          (
+            subq_1.metric_time__day <= subq_2.metric_time__day
+          ) AND (
+            subq_1.metric_time__day > DATEADD(day, -2, subq_2.metric_time__day)
+          )
+      ) subq_4
+    ) subq_5
+    WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+  ) subq_6
+  GROUP BY
+    subq_6.metric_time__day
+) subq_7

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -1,0 +1,26 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  SELECT
+    subq_11.ds AS metric_time__day
+    , bookings_source_src_10001.guest_id AS bookers
+  FROM ***************************.mf_time_spine subq_11
+  INNER JOIN
+    ***************************.fct_bookings bookings_source_src_10001
+  ON
+    (
+      DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_11.ds
+    ) AND (
+      DATE_TRUNC('day', bookings_source_src_10001.ds) > DATEADD(day, -2, subq_11.ds)
+    )
+) subq_13
+WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+GROUP BY
+  metric_time__day

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,130 +1,190 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements:
-    --   ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements:
+      --   ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.company__ds__day
-        , subq_1.company__ds__week
-        , subq_1.company__ds__month
-        , subq_1.company__ds__quarter
-        , subq_1.company__ds__year
-        , subq_1.company__ds__extract_year
-        , subq_1.company__ds__extract_quarter
-        , subq_1.company__ds__extract_month
-        , subq_1.company__ds__extract_day
-        , subq_1.company__ds__extract_dow
-        , subq_1.company__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.company__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.company__ds__day
-          , subq_0.company__ds__week
-          , subq_0.company__ds__month
-          , subq_0.company__ds__quarter
-          , subq_0.company__ds__year
-          , subq_0.company__ds__extract_year
-          , subq_0.company__ds__extract_quarter
-          , subq_0.company__ds__extract_month
-          , subq_0.company__ds__extract_day
-          , subq_0.company__ds__extract_dow
-          , subq_0.company__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.company__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.company__ds__day AS company__ds__day
+          , subq_2.company__ds__week AS company__ds__week
+          , subq_2.company__ds__month AS company__ds__month
+          , subq_2.company__ds__quarter AS company__ds__quarter
+          , subq_2.company__ds__year AS company__ds__year
+          , subq_2.company__ds__extract_year AS company__ds__extract_year
+          , subq_2.company__ds__extract_quarter AS company__ds__extract_quarter
+          , subq_2.company__ds__extract_month AS company__ds__extract_month
+          , subq_2.company__ds__extract_day AS company__ds__extract_day
+          , subq_2.company__ds__extract_dow AS company__ds__extract_dow
+          , subq_2.company__ds__extract_doy AS company__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.company__user AS company__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Date Spine
           SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
-            , CASE WHEN EXTRACT(dow FROM revenue_src_10006.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_10006.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_10006.created_at) END AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS company__ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
-            , CASE WHEN EXTRACT(dow FROM revenue_src_10006.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_10006.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_10006.created_at) END AS company__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10006.created_at) AS company__ds__extract_doy
-            , revenue_src_10006.user_id AS user
-            , revenue_src_10006.user_id AS company__user
-          FROM ***************************.fct_revenue revenue_src_10006
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.company__ds__day
+            , subq_1.company__ds__week
+            , subq_1.company__ds__month
+            , subq_1.company__ds__quarter
+            , subq_1.company__ds__year
+            , subq_1.company__ds__extract_year
+            , subq_1.company__ds__extract_quarter
+            , subq_1.company__ds__extract_month
+            , subq_1.company__ds__extract_day
+            , subq_1.company__ds__extract_dow
+            , subq_1.company__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.company__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.company__ds__day
+              , subq_0.company__ds__week
+              , subq_0.company__ds__month
+              , subq_0.company__ds__quarter
+              , subq_0.company__ds__year
+              , subq_0.company__ds__extract_year
+              , subq_0.company__ds__extract_quarter
+              , subq_0.company__ds__extract_month
+              , subq_0.company__ds__extract_day
+              , subq_0.company__ds__extract_dow
+              , subq_0.company__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.company__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10006.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM revenue_src_10006.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_10006.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_10006.created_at) END AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
+                , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
+                , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10006.created_at) AS company__ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM revenue_src_10006.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_10006.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_10006.created_at) END AS company__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10006.created_at) AS company__ds__extract_doy
+                , revenue_src_10006.user_id AS user
+                , revenue_src_10006.user_id AS company__user
+              FROM ***************************.fct_revenue revenue_src_10006
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (
+            subq_2.metric_time__day <= subq_3.metric_time__day
+          ) AND (
+            subq_2.metric_time__day > DATEADD(month, -2, subq_3.metric_time__day)
+          )
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,14 +1,36 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+-- Join Self Over Time Range
 -- Pass Only Elements:
---   ['txn_revenue', 'ds__month']
+--   ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS trailing_2_months_revenue
-FROM ***************************.fct_revenue revenue_src_10006
-WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
+  subq_11.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
+FROM (
+  -- Date Spine
+  SELECT
+    ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('day', created_at) AS metric_time__day
+    , DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10006
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
+) subq_11
+ON
+  (
+    subq_11.metric_time__day <= subq_12.metric_time__day
+  ) AND (
+    subq_11.metric_time__day > DATEADD(month, -2, subq_12.metric_time__day)
+  )
+WHERE subq_11.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_11.metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_adjustable_time_filter__plan0.sql
@@ -1,0 +1,335 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , subq_7.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_6.metric_time__day
+    , COUNT(DISTINCT subq_6.bookers) AS bookers
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_5.metric_time__day
+      , subq_5.bookers
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookers', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookers
+      FROM (
+        -- Join Self Over Time Range
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.metric_time__week AS metric_time__week
+          , subq_1.metric_time__month AS metric_time__month
+          , subq_1.metric_time__quarter AS metric_time__quarter
+          , subq_1.metric_time__year AS metric_time__year
+          , subq_1.metric_time__extract_year AS metric_time__extract_year
+          , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_1.metric_time__extract_month AS metric_time__extract_month
+          , subq_1.metric_time__extract_day AS metric_time__extract_day
+          , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          (
+            subq_1.metric_time__day <= subq_2.metric_time__day
+          ) AND (
+            subq_1.metric_time__day > DATEADD(day, -2, subq_2.metric_time__day)
+          )
+      ) subq_4
+    ) subq_5
+    WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+  ) subq_6
+  GROUP BY
+    subq_6.metric_time__day
+) subq_7

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_adjustable_time_filter__plan0_optimized.sql
@@ -1,0 +1,26 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  SELECT
+    subq_11.ds AS metric_time__day
+    , bookings_source_src_10001.guest_id AS bookers
+  FROM ***************************.mf_time_spine subq_11
+  INNER JOIN
+    ***************************.fct_bookings bookings_source_src_10001
+  ON
+    (
+      DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_11.ds
+    ) AND (
+      DATE_TRUNC('day', bookings_source_src_10001.ds) > DATEADD(day, -2, subq_11.ds)
+    )
+) subq_13
+WHERE metric_time__day = '2020-01-03' or metric_time__day = '2020-01-07'
+GROUP BY
+  metric_time__day

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0.sql
@@ -1,130 +1,190 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS trailing_2_months_revenue
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS trailing_2_months_revenue
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements:
-    --   ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements:
+      --   ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.company__ds__day
-        , subq_1.company__ds__week
-        , subq_1.company__ds__month
-        , subq_1.company__ds__quarter
-        , subq_1.company__ds__year
-        , subq_1.company__ds__extract_year
-        , subq_1.company__ds__extract_quarter
-        , subq_1.company__ds__extract_month
-        , subq_1.company__ds__extract_day
-        , subq_1.company__ds__extract_dow
-        , subq_1.company__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.company__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.company__ds__day
-          , subq_0.company__ds__week
-          , subq_0.company__ds__month
-          , subq_0.company__ds__quarter
-          , subq_0.company__ds__year
-          , subq_0.company__ds__extract_year
-          , subq_0.company__ds__extract_quarter
-          , subq_0.company__ds__extract_month
-          , subq_0.company__ds__extract_day
-          , subq_0.company__ds__extract_dow
-          , subq_0.company__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.company__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__day AS metric_time__day
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.company__ds__day AS company__ds__day
+          , subq_2.company__ds__week AS company__ds__week
+          , subq_2.company__ds__month AS company__ds__month
+          , subq_2.company__ds__quarter AS company__ds__quarter
+          , subq_2.company__ds__year AS company__ds__year
+          , subq_2.company__ds__extract_year AS company__ds__extract_year
+          , subq_2.company__ds__extract_quarter AS company__ds__extract_quarter
+          , subq_2.company__ds__extract_month AS company__ds__extract_month
+          , subq_2.company__ds__extract_day AS company__ds__extract_day
+          , subq_2.company__ds__extract_dow AS company__ds__extract_dow
+          , subq_2.company__ds__extract_doy AS company__ds__extract_doy
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__month AS metric_time__month
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.company__user AS company__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Date Spine
           SELECT
-            revenue_src_10006.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
-            , EXTRACT(dayofweekiso FROM revenue_src_10006.created_at) AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
-            , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
-            , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10006.created_at) AS company__ds__year
-            , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
-            , EXTRACT(dayofweekiso FROM revenue_src_10006.created_at) AS company__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10006.created_at) AS company__ds__extract_doy
-            , revenue_src_10006.user_id AS user
-            , revenue_src_10006.user_id AS company__user
-          FROM ***************************.fct_revenue revenue_src_10006
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            subq_4.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.company__ds__day
+            , subq_1.company__ds__week
+            , subq_1.company__ds__month
+            , subq_1.company__ds__quarter
+            , subq_1.company__ds__year
+            , subq_1.company__ds__extract_year
+            , subq_1.company__ds__extract_quarter
+            , subq_1.company__ds__extract_month
+            , subq_1.company__ds__extract_day
+            , subq_1.company__ds__extract_dow
+            , subq_1.company__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.company__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.company__ds__day
+              , subq_0.company__ds__week
+              , subq_0.company__ds__month
+              , subq_0.company__ds__quarter
+              , subq_0.company__ds__year
+              , subq_0.company__ds__extract_year
+              , subq_0.company__ds__extract_quarter
+              , subq_0.company__ds__extract_month
+              , subq_0.company__ds__extract_day
+              , subq_0.company__ds__extract_dow
+              , subq_0.company__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.company__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10006.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10006.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10006.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10006.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10006.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM revenue_src_10006.created_at) AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10006.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10006.created_at) AS company__ds__day
+                , DATE_TRUNC('week', revenue_src_10006.created_at) AS company__ds__week
+                , DATE_TRUNC('month', revenue_src_10006.created_at) AS company__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10006.created_at) AS company__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10006.created_at) AS company__ds__year
+                , EXTRACT(year FROM revenue_src_10006.created_at) AS company__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10006.created_at) AS company__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10006.created_at) AS company__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10006.created_at) AS company__ds__extract_day
+                , EXTRACT(dayofweekiso FROM revenue_src_10006.created_at) AS company__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10006.created_at) AS company__ds__extract_doy
+                , revenue_src_10006.user_id AS user
+                , revenue_src_10006.user_id AS company__user
+              FROM ***************************.fct_revenue revenue_src_10006
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2019-12-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (
+            subq_2.metric_time__day <= subq_3.metric_time__day
+          ) AND (
+            subq_2.metric_time__day > DATEADD(month, -2, subq_3.metric_time__day)
+          )
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -1,14 +1,36 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+-- Join Self Over Time Range
 -- Pass Only Elements:
---   ['txn_revenue', 'ds__month']
+--   ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS trailing_2_months_revenue
-FROM ***************************.fct_revenue revenue_src_10006
-WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
+  subq_11.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS trailing_2_months_revenue
+FROM (
+  -- Date Spine
+  SELECT
+    ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2019-12-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('day', created_at) AS metric_time__day
+    , DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10006
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-12-01' AND '2020-01-01'
+) subq_11
+ON
+  (
+    subq_11.metric_time__day <= subq_12.metric_time__day
+  ) AND (
+    subq_11.metric_time__day > DATEADD(month, -2, subq_12.metric_time__day)
+  )
+WHERE subq_11.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_11.metric_time__month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -1,0 +1,561 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_5.bookings) AS bookings
+    , MAX(subq_14.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_3
+      GROUP BY
+        metric_time__day
+    ) subq_4
+  ) subq_5
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_12.metric_time__day
+        , SUM(subq_12.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_11.metric_time__day
+          , subq_11.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_8.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
+              , subq_7.ds__week AS ds__week
+              , subq_7.ds__month AS ds__month
+              , subq_7.ds__quarter AS ds__quarter
+              , subq_7.ds__year AS ds__year
+              , subq_7.ds__extract_year AS ds__extract_year
+              , subq_7.ds__extract_quarter AS ds__extract_quarter
+              , subq_7.ds__extract_month AS ds__extract_month
+              , subq_7.ds__extract_day AS ds__extract_day
+              , subq_7.ds__extract_dow AS ds__extract_dow
+              , subq_7.ds__extract_doy AS ds__extract_doy
+              , subq_7.ds_partitioned__day AS ds_partitioned__day
+              , subq_7.ds_partitioned__week AS ds_partitioned__week
+              , subq_7.ds_partitioned__month AS ds_partitioned__month
+              , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_7.ds_partitioned__year AS ds_partitioned__year
+              , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_7.paid_at__day AS paid_at__day
+              , subq_7.paid_at__week AS paid_at__week
+              , subq_7.paid_at__month AS paid_at__month
+              , subq_7.paid_at__quarter AS paid_at__quarter
+              , subq_7.paid_at__year AS paid_at__year
+              , subq_7.paid_at__extract_year AS paid_at__extract_year
+              , subq_7.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_7.paid_at__extract_month AS paid_at__extract_month
+              , subq_7.paid_at__extract_day AS paid_at__extract_day
+              , subq_7.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_7.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_7.booking__ds__day AS booking__ds__day
+              , subq_7.booking__ds__week AS booking__ds__week
+              , subq_7.booking__ds__month AS booking__ds__month
+              , subq_7.booking__ds__quarter AS booking__ds__quarter
+              , subq_7.booking__ds__year AS booking__ds__year
+              , subq_7.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_7.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_7.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_7.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_7.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_7.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_7.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_7.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_7.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_7.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_7.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_7.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_7.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_7.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_7.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_7.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_7.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_7.booking__paid_at__day AS booking__paid_at__day
+              , subq_7.booking__paid_at__week AS booking__paid_at__week
+              , subq_7.booking__paid_at__month AS booking__paid_at__month
+              , subq_7.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_7.booking__paid_at__year AS booking__paid_at__year
+              , subq_7.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_7.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_7.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.listing AS listing
+              , subq_7.guest AS guest
+              , subq_7.host AS host
+              , subq_7.booking__listing AS booking__listing
+              , subq_7.booking__guest AS booking__guest
+              , subq_7.booking__host AS booking__host
+              , subq_7.is_instant AS is_instant
+              , subq_7.booking__is_instant AS booking__is_instant
+              , subq_7.bookings AS bookings
+              , subq_7.instant_bookings AS instant_bookings
+              , subq_7.booking_value AS booking_value
+              , subq_7.max_booking_value AS max_booking_value
+              , subq_7.min_booking_value AS min_booking_value
+              , subq_7.bookers AS bookers
+              , subq_7.average_booking_value AS average_booking_value
+              , subq_7.referred_bookings AS referred_bookings
+              , subq_7.median_booking_value AS median_booking_value
+              , subq_7.booking_value_p99 AS booking_value_p99
+              , subq_7.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_9.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_9
+            ) subq_8
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds_partitioned__day
+                , subq_6.ds_partitioned__week
+                , subq_6.ds_partitioned__month
+                , subq_6.ds_partitioned__quarter
+                , subq_6.ds_partitioned__year
+                , subq_6.ds_partitioned__extract_year
+                , subq_6.ds_partitioned__extract_quarter
+                , subq_6.ds_partitioned__extract_month
+                , subq_6.ds_partitioned__extract_day
+                , subq_6.ds_partitioned__extract_dow
+                , subq_6.ds_partitioned__extract_doy
+                , subq_6.paid_at__day
+                , subq_6.paid_at__week
+                , subq_6.paid_at__month
+                , subq_6.paid_at__quarter
+                , subq_6.paid_at__year
+                , subq_6.paid_at__extract_year
+                , subq_6.paid_at__extract_quarter
+                , subq_6.paid_at__extract_month
+                , subq_6.paid_at__extract_day
+                , subq_6.paid_at__extract_dow
+                , subq_6.paid_at__extract_doy
+                , subq_6.booking__ds__day
+                , subq_6.booking__ds__week
+                , subq_6.booking__ds__month
+                , subq_6.booking__ds__quarter
+                , subq_6.booking__ds__year
+                , subq_6.booking__ds__extract_year
+                , subq_6.booking__ds__extract_quarter
+                , subq_6.booking__ds__extract_month
+                , subq_6.booking__ds__extract_day
+                , subq_6.booking__ds__extract_dow
+                , subq_6.booking__ds__extract_doy
+                , subq_6.booking__ds_partitioned__day
+                , subq_6.booking__ds_partitioned__week
+                , subq_6.booking__ds_partitioned__month
+                , subq_6.booking__ds_partitioned__quarter
+                , subq_6.booking__ds_partitioned__year
+                , subq_6.booking__ds_partitioned__extract_year
+                , subq_6.booking__ds_partitioned__extract_quarter
+                , subq_6.booking__ds_partitioned__extract_month
+                , subq_6.booking__ds_partitioned__extract_day
+                , subq_6.booking__ds_partitioned__extract_dow
+                , subq_6.booking__ds_partitioned__extract_doy
+                , subq_6.booking__paid_at__day
+                , subq_6.booking__paid_at__week
+                , subq_6.booking__paid_at__month
+                , subq_6.booking__paid_at__quarter
+                , subq_6.booking__paid_at__year
+                , subq_6.booking__paid_at__extract_year
+                , subq_6.booking__paid_at__extract_quarter
+                , subq_6.booking__paid_at__extract_month
+                , subq_6.booking__paid_at__extract_day
+                , subq_6.booking__paid_at__extract_dow
+                , subq_6.booking__paid_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.guest
+                , subq_6.host
+                , subq_6.booking__listing
+                , subq_6.booking__guest
+                , subq_6.booking__host
+                , subq_6.is_instant
+                , subq_6.booking__is_instant
+                , subq_6.bookings
+                , subq_6.instant_bookings
+                , subq_6.booking_value
+                , subq_6.max_booking_value
+                , subq_6.min_booking_value
+                , subq_6.bookers
+                , subq_6.average_booking_value
+                , subq_6.referred_bookings
+                , subq_6.median_booking_value
+                , subq_6.booking_value_p99
+                , subq_6.discrete_booking_value_p99
+                , subq_6.approximate_continuous_booking_value_p99
+                , subq_6.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_6
+            ) subq_7
+            ON
+              DATE_SUB(CAST(subq_8.metric_time__day AS DATETIME), INTERVAL 14 day) = subq_7.metric_time__day
+          ) subq_10
+        ) subq_11
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_12
+      GROUP BY
+        metric_time__day
+    ) subq_13
+  ) subq_14
+  ON
+    subq_5.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    metric_time__day
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -1,0 +1,66 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_21.bookings) AS bookings
+    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC(ds, day) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_18
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_25.ds AS metric_time__day
+        , subq_23.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_25
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC(ds, day) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_23
+      ON
+        DATE_SUB(CAST(subq_25.ds AS DATETIME), INTERVAL 14 day) = subq_23.metric_time__day
+    ) subq_27
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_30
+  ON
+    subq_21.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    metric_time__day
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -1,0 +1,561 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_5.bookings) AS bookings
+    , MAX(subq_14.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+    ) subq_4
+  ) subq_5
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_12.metric_time__day
+        , SUM(subq_12.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_11.metric_time__day
+          , subq_11.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_8.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
+              , subq_7.ds__week AS ds__week
+              , subq_7.ds__month AS ds__month
+              , subq_7.ds__quarter AS ds__quarter
+              , subq_7.ds__year AS ds__year
+              , subq_7.ds__extract_year AS ds__extract_year
+              , subq_7.ds__extract_quarter AS ds__extract_quarter
+              , subq_7.ds__extract_month AS ds__extract_month
+              , subq_7.ds__extract_day AS ds__extract_day
+              , subq_7.ds__extract_dow AS ds__extract_dow
+              , subq_7.ds__extract_doy AS ds__extract_doy
+              , subq_7.ds_partitioned__day AS ds_partitioned__day
+              , subq_7.ds_partitioned__week AS ds_partitioned__week
+              , subq_7.ds_partitioned__month AS ds_partitioned__month
+              , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_7.ds_partitioned__year AS ds_partitioned__year
+              , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_7.paid_at__day AS paid_at__day
+              , subq_7.paid_at__week AS paid_at__week
+              , subq_7.paid_at__month AS paid_at__month
+              , subq_7.paid_at__quarter AS paid_at__quarter
+              , subq_7.paid_at__year AS paid_at__year
+              , subq_7.paid_at__extract_year AS paid_at__extract_year
+              , subq_7.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_7.paid_at__extract_month AS paid_at__extract_month
+              , subq_7.paid_at__extract_day AS paid_at__extract_day
+              , subq_7.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_7.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_7.booking__ds__day AS booking__ds__day
+              , subq_7.booking__ds__week AS booking__ds__week
+              , subq_7.booking__ds__month AS booking__ds__month
+              , subq_7.booking__ds__quarter AS booking__ds__quarter
+              , subq_7.booking__ds__year AS booking__ds__year
+              , subq_7.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_7.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_7.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_7.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_7.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_7.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_7.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_7.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_7.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_7.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_7.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_7.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_7.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_7.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_7.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_7.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_7.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_7.booking__paid_at__day AS booking__paid_at__day
+              , subq_7.booking__paid_at__week AS booking__paid_at__week
+              , subq_7.booking__paid_at__month AS booking__paid_at__month
+              , subq_7.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_7.booking__paid_at__year AS booking__paid_at__year
+              , subq_7.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_7.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_7.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.listing AS listing
+              , subq_7.guest AS guest
+              , subq_7.host AS host
+              , subq_7.booking__listing AS booking__listing
+              , subq_7.booking__guest AS booking__guest
+              , subq_7.booking__host AS booking__host
+              , subq_7.is_instant AS is_instant
+              , subq_7.booking__is_instant AS booking__is_instant
+              , subq_7.bookings AS bookings
+              , subq_7.instant_bookings AS instant_bookings
+              , subq_7.booking_value AS booking_value
+              , subq_7.max_booking_value AS max_booking_value
+              , subq_7.min_booking_value AS min_booking_value
+              , subq_7.bookers AS bookers
+              , subq_7.average_booking_value AS average_booking_value
+              , subq_7.referred_bookings AS referred_bookings
+              , subq_7.median_booking_value AS median_booking_value
+              , subq_7.booking_value_p99 AS booking_value_p99
+              , subq_7.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_9.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_9
+            ) subq_8
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds_partitioned__day
+                , subq_6.ds_partitioned__week
+                , subq_6.ds_partitioned__month
+                , subq_6.ds_partitioned__quarter
+                , subq_6.ds_partitioned__year
+                , subq_6.ds_partitioned__extract_year
+                , subq_6.ds_partitioned__extract_quarter
+                , subq_6.ds_partitioned__extract_month
+                , subq_6.ds_partitioned__extract_day
+                , subq_6.ds_partitioned__extract_dow
+                , subq_6.ds_partitioned__extract_doy
+                , subq_6.paid_at__day
+                , subq_6.paid_at__week
+                , subq_6.paid_at__month
+                , subq_6.paid_at__quarter
+                , subq_6.paid_at__year
+                , subq_6.paid_at__extract_year
+                , subq_6.paid_at__extract_quarter
+                , subq_6.paid_at__extract_month
+                , subq_6.paid_at__extract_day
+                , subq_6.paid_at__extract_dow
+                , subq_6.paid_at__extract_doy
+                , subq_6.booking__ds__day
+                , subq_6.booking__ds__week
+                , subq_6.booking__ds__month
+                , subq_6.booking__ds__quarter
+                , subq_6.booking__ds__year
+                , subq_6.booking__ds__extract_year
+                , subq_6.booking__ds__extract_quarter
+                , subq_6.booking__ds__extract_month
+                , subq_6.booking__ds__extract_day
+                , subq_6.booking__ds__extract_dow
+                , subq_6.booking__ds__extract_doy
+                , subq_6.booking__ds_partitioned__day
+                , subq_6.booking__ds_partitioned__week
+                , subq_6.booking__ds_partitioned__month
+                , subq_6.booking__ds_partitioned__quarter
+                , subq_6.booking__ds_partitioned__year
+                , subq_6.booking__ds_partitioned__extract_year
+                , subq_6.booking__ds_partitioned__extract_quarter
+                , subq_6.booking__ds_partitioned__extract_month
+                , subq_6.booking__ds_partitioned__extract_day
+                , subq_6.booking__ds_partitioned__extract_dow
+                , subq_6.booking__ds_partitioned__extract_doy
+                , subq_6.booking__paid_at__day
+                , subq_6.booking__paid_at__week
+                , subq_6.booking__paid_at__month
+                , subq_6.booking__paid_at__quarter
+                , subq_6.booking__paid_at__year
+                , subq_6.booking__paid_at__extract_year
+                , subq_6.booking__paid_at__extract_quarter
+                , subq_6.booking__paid_at__extract_month
+                , subq_6.booking__paid_at__extract_day
+                , subq_6.booking__paid_at__extract_dow
+                , subq_6.booking__paid_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.guest
+                , subq_6.host
+                , subq_6.booking__listing
+                , subq_6.booking__guest
+                , subq_6.booking__host
+                , subq_6.is_instant
+                , subq_6.booking__is_instant
+                , subq_6.bookings
+                , subq_6.instant_bookings
+                , subq_6.booking_value
+                , subq_6.max_booking_value
+                , subq_6.min_booking_value
+                , subq_6.bookers
+                , subq_6.average_booking_value
+                , subq_6.referred_bookings
+                , subq_6.median_booking_value
+                , subq_6.booking_value_p99
+                , subq_6.discrete_booking_value_p99
+                , subq_6.approximate_continuous_booking_value_p99
+                , subq_6.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_6
+            ) subq_7
+            ON
+              DATEADD(day, -14, subq_8.metric_time__day) = subq_7.metric_time__day
+          ) subq_10
+        ) subq_11
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_12
+      GROUP BY
+        subq_12.metric_time__day
+    ) subq_13
+  ) subq_14
+  ON
+    subq_5.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day)
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -1,0 +1,66 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_21.bookings) AS bookings
+    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_18
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_25.ds AS metric_time__day
+        , subq_23.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_25
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_23
+      ON
+        DATEADD(day, -14, subq_25.ds) = subq_23.metric_time__day
+    ) subq_27
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_30
+  ON
+    subq_21.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -1,0 +1,561 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_5.bookings) AS bookings
+    , MAX(subq_14.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+    ) subq_4
+  ) subq_5
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_12.metric_time__day
+        , SUM(subq_12.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_11.metric_time__day
+          , subq_11.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_8.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
+              , subq_7.ds__week AS ds__week
+              , subq_7.ds__month AS ds__month
+              , subq_7.ds__quarter AS ds__quarter
+              , subq_7.ds__year AS ds__year
+              , subq_7.ds__extract_year AS ds__extract_year
+              , subq_7.ds__extract_quarter AS ds__extract_quarter
+              , subq_7.ds__extract_month AS ds__extract_month
+              , subq_7.ds__extract_day AS ds__extract_day
+              , subq_7.ds__extract_dow AS ds__extract_dow
+              , subq_7.ds__extract_doy AS ds__extract_doy
+              , subq_7.ds_partitioned__day AS ds_partitioned__day
+              , subq_7.ds_partitioned__week AS ds_partitioned__week
+              , subq_7.ds_partitioned__month AS ds_partitioned__month
+              , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_7.ds_partitioned__year AS ds_partitioned__year
+              , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_7.paid_at__day AS paid_at__day
+              , subq_7.paid_at__week AS paid_at__week
+              , subq_7.paid_at__month AS paid_at__month
+              , subq_7.paid_at__quarter AS paid_at__quarter
+              , subq_7.paid_at__year AS paid_at__year
+              , subq_7.paid_at__extract_year AS paid_at__extract_year
+              , subq_7.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_7.paid_at__extract_month AS paid_at__extract_month
+              , subq_7.paid_at__extract_day AS paid_at__extract_day
+              , subq_7.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_7.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_7.booking__ds__day AS booking__ds__day
+              , subq_7.booking__ds__week AS booking__ds__week
+              , subq_7.booking__ds__month AS booking__ds__month
+              , subq_7.booking__ds__quarter AS booking__ds__quarter
+              , subq_7.booking__ds__year AS booking__ds__year
+              , subq_7.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_7.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_7.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_7.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_7.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_7.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_7.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_7.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_7.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_7.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_7.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_7.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_7.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_7.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_7.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_7.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_7.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_7.booking__paid_at__day AS booking__paid_at__day
+              , subq_7.booking__paid_at__week AS booking__paid_at__week
+              , subq_7.booking__paid_at__month AS booking__paid_at__month
+              , subq_7.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_7.booking__paid_at__year AS booking__paid_at__year
+              , subq_7.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_7.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_7.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.listing AS listing
+              , subq_7.guest AS guest
+              , subq_7.host AS host
+              , subq_7.booking__listing AS booking__listing
+              , subq_7.booking__guest AS booking__guest
+              , subq_7.booking__host AS booking__host
+              , subq_7.is_instant AS is_instant
+              , subq_7.booking__is_instant AS booking__is_instant
+              , subq_7.bookings AS bookings
+              , subq_7.instant_bookings AS instant_bookings
+              , subq_7.booking_value AS booking_value
+              , subq_7.max_booking_value AS max_booking_value
+              , subq_7.min_booking_value AS min_booking_value
+              , subq_7.bookers AS bookers
+              , subq_7.average_booking_value AS average_booking_value
+              , subq_7.referred_bookings AS referred_bookings
+              , subq_7.median_booking_value AS median_booking_value
+              , subq_7.booking_value_p99 AS booking_value_p99
+              , subq_7.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_9.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_9
+            ) subq_8
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds_partitioned__day
+                , subq_6.ds_partitioned__week
+                , subq_6.ds_partitioned__month
+                , subq_6.ds_partitioned__quarter
+                , subq_6.ds_partitioned__year
+                , subq_6.ds_partitioned__extract_year
+                , subq_6.ds_partitioned__extract_quarter
+                , subq_6.ds_partitioned__extract_month
+                , subq_6.ds_partitioned__extract_day
+                , subq_6.ds_partitioned__extract_dow
+                , subq_6.ds_partitioned__extract_doy
+                , subq_6.paid_at__day
+                , subq_6.paid_at__week
+                , subq_6.paid_at__month
+                , subq_6.paid_at__quarter
+                , subq_6.paid_at__year
+                , subq_6.paid_at__extract_year
+                , subq_6.paid_at__extract_quarter
+                , subq_6.paid_at__extract_month
+                , subq_6.paid_at__extract_day
+                , subq_6.paid_at__extract_dow
+                , subq_6.paid_at__extract_doy
+                , subq_6.booking__ds__day
+                , subq_6.booking__ds__week
+                , subq_6.booking__ds__month
+                , subq_6.booking__ds__quarter
+                , subq_6.booking__ds__year
+                , subq_6.booking__ds__extract_year
+                , subq_6.booking__ds__extract_quarter
+                , subq_6.booking__ds__extract_month
+                , subq_6.booking__ds__extract_day
+                , subq_6.booking__ds__extract_dow
+                , subq_6.booking__ds__extract_doy
+                , subq_6.booking__ds_partitioned__day
+                , subq_6.booking__ds_partitioned__week
+                , subq_6.booking__ds_partitioned__month
+                , subq_6.booking__ds_partitioned__quarter
+                , subq_6.booking__ds_partitioned__year
+                , subq_6.booking__ds_partitioned__extract_year
+                , subq_6.booking__ds_partitioned__extract_quarter
+                , subq_6.booking__ds_partitioned__extract_month
+                , subq_6.booking__ds_partitioned__extract_day
+                , subq_6.booking__ds_partitioned__extract_dow
+                , subq_6.booking__ds_partitioned__extract_doy
+                , subq_6.booking__paid_at__day
+                , subq_6.booking__paid_at__week
+                , subq_6.booking__paid_at__month
+                , subq_6.booking__paid_at__quarter
+                , subq_6.booking__paid_at__year
+                , subq_6.booking__paid_at__extract_year
+                , subq_6.booking__paid_at__extract_quarter
+                , subq_6.booking__paid_at__extract_month
+                , subq_6.booking__paid_at__extract_day
+                , subq_6.booking__paid_at__extract_dow
+                , subq_6.booking__paid_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.guest
+                , subq_6.host
+                , subq_6.booking__listing
+                , subq_6.booking__guest
+                , subq_6.booking__host
+                , subq_6.is_instant
+                , subq_6.booking__is_instant
+                , subq_6.bookings
+                , subq_6.instant_bookings
+                , subq_6.booking_value
+                , subq_6.max_booking_value
+                , subq_6.min_booking_value
+                , subq_6.bookers
+                , subq_6.average_booking_value
+                , subq_6.referred_bookings
+                , subq_6.median_booking_value
+                , subq_6.booking_value_p99
+                , subq_6.discrete_booking_value_p99
+                , subq_6.approximate_continuous_booking_value_p99
+                , subq_6.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_6
+            ) subq_7
+            ON
+              subq_8.metric_time__day - INTERVAL 14 day = subq_7.metric_time__day
+          ) subq_10
+        ) subq_11
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_12
+      GROUP BY
+        subq_12.metric_time__day
+    ) subq_13
+  ) subq_14
+  ON
+    subq_5.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day)
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -1,0 +1,66 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_21.bookings) AS bookings
+    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_18
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_25.ds AS metric_time__day
+        , subq_23.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_25
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_23
+      ON
+        subq_25.ds - INTERVAL 14 day = subq_23.metric_time__day
+    ) subq_27
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_30
+  ON
+    subq_21.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -1,0 +1,561 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_5.bookings) AS bookings
+    , MAX(subq_14.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+    ) subq_4
+  ) subq_5
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_12.metric_time__day
+        , SUM(subq_12.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_11.metric_time__day
+          , subq_11.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_8.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
+              , subq_7.ds__week AS ds__week
+              , subq_7.ds__month AS ds__month
+              , subq_7.ds__quarter AS ds__quarter
+              , subq_7.ds__year AS ds__year
+              , subq_7.ds__extract_year AS ds__extract_year
+              , subq_7.ds__extract_quarter AS ds__extract_quarter
+              , subq_7.ds__extract_month AS ds__extract_month
+              , subq_7.ds__extract_day AS ds__extract_day
+              , subq_7.ds__extract_dow AS ds__extract_dow
+              , subq_7.ds__extract_doy AS ds__extract_doy
+              , subq_7.ds_partitioned__day AS ds_partitioned__day
+              , subq_7.ds_partitioned__week AS ds_partitioned__week
+              , subq_7.ds_partitioned__month AS ds_partitioned__month
+              , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_7.ds_partitioned__year AS ds_partitioned__year
+              , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_7.paid_at__day AS paid_at__day
+              , subq_7.paid_at__week AS paid_at__week
+              , subq_7.paid_at__month AS paid_at__month
+              , subq_7.paid_at__quarter AS paid_at__quarter
+              , subq_7.paid_at__year AS paid_at__year
+              , subq_7.paid_at__extract_year AS paid_at__extract_year
+              , subq_7.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_7.paid_at__extract_month AS paid_at__extract_month
+              , subq_7.paid_at__extract_day AS paid_at__extract_day
+              , subq_7.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_7.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_7.booking__ds__day AS booking__ds__day
+              , subq_7.booking__ds__week AS booking__ds__week
+              , subq_7.booking__ds__month AS booking__ds__month
+              , subq_7.booking__ds__quarter AS booking__ds__quarter
+              , subq_7.booking__ds__year AS booking__ds__year
+              , subq_7.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_7.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_7.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_7.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_7.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_7.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_7.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_7.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_7.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_7.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_7.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_7.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_7.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_7.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_7.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_7.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_7.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_7.booking__paid_at__day AS booking__paid_at__day
+              , subq_7.booking__paid_at__week AS booking__paid_at__week
+              , subq_7.booking__paid_at__month AS booking__paid_at__month
+              , subq_7.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_7.booking__paid_at__year AS booking__paid_at__year
+              , subq_7.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_7.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_7.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.listing AS listing
+              , subq_7.guest AS guest
+              , subq_7.host AS host
+              , subq_7.booking__listing AS booking__listing
+              , subq_7.booking__guest AS booking__guest
+              , subq_7.booking__host AS booking__host
+              , subq_7.is_instant AS is_instant
+              , subq_7.booking__is_instant AS booking__is_instant
+              , subq_7.bookings AS bookings
+              , subq_7.instant_bookings AS instant_bookings
+              , subq_7.booking_value AS booking_value
+              , subq_7.max_booking_value AS max_booking_value
+              , subq_7.min_booking_value AS min_booking_value
+              , subq_7.bookers AS bookers
+              , subq_7.average_booking_value AS average_booking_value
+              , subq_7.referred_bookings AS referred_bookings
+              , subq_7.median_booking_value AS median_booking_value
+              , subq_7.booking_value_p99 AS booking_value_p99
+              , subq_7.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_9.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_9
+            ) subq_8
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds_partitioned__day
+                , subq_6.ds_partitioned__week
+                , subq_6.ds_partitioned__month
+                , subq_6.ds_partitioned__quarter
+                , subq_6.ds_partitioned__year
+                , subq_6.ds_partitioned__extract_year
+                , subq_6.ds_partitioned__extract_quarter
+                , subq_6.ds_partitioned__extract_month
+                , subq_6.ds_partitioned__extract_day
+                , subq_6.ds_partitioned__extract_dow
+                , subq_6.ds_partitioned__extract_doy
+                , subq_6.paid_at__day
+                , subq_6.paid_at__week
+                , subq_6.paid_at__month
+                , subq_6.paid_at__quarter
+                , subq_6.paid_at__year
+                , subq_6.paid_at__extract_year
+                , subq_6.paid_at__extract_quarter
+                , subq_6.paid_at__extract_month
+                , subq_6.paid_at__extract_day
+                , subq_6.paid_at__extract_dow
+                , subq_6.paid_at__extract_doy
+                , subq_6.booking__ds__day
+                , subq_6.booking__ds__week
+                , subq_6.booking__ds__month
+                , subq_6.booking__ds__quarter
+                , subq_6.booking__ds__year
+                , subq_6.booking__ds__extract_year
+                , subq_6.booking__ds__extract_quarter
+                , subq_6.booking__ds__extract_month
+                , subq_6.booking__ds__extract_day
+                , subq_6.booking__ds__extract_dow
+                , subq_6.booking__ds__extract_doy
+                , subq_6.booking__ds_partitioned__day
+                , subq_6.booking__ds_partitioned__week
+                , subq_6.booking__ds_partitioned__month
+                , subq_6.booking__ds_partitioned__quarter
+                , subq_6.booking__ds_partitioned__year
+                , subq_6.booking__ds_partitioned__extract_year
+                , subq_6.booking__ds_partitioned__extract_quarter
+                , subq_6.booking__ds_partitioned__extract_month
+                , subq_6.booking__ds_partitioned__extract_day
+                , subq_6.booking__ds_partitioned__extract_dow
+                , subq_6.booking__ds_partitioned__extract_doy
+                , subq_6.booking__paid_at__day
+                , subq_6.booking__paid_at__week
+                , subq_6.booking__paid_at__month
+                , subq_6.booking__paid_at__quarter
+                , subq_6.booking__paid_at__year
+                , subq_6.booking__paid_at__extract_year
+                , subq_6.booking__paid_at__extract_quarter
+                , subq_6.booking__paid_at__extract_month
+                , subq_6.booking__paid_at__extract_day
+                , subq_6.booking__paid_at__extract_dow
+                , subq_6.booking__paid_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.guest
+                , subq_6.host
+                , subq_6.booking__listing
+                , subq_6.booking__guest
+                , subq_6.booking__host
+                , subq_6.is_instant
+                , subq_6.booking__is_instant
+                , subq_6.bookings
+                , subq_6.instant_bookings
+                , subq_6.booking_value
+                , subq_6.max_booking_value
+                , subq_6.min_booking_value
+                , subq_6.bookers
+                , subq_6.average_booking_value
+                , subq_6.referred_bookings
+                , subq_6.median_booking_value
+                , subq_6.booking_value_p99
+                , subq_6.discrete_booking_value_p99
+                , subq_6.approximate_continuous_booking_value_p99
+                , subq_6.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_6
+            ) subq_7
+            ON
+              subq_8.metric_time__day - MAKE_INTERVAL(days => 14) = subq_7.metric_time__day
+          ) subq_10
+        ) subq_11
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_12
+      GROUP BY
+        subq_12.metric_time__day
+    ) subq_13
+  ) subq_14
+  ON
+    subq_5.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day)
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -1,0 +1,66 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_21.bookings) AS bookings
+    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_18
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_25.ds AS metric_time__day
+        , subq_23.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_25
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_23
+      ON
+        subq_25.ds - MAKE_INTERVAL(days => 14) = subq_23.metric_time__day
+    ) subq_27
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_30
+  ON
+    subq_21.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -1,0 +1,561 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_5.bookings) AS bookings
+    , MAX(subq_14.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+    ) subq_4
+  ) subq_5
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_12.metric_time__day
+        , SUM(subq_12.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_11.metric_time__day
+          , subq_11.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_8.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
+              , subq_7.ds__week AS ds__week
+              , subq_7.ds__month AS ds__month
+              , subq_7.ds__quarter AS ds__quarter
+              , subq_7.ds__year AS ds__year
+              , subq_7.ds__extract_year AS ds__extract_year
+              , subq_7.ds__extract_quarter AS ds__extract_quarter
+              , subq_7.ds__extract_month AS ds__extract_month
+              , subq_7.ds__extract_day AS ds__extract_day
+              , subq_7.ds__extract_dow AS ds__extract_dow
+              , subq_7.ds__extract_doy AS ds__extract_doy
+              , subq_7.ds_partitioned__day AS ds_partitioned__day
+              , subq_7.ds_partitioned__week AS ds_partitioned__week
+              , subq_7.ds_partitioned__month AS ds_partitioned__month
+              , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_7.ds_partitioned__year AS ds_partitioned__year
+              , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_7.paid_at__day AS paid_at__day
+              , subq_7.paid_at__week AS paid_at__week
+              , subq_7.paid_at__month AS paid_at__month
+              , subq_7.paid_at__quarter AS paid_at__quarter
+              , subq_7.paid_at__year AS paid_at__year
+              , subq_7.paid_at__extract_year AS paid_at__extract_year
+              , subq_7.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_7.paid_at__extract_month AS paid_at__extract_month
+              , subq_7.paid_at__extract_day AS paid_at__extract_day
+              , subq_7.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_7.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_7.booking__ds__day AS booking__ds__day
+              , subq_7.booking__ds__week AS booking__ds__week
+              , subq_7.booking__ds__month AS booking__ds__month
+              , subq_7.booking__ds__quarter AS booking__ds__quarter
+              , subq_7.booking__ds__year AS booking__ds__year
+              , subq_7.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_7.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_7.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_7.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_7.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_7.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_7.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_7.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_7.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_7.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_7.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_7.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_7.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_7.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_7.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_7.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_7.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_7.booking__paid_at__day AS booking__paid_at__day
+              , subq_7.booking__paid_at__week AS booking__paid_at__week
+              , subq_7.booking__paid_at__month AS booking__paid_at__month
+              , subq_7.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_7.booking__paid_at__year AS booking__paid_at__year
+              , subq_7.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_7.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_7.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.listing AS listing
+              , subq_7.guest AS guest
+              , subq_7.host AS host
+              , subq_7.booking__listing AS booking__listing
+              , subq_7.booking__guest AS booking__guest
+              , subq_7.booking__host AS booking__host
+              , subq_7.is_instant AS is_instant
+              , subq_7.booking__is_instant AS booking__is_instant
+              , subq_7.bookings AS bookings
+              , subq_7.instant_bookings AS instant_bookings
+              , subq_7.booking_value AS booking_value
+              , subq_7.max_booking_value AS max_booking_value
+              , subq_7.min_booking_value AS min_booking_value
+              , subq_7.bookers AS bookers
+              , subq_7.average_booking_value AS average_booking_value
+              , subq_7.referred_bookings AS referred_bookings
+              , subq_7.median_booking_value AS median_booking_value
+              , subq_7.booking_value_p99 AS booking_value_p99
+              , subq_7.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_9.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_9
+            ) subq_8
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds_partitioned__day
+                , subq_6.ds_partitioned__week
+                , subq_6.ds_partitioned__month
+                , subq_6.ds_partitioned__quarter
+                , subq_6.ds_partitioned__year
+                , subq_6.ds_partitioned__extract_year
+                , subq_6.ds_partitioned__extract_quarter
+                , subq_6.ds_partitioned__extract_month
+                , subq_6.ds_partitioned__extract_day
+                , subq_6.ds_partitioned__extract_dow
+                , subq_6.ds_partitioned__extract_doy
+                , subq_6.paid_at__day
+                , subq_6.paid_at__week
+                , subq_6.paid_at__month
+                , subq_6.paid_at__quarter
+                , subq_6.paid_at__year
+                , subq_6.paid_at__extract_year
+                , subq_6.paid_at__extract_quarter
+                , subq_6.paid_at__extract_month
+                , subq_6.paid_at__extract_day
+                , subq_6.paid_at__extract_dow
+                , subq_6.paid_at__extract_doy
+                , subq_6.booking__ds__day
+                , subq_6.booking__ds__week
+                , subq_6.booking__ds__month
+                , subq_6.booking__ds__quarter
+                , subq_6.booking__ds__year
+                , subq_6.booking__ds__extract_year
+                , subq_6.booking__ds__extract_quarter
+                , subq_6.booking__ds__extract_month
+                , subq_6.booking__ds__extract_day
+                , subq_6.booking__ds__extract_dow
+                , subq_6.booking__ds__extract_doy
+                , subq_6.booking__ds_partitioned__day
+                , subq_6.booking__ds_partitioned__week
+                , subq_6.booking__ds_partitioned__month
+                , subq_6.booking__ds_partitioned__quarter
+                , subq_6.booking__ds_partitioned__year
+                , subq_6.booking__ds_partitioned__extract_year
+                , subq_6.booking__ds_partitioned__extract_quarter
+                , subq_6.booking__ds_partitioned__extract_month
+                , subq_6.booking__ds_partitioned__extract_day
+                , subq_6.booking__ds_partitioned__extract_dow
+                , subq_6.booking__ds_partitioned__extract_doy
+                , subq_6.booking__paid_at__day
+                , subq_6.booking__paid_at__week
+                , subq_6.booking__paid_at__month
+                , subq_6.booking__paid_at__quarter
+                , subq_6.booking__paid_at__year
+                , subq_6.booking__paid_at__extract_year
+                , subq_6.booking__paid_at__extract_quarter
+                , subq_6.booking__paid_at__extract_month
+                , subq_6.booking__paid_at__extract_day
+                , subq_6.booking__paid_at__extract_dow
+                , subq_6.booking__paid_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.guest
+                , subq_6.host
+                , subq_6.booking__listing
+                , subq_6.booking__guest
+                , subq_6.booking__host
+                , subq_6.is_instant
+                , subq_6.booking__is_instant
+                , subq_6.bookings
+                , subq_6.instant_bookings
+                , subq_6.booking_value
+                , subq_6.max_booking_value
+                , subq_6.min_booking_value
+                , subq_6.bookers
+                , subq_6.average_booking_value
+                , subq_6.referred_bookings
+                , subq_6.median_booking_value
+                , subq_6.booking_value_p99
+                , subq_6.discrete_booking_value_p99
+                , subq_6.approximate_continuous_booking_value_p99
+                , subq_6.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_6
+            ) subq_7
+            ON
+              DATEADD(day, -14, subq_8.metric_time__day) = subq_7.metric_time__day
+          ) subq_10
+        ) subq_11
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_12
+      GROUP BY
+        subq_12.metric_time__day
+    ) subq_13
+  ) subq_14
+  ON
+    subq_5.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day)
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -1,0 +1,66 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_21.bookings) AS bookings
+    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_18
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_25.ds AS metric_time__day
+        , subq_23.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_25
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_23
+      ON
+        DATEADD(day, -14, subq_25.ds) = subq_23.metric_time__day
+    ) subq_27
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_30
+  ON
+    subq_21.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0.sql
@@ -1,0 +1,561 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_5.bookings) AS bookings
+    , MAX(subq_14.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+    ) subq_4
+  ) subq_5
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_12.metric_time__day
+        , SUM(subq_12.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_11.metric_time__day
+          , subq_11.bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_8.metric_time__day AS metric_time__day
+              , subq_7.ds__day AS ds__day
+              , subq_7.ds__week AS ds__week
+              , subq_7.ds__month AS ds__month
+              , subq_7.ds__quarter AS ds__quarter
+              , subq_7.ds__year AS ds__year
+              , subq_7.ds__extract_year AS ds__extract_year
+              , subq_7.ds__extract_quarter AS ds__extract_quarter
+              , subq_7.ds__extract_month AS ds__extract_month
+              , subq_7.ds__extract_day AS ds__extract_day
+              , subq_7.ds__extract_dow AS ds__extract_dow
+              , subq_7.ds__extract_doy AS ds__extract_doy
+              , subq_7.ds_partitioned__day AS ds_partitioned__day
+              , subq_7.ds_partitioned__week AS ds_partitioned__week
+              , subq_7.ds_partitioned__month AS ds_partitioned__month
+              , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_7.ds_partitioned__year AS ds_partitioned__year
+              , subq_7.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_7.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_7.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_7.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_7.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_7.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_7.paid_at__day AS paid_at__day
+              , subq_7.paid_at__week AS paid_at__week
+              , subq_7.paid_at__month AS paid_at__month
+              , subq_7.paid_at__quarter AS paid_at__quarter
+              , subq_7.paid_at__year AS paid_at__year
+              , subq_7.paid_at__extract_year AS paid_at__extract_year
+              , subq_7.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_7.paid_at__extract_month AS paid_at__extract_month
+              , subq_7.paid_at__extract_day AS paid_at__extract_day
+              , subq_7.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_7.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_7.booking__ds__day AS booking__ds__day
+              , subq_7.booking__ds__week AS booking__ds__week
+              , subq_7.booking__ds__month AS booking__ds__month
+              , subq_7.booking__ds__quarter AS booking__ds__quarter
+              , subq_7.booking__ds__year AS booking__ds__year
+              , subq_7.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_7.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_7.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_7.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_7.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_7.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_7.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_7.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_7.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_7.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_7.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_7.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_7.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_7.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_7.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_7.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_7.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_7.booking__paid_at__day AS booking__paid_at__day
+              , subq_7.booking__paid_at__week AS booking__paid_at__week
+              , subq_7.booking__paid_at__month AS booking__paid_at__month
+              , subq_7.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_7.booking__paid_at__year AS booking__paid_at__year
+              , subq_7.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_7.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_7.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_7.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_7.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_7.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_7.listing AS listing
+              , subq_7.guest AS guest
+              , subq_7.host AS host
+              , subq_7.booking__listing AS booking__listing
+              , subq_7.booking__guest AS booking__guest
+              , subq_7.booking__host AS booking__host
+              , subq_7.is_instant AS is_instant
+              , subq_7.booking__is_instant AS booking__is_instant
+              , subq_7.bookings AS bookings
+              , subq_7.instant_bookings AS instant_bookings
+              , subq_7.booking_value AS booking_value
+              , subq_7.max_booking_value AS max_booking_value
+              , subq_7.min_booking_value AS min_booking_value
+              , subq_7.bookers AS bookers
+              , subq_7.average_booking_value AS average_booking_value
+              , subq_7.referred_bookings AS referred_bookings
+              , subq_7.median_booking_value AS median_booking_value
+              , subq_7.booking_value_p99 AS booking_value_p99
+              , subq_7.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_7.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_7.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_9.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_9
+            ) subq_8
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.ds_partitioned__day
+                , subq_6.ds_partitioned__week
+                , subq_6.ds_partitioned__month
+                , subq_6.ds_partitioned__quarter
+                , subq_6.ds_partitioned__year
+                , subq_6.ds_partitioned__extract_year
+                , subq_6.ds_partitioned__extract_quarter
+                , subq_6.ds_partitioned__extract_month
+                , subq_6.ds_partitioned__extract_day
+                , subq_6.ds_partitioned__extract_dow
+                , subq_6.ds_partitioned__extract_doy
+                , subq_6.paid_at__day
+                , subq_6.paid_at__week
+                , subq_6.paid_at__month
+                , subq_6.paid_at__quarter
+                , subq_6.paid_at__year
+                , subq_6.paid_at__extract_year
+                , subq_6.paid_at__extract_quarter
+                , subq_6.paid_at__extract_month
+                , subq_6.paid_at__extract_day
+                , subq_6.paid_at__extract_dow
+                , subq_6.paid_at__extract_doy
+                , subq_6.booking__ds__day
+                , subq_6.booking__ds__week
+                , subq_6.booking__ds__month
+                , subq_6.booking__ds__quarter
+                , subq_6.booking__ds__year
+                , subq_6.booking__ds__extract_year
+                , subq_6.booking__ds__extract_quarter
+                , subq_6.booking__ds__extract_month
+                , subq_6.booking__ds__extract_day
+                , subq_6.booking__ds__extract_dow
+                , subq_6.booking__ds__extract_doy
+                , subq_6.booking__ds_partitioned__day
+                , subq_6.booking__ds_partitioned__week
+                , subq_6.booking__ds_partitioned__month
+                , subq_6.booking__ds_partitioned__quarter
+                , subq_6.booking__ds_partitioned__year
+                , subq_6.booking__ds_partitioned__extract_year
+                , subq_6.booking__ds_partitioned__extract_quarter
+                , subq_6.booking__ds_partitioned__extract_month
+                , subq_6.booking__ds_partitioned__extract_day
+                , subq_6.booking__ds_partitioned__extract_dow
+                , subq_6.booking__ds_partitioned__extract_doy
+                , subq_6.booking__paid_at__day
+                , subq_6.booking__paid_at__week
+                , subq_6.booking__paid_at__month
+                , subq_6.booking__paid_at__quarter
+                , subq_6.booking__paid_at__year
+                , subq_6.booking__paid_at__extract_year
+                , subq_6.booking__paid_at__extract_quarter
+                , subq_6.booking__paid_at__extract_month
+                , subq_6.booking__paid_at__extract_day
+                , subq_6.booking__paid_at__extract_dow
+                , subq_6.booking__paid_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.guest
+                , subq_6.host
+                , subq_6.booking__listing
+                , subq_6.booking__guest
+                , subq_6.booking__host
+                , subq_6.is_instant
+                , subq_6.booking__is_instant
+                , subq_6.bookings
+                , subq_6.instant_bookings
+                , subq_6.booking_value
+                , subq_6.max_booking_value
+                , subq_6.min_booking_value
+                , subq_6.bookers
+                , subq_6.average_booking_value
+                , subq_6.referred_bookings
+                , subq_6.median_booking_value
+                , subq_6.booking_value_p99
+                , subq_6.discrete_booking_value_p99
+                , subq_6.approximate_continuous_booking_value_p99
+                , subq_6.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_6
+            ) subq_7
+            ON
+              DATEADD(day, -14, subq_8.metric_time__day) = subq_7.metric_time__day
+          ) subq_10
+        ) subq_11
+        WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+      ) subq_12
+      GROUP BY
+        subq_12.metric_time__day
+    ) subq_13
+  ) subq_14
+  ON
+    subq_5.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    COALESCE(subq_5.metric_time__day, subq_14.metric_time__day)
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_offset_window_and_time_filter__plan0_optimized.sql
@@ -1,0 +1,66 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_21.bookings) AS bookings
+    , MAX(subq_30.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_18
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_25.ds AS metric_time__day
+        , subq_23.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_25
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_23
+      ON
+        DATEADD(day, -14, subq_25.ds) = subq_23.metric_time__day
+    ) subq_27
+    WHERE metric_time__day = '2020-01-01' or metric_time__day = '2020-01-14'
+    GROUP BY
+      metric_time__day
+  ) subq_30
+  ON
+    subq_21.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    COALESCE(subq_21.metric_time__day, subq_30.metric_time__day)
+) subq_31


### PR DESCRIPTION
Current test coverage for cumulative and derived offset metrics does not include
any tests of how we render queries with filters that do not allow us to do any
expansion on metric_time. This will be necessary as we add support for
detecting metric_time filter expressions and full predicate pushdown, as we will need
a way to verify that our logic is still rendering queries that will produce the correct results.

Worth noting, in this PR, that we currently have a number of rendering scenarios for
cumulative metrics where the queries are incorrect. As these are meant to be blocked by
query validation, I am leaving most of them intact, with the idea that when we properly
support those scenarios the rendering tests will update to reflect the fixes.