### PR TITLE
Fix query validation for metric_time requirements

### DIFF
--- a/.changes/unreleased/Fixes-20231108-150708.yaml
+++ b/.changes/unreleased/Fixes-20231108-150708.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix query validation for metric_time requirements
+time: 2023-11-08T15:07:08.681102-08:00
+custom:
+  Author: tlento
+  Issue: "825"

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -270,8 +270,13 @@ class MetricFlowQueryParser:
         finally:
             logger.info(f"Parsing the query took: {time.time() - start_time:.2f}s")
 
-    def _validate_no_time_dimension_query(self, metric_references: Sequence[MetricReference]) -> None:
-        """Validate if all requested metrics are queryable without a time dimension."""
+    def _validate_no_metric_time_dimension_query(
+        self, metric_references: Sequence[MetricReference], time_dimension_specs: Sequence[TimeDimensionSpec]
+    ) -> None:
+        """Validate if all requested metrics are queryable without grouping by metric_time."""
+        if any([spec.reference == DataSet.metric_time_dimension_reference() for spec in time_dimension_specs]):
+            return
+
         for metric_reference in metric_references:
             metric = self._metric_lookup.get_metric(metric_reference)
             if metric.type == MetricType.CUMULATIVE:
@@ -471,8 +476,9 @@ class MetricFlowQueryParser:
         time_dimension_specs = requested_linkable_specs.time_dimension_specs + tuple(
             time_dimension_spec for _, time_dimension_spec in partial_time_dimension_spec_replacements.items()
         )
-        if len(time_dimension_specs) == 0:
-            self._validate_no_time_dimension_query(metric_references=metric_references)
+        self._validate_no_metric_time_dimension_query(
+            metric_references=metric_references, time_dimension_specs=time_dimension_specs
+        )
 
         self._time_granularity_solver.validate_time_granularity(metric_references, time_dimension_specs)
         self._validate_date_part(metric_references, time_dimension_specs)


### PR DESCRIPTION
Resolves #825

### Description

As of right now we require metric_time in the group by expression
for any metric query against cumulative metrics or derived metrics
with time offset windows or an offset_to_grain parameter set.

The current query validation was only asserting that some time
dimension was included in the group by. In the case of derived
metrics, this simply failed later in the query building phase for
any query with a different time dimension in the group by expression.

In the case of cumulative metrics, this would run an incorrectly
rendered query and then return incorrect results.

This validation change ensures that users have the proper
configuration on queries based on our current limitations.