### PR TITLE
Add test for time offset metric based on non-default granularity

### DIFF
--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1043,8 +1043,8 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                 semantic_model_reference=measure_instance.origin_semantic_model_reference.semantic_model_reference
             )
             assert semantic_model is not None, (
-                f"{measure_instance} was defined from {measure_instance.origin_semantic_model_reference}, but that"
-                f"can't be found"
+                f"{measure_instance} was defined from "
+                f"{measure_instance.origin_semantic_model_reference.semantic_model_reference}, but that can't be found"
             )
             aggregation_time_dimension_for_measure = semantic_model.checked_agg_time_dimension_for_measure(
                 measure_reference=measure_instance.spec.as_reference

--- a/metricflow/test/fixtures/dataflow_fixtures.py
+++ b/metricflow/test/fixtures/dataflow_fixtures.py
@@ -39,6 +39,18 @@ def dataflow_plan_builder(  # noqa: D
 
 
 @pytest.fixture
+def extended_date_dataflow_plan_builder(  # noqa: D
+    extended_date_semantic_manifest_lookup: SemanticManifestLookup,
+    consistent_id_object_repository: ConsistentIdObjectRepository,
+) -> DataflowPlanBuilder:
+    return DataflowPlanBuilder(
+        source_nodes=consistent_id_object_repository.extended_date_model_source_nodes,
+        read_nodes=list(consistent_id_object_repository.extended_date_model_read_nodes.values()),
+        semantic_manifest_lookup=extended_date_semantic_manifest_lookup,
+    )
+
+
+@pytest.fixture
 def multihop_dataflow_plan_builder(  # noqa: D
     multi_hop_join_semantic_manifest_lookup: SemanticManifestLookup,
     consistent_id_object_repository: ConsistentIdObjectRepository,

--- a/metricflow/test/fixtures/semantic_manifest_yamls/extended_date_manifest/metrics/bookings_last_month.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/extended_date_manifest/metrics/bookings_last_month.yaml
@@ -1,0 +1,10 @@
+metric:
+  name: bookings_last_month
+  description: bookings the prior month, based on dimension with month granularity
+  type: derived
+  type_params:
+    expr: bookings_last_month
+    metrics:
+      - name: bookings_monthly
+        offset_window: 1 month
+        alias: bookings_last_month

--- a/metricflow/test/fixtures/sql_fixtures.py
+++ b/metricflow/test/fixtures/sql_fixtures.py
@@ -21,3 +21,13 @@ def dataflow_to_sql_converter(  # noqa: D
         column_association_resolver=DunderColumnAssociationResolver(simple_semantic_manifest_lookup),
         semantic_manifest_lookup=simple_semantic_manifest_lookup,
     )
+
+
+@pytest.fixture(scope="session")
+def extended_date_dataflow_to_sql_converter(  # noqa: D
+    extended_date_semantic_manifest_lookup: SemanticManifestLookup,
+) -> DataflowToSqlQueryPlanConverter:
+    return DataflowToSqlQueryPlanConverter(
+        column_association_resolver=DunderColumnAssociationResolver(extended_date_semantic_manifest_lookup),
+        semantic_manifest_lookup=extended_date_semantic_manifest_lookup,
+    )

--- a/metricflow/test/query_rendering/test_derived_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_derived_metric_rendering.py
@@ -17,7 +17,13 @@ from metricflow.specs.specs import (
 from metricflow.specs.where_filter_transform import WhereSpecFactory
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.query_rendering.compare_rendered_query import convert_and_check
-from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_QUARTER, MTD_SPEC_WEEK, MTD_SPEC_YEAR
+from metricflow.test.time.metric_time_dimension import (
+    MTD_SPEC_DAY,
+    MTD_SPEC_MONTH,
+    MTD_SPEC_QUARTER,
+    MTD_SPEC_WEEK,
+    MTD_SPEC_YEAR,
+)
 
 
 @pytest.mark.sql_engine_snapshot
@@ -218,6 +224,30 @@ def test_derived_metric_with_offset_window_and_granularity(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_derived_metric_with_month_dimension_and_offset_window(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    extended_date_dataflow_plan_builder: DataflowPlanBuilder,
+    extended_date_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+) -> None:
+    dataflow_plan = extended_date_dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_last_month"),),
+            time_dimension_specs=(MTD_SPEC_MONTH,),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=extended_date_dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
     )

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -1,0 +1,100 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__month
+    , subq_6.bookings_monthly AS bookings_last_month
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__month
+      , SUM(subq_5.bookings_monthly) AS bookings_monthly
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings_monthly', 'metric_time__month']
+      SELECT
+        subq_4.metric_time__month
+        , subq_4.bookings_monthly
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__month AS metric_time__month
+          , subq_1.monthly_ds__month AS monthly_ds__month
+          , subq_1.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_1.monthly_ds__year AS monthly_ds__year
+          , subq_1.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_1.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_1.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_1.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_1.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_1.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_1.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_1.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_1.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_1.listing AS listing
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.bookings_monthly AS bookings_monthly
+        FROM (
+          -- Date Spine
+          SELECT
+            DATE_TRUNC(subq_3.ds, month) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_3
+          GROUP BY
+            metric_time__month
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'monthly_ds'
+          SELECT
+            subq_0.monthly_ds__month
+            , subq_0.monthly_ds__quarter
+            , subq_0.monthly_ds__year
+            , subq_0.monthly_ds__extract_year
+            , subq_0.monthly_ds__extract_quarter
+            , subq_0.monthly_ds__extract_month
+            , subq_0.booking__monthly_ds__month
+            , subq_0.booking__monthly_ds__quarter
+            , subq_0.booking__monthly_ds__year
+            , subq_0.booking__monthly_ds__extract_year
+            , subq_0.booking__monthly_ds__extract_quarter
+            , subq_0.booking__monthly_ds__extract_month
+            , subq_0.monthly_ds__month AS metric_time__month
+            , subq_0.monthly_ds__quarter AS metric_time__quarter
+            , subq_0.monthly_ds__year AS metric_time__year
+            , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+            , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+            , subq_0.listing
+            , subq_0.booking__listing
+            , subq_0.bookings_monthly
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_monthly_source'
+            SELECT
+              bookings_monthly_source_src_10024.bookings_monthly
+              , DATE_TRUNC(bookings_monthly_source_src_10024.ds, month) AS monthly_ds__month
+              , DATE_TRUNC(bookings_monthly_source_src_10024.ds, quarter) AS monthly_ds__quarter
+              , DATE_TRUNC(bookings_monthly_source_src_10024.ds, year) AS monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_month
+              , DATE_TRUNC(bookings_monthly_source_src_10024.ds, month) AS booking__monthly_ds__month
+              , DATE_TRUNC(bookings_monthly_source_src_10024.ds, quarter) AS booking__monthly_ds__quarter
+              , DATE_TRUNC(bookings_monthly_source_src_10024.ds, year) AS booking__monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_month
+              , bookings_monthly_source_src_10024.listing_id AS listing
+              , bookings_monthly_source_src_10024.listing_id AS booking__listing
+            FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+          ) subq_0
+        ) subq_1
+        ON
+          DATE_SUB(CAST(subq_2.metric_time__month AS DATETIME), INTERVAL 1 month) = subq_1.metric_time__month
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      metric_time__month
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -1,0 +1,28 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings_monthly', 'metric_time__month']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__month AS metric_time__month
+    , SUM(bookings_monthly_source_src_10024.bookings_monthly) AS bookings_last_month
+  FROM (
+    -- Date Spine
+    SELECT
+      DATE_TRUNC(ds, month) AS metric_time__month
+    FROM ***************************.mf_time_spine subq_11
+    GROUP BY
+      metric_time__month
+  ) subq_10
+  INNER JOIN
+    ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+  ON
+    DATE_SUB(CAST(subq_10.metric_time__month AS DATETIME), INTERVAL 1 month) = DATE_TRUNC(bookings_monthly_source_src_10024.ds, month)
+  GROUP BY
+    metric_time__month
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -1,0 +1,100 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__month
+    , subq_6.bookings_monthly AS bookings_last_month
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__month
+      , SUM(subq_5.bookings_monthly) AS bookings_monthly
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings_monthly', 'metric_time__month']
+      SELECT
+        subq_4.metric_time__month
+        , subq_4.bookings_monthly
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__month AS metric_time__month
+          , subq_1.monthly_ds__month AS monthly_ds__month
+          , subq_1.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_1.monthly_ds__year AS monthly_ds__year
+          , subq_1.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_1.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_1.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_1.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_1.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_1.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_1.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_1.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_1.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_1.listing AS listing
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.bookings_monthly AS bookings_monthly
+        FROM (
+          -- Date Spine
+          SELECT
+            DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_3
+          GROUP BY
+            DATE_TRUNC('month', subq_3.ds)
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'monthly_ds'
+          SELECT
+            subq_0.monthly_ds__month
+            , subq_0.monthly_ds__quarter
+            , subq_0.monthly_ds__year
+            , subq_0.monthly_ds__extract_year
+            , subq_0.monthly_ds__extract_quarter
+            , subq_0.monthly_ds__extract_month
+            , subq_0.booking__monthly_ds__month
+            , subq_0.booking__monthly_ds__quarter
+            , subq_0.booking__monthly_ds__year
+            , subq_0.booking__monthly_ds__extract_year
+            , subq_0.booking__monthly_ds__extract_quarter
+            , subq_0.booking__monthly_ds__extract_month
+            , subq_0.monthly_ds__month AS metric_time__month
+            , subq_0.monthly_ds__quarter AS metric_time__quarter
+            , subq_0.monthly_ds__year AS metric_time__year
+            , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+            , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+            , subq_0.listing
+            , subq_0.booking__listing
+            , subq_0.bookings_monthly
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_monthly_source'
+            SELECT
+              bookings_monthly_source_src_10024.bookings_monthly
+              , DATE_TRUNC('month', bookings_monthly_source_src_10024.ds) AS monthly_ds__month
+              , DATE_TRUNC('quarter', bookings_monthly_source_src_10024.ds) AS monthly_ds__quarter
+              , DATE_TRUNC('year', bookings_monthly_source_src_10024.ds) AS monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_month
+              , DATE_TRUNC('month', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__month
+              , DATE_TRUNC('quarter', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__quarter
+              , DATE_TRUNC('year', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_month
+              , bookings_monthly_source_src_10024.listing_id AS listing
+              , bookings_monthly_source_src_10024.listing_id AS booking__listing
+            FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+          ) subq_0
+        ) subq_1
+        ON
+          DATEADD(month, -1, subq_2.metric_time__month) = subq_1.metric_time__month
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      subq_5.metric_time__month
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -1,0 +1,28 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings_monthly', 'metric_time__month']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__month AS metric_time__month
+    , SUM(bookings_monthly_source_src_10024.bookings_monthly) AS bookings_last_month
+  FROM (
+    -- Date Spine
+    SELECT
+      DATE_TRUNC('month', ds) AS metric_time__month
+    FROM ***************************.mf_time_spine subq_11
+    GROUP BY
+      DATE_TRUNC('month', ds)
+  ) subq_10
+  INNER JOIN
+    ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+  ON
+    DATEADD(month, -1, subq_10.metric_time__month) = DATE_TRUNC('month', bookings_monthly_source_src_10024.ds)
+  GROUP BY
+    subq_10.metric_time__month
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -1,0 +1,100 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__month
+    , subq_6.bookings_monthly AS bookings_last_month
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__month
+      , SUM(subq_5.bookings_monthly) AS bookings_monthly
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings_monthly', 'metric_time__month']
+      SELECT
+        subq_4.metric_time__month
+        , subq_4.bookings_monthly
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__month AS metric_time__month
+          , subq_1.monthly_ds__month AS monthly_ds__month
+          , subq_1.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_1.monthly_ds__year AS monthly_ds__year
+          , subq_1.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_1.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_1.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_1.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_1.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_1.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_1.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_1.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_1.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_1.listing AS listing
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.bookings_monthly AS bookings_monthly
+        FROM (
+          -- Date Spine
+          SELECT
+            DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_3
+          GROUP BY
+            DATE_TRUNC('month', subq_3.ds)
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'monthly_ds'
+          SELECT
+            subq_0.monthly_ds__month
+            , subq_0.monthly_ds__quarter
+            , subq_0.monthly_ds__year
+            , subq_0.monthly_ds__extract_year
+            , subq_0.monthly_ds__extract_quarter
+            , subq_0.monthly_ds__extract_month
+            , subq_0.booking__monthly_ds__month
+            , subq_0.booking__monthly_ds__quarter
+            , subq_0.booking__monthly_ds__year
+            , subq_0.booking__monthly_ds__extract_year
+            , subq_0.booking__monthly_ds__extract_quarter
+            , subq_0.booking__monthly_ds__extract_month
+            , subq_0.monthly_ds__month AS metric_time__month
+            , subq_0.monthly_ds__quarter AS metric_time__quarter
+            , subq_0.monthly_ds__year AS metric_time__year
+            , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+            , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+            , subq_0.listing
+            , subq_0.booking__listing
+            , subq_0.bookings_monthly
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_monthly_source'
+            SELECT
+              bookings_monthly_source_src_10024.bookings_monthly
+              , DATE_TRUNC('month', bookings_monthly_source_src_10024.ds) AS monthly_ds__month
+              , DATE_TRUNC('quarter', bookings_monthly_source_src_10024.ds) AS monthly_ds__quarter
+              , DATE_TRUNC('year', bookings_monthly_source_src_10024.ds) AS monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_month
+              , DATE_TRUNC('month', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__month
+              , DATE_TRUNC('quarter', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__quarter
+              , DATE_TRUNC('year', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_month
+              , bookings_monthly_source_src_10024.listing_id AS listing
+              , bookings_monthly_source_src_10024.listing_id AS booking__listing
+            FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+          ) subq_0
+        ) subq_1
+        ON
+          subq_2.metric_time__month - INTERVAL 1 month = subq_1.metric_time__month
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      subq_5.metric_time__month
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -1,0 +1,28 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings_monthly', 'metric_time__month']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__month AS metric_time__month
+    , SUM(bookings_monthly_source_src_10024.bookings_monthly) AS bookings_last_month
+  FROM (
+    -- Date Spine
+    SELECT
+      DATE_TRUNC('month', ds) AS metric_time__month
+    FROM ***************************.mf_time_spine subq_11
+    GROUP BY
+      DATE_TRUNC('month', ds)
+  ) subq_10
+  INNER JOIN
+    ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+  ON
+    subq_10.metric_time__month - INTERVAL 1 month = DATE_TRUNC('month', bookings_monthly_source_src_10024.ds)
+  GROUP BY
+    subq_10.metric_time__month
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -1,0 +1,100 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__month
+    , subq_6.bookings_monthly AS bookings_last_month
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__month
+      , SUM(subq_5.bookings_monthly) AS bookings_monthly
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings_monthly', 'metric_time__month']
+      SELECT
+        subq_4.metric_time__month
+        , subq_4.bookings_monthly
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__month AS metric_time__month
+          , subq_1.monthly_ds__month AS monthly_ds__month
+          , subq_1.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_1.monthly_ds__year AS monthly_ds__year
+          , subq_1.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_1.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_1.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_1.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_1.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_1.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_1.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_1.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_1.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_1.listing AS listing
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.bookings_monthly AS bookings_monthly
+        FROM (
+          -- Date Spine
+          SELECT
+            DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_3
+          GROUP BY
+            DATE_TRUNC('month', subq_3.ds)
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'monthly_ds'
+          SELECT
+            subq_0.monthly_ds__month
+            , subq_0.monthly_ds__quarter
+            , subq_0.monthly_ds__year
+            , subq_0.monthly_ds__extract_year
+            , subq_0.monthly_ds__extract_quarter
+            , subq_0.monthly_ds__extract_month
+            , subq_0.booking__monthly_ds__month
+            , subq_0.booking__monthly_ds__quarter
+            , subq_0.booking__monthly_ds__year
+            , subq_0.booking__monthly_ds__extract_year
+            , subq_0.booking__monthly_ds__extract_quarter
+            , subq_0.booking__monthly_ds__extract_month
+            , subq_0.monthly_ds__month AS metric_time__month
+            , subq_0.monthly_ds__quarter AS metric_time__quarter
+            , subq_0.monthly_ds__year AS metric_time__year
+            , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+            , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+            , subq_0.listing
+            , subq_0.booking__listing
+            , subq_0.bookings_monthly
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_monthly_source'
+            SELECT
+              bookings_monthly_source_src_10024.bookings_monthly
+              , DATE_TRUNC('month', bookings_monthly_source_src_10024.ds) AS monthly_ds__month
+              , DATE_TRUNC('quarter', bookings_monthly_source_src_10024.ds) AS monthly_ds__quarter
+              , DATE_TRUNC('year', bookings_monthly_source_src_10024.ds) AS monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_month
+              , DATE_TRUNC('month', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__month
+              , DATE_TRUNC('quarter', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__quarter
+              , DATE_TRUNC('year', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_month
+              , bookings_monthly_source_src_10024.listing_id AS listing
+              , bookings_monthly_source_src_10024.listing_id AS booking__listing
+            FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+          ) subq_0
+        ) subq_1
+        ON
+          subq_2.metric_time__month - MAKE_INTERVAL(months => 1) = subq_1.metric_time__month
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      subq_5.metric_time__month
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -1,0 +1,28 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings_monthly', 'metric_time__month']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__month AS metric_time__month
+    , SUM(bookings_monthly_source_src_10024.bookings_monthly) AS bookings_last_month
+  FROM (
+    -- Date Spine
+    SELECT
+      DATE_TRUNC('month', ds) AS metric_time__month
+    FROM ***************************.mf_time_spine subq_11
+    GROUP BY
+      DATE_TRUNC('month', ds)
+  ) subq_10
+  INNER JOIN
+    ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+  ON
+    subq_10.metric_time__month - MAKE_INTERVAL(months => 1) = DATE_TRUNC('month', bookings_monthly_source_src_10024.ds)
+  GROUP BY
+    subq_10.metric_time__month
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -1,0 +1,100 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__month
+    , subq_6.bookings_monthly AS bookings_last_month
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__month
+      , SUM(subq_5.bookings_monthly) AS bookings_monthly
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings_monthly', 'metric_time__month']
+      SELECT
+        subq_4.metric_time__month
+        , subq_4.bookings_monthly
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__month AS metric_time__month
+          , subq_1.monthly_ds__month AS monthly_ds__month
+          , subq_1.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_1.monthly_ds__year AS monthly_ds__year
+          , subq_1.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_1.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_1.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_1.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_1.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_1.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_1.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_1.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_1.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_1.listing AS listing
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.bookings_monthly AS bookings_monthly
+        FROM (
+          -- Date Spine
+          SELECT
+            DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_3
+          GROUP BY
+            DATE_TRUNC('month', subq_3.ds)
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'monthly_ds'
+          SELECT
+            subq_0.monthly_ds__month
+            , subq_0.monthly_ds__quarter
+            , subq_0.monthly_ds__year
+            , subq_0.monthly_ds__extract_year
+            , subq_0.monthly_ds__extract_quarter
+            , subq_0.monthly_ds__extract_month
+            , subq_0.booking__monthly_ds__month
+            , subq_0.booking__monthly_ds__quarter
+            , subq_0.booking__monthly_ds__year
+            , subq_0.booking__monthly_ds__extract_year
+            , subq_0.booking__monthly_ds__extract_quarter
+            , subq_0.booking__monthly_ds__extract_month
+            , subq_0.monthly_ds__month AS metric_time__month
+            , subq_0.monthly_ds__quarter AS metric_time__quarter
+            , subq_0.monthly_ds__year AS metric_time__year
+            , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+            , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+            , subq_0.listing
+            , subq_0.booking__listing
+            , subq_0.bookings_monthly
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_monthly_source'
+            SELECT
+              bookings_monthly_source_src_10024.bookings_monthly
+              , DATE_TRUNC('month', bookings_monthly_source_src_10024.ds) AS monthly_ds__month
+              , DATE_TRUNC('quarter', bookings_monthly_source_src_10024.ds) AS monthly_ds__quarter
+              , DATE_TRUNC('year', bookings_monthly_source_src_10024.ds) AS monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_month
+              , DATE_TRUNC('month', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__month
+              , DATE_TRUNC('quarter', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__quarter
+              , DATE_TRUNC('year', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_month
+              , bookings_monthly_source_src_10024.listing_id AS listing
+              , bookings_monthly_source_src_10024.listing_id AS booking__listing
+            FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+          ) subq_0
+        ) subq_1
+        ON
+          DATEADD(month, -1, subq_2.metric_time__month) = subq_1.metric_time__month
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      subq_5.metric_time__month
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -1,0 +1,28 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings_monthly', 'metric_time__month']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__month AS metric_time__month
+    , SUM(bookings_monthly_source_src_10024.bookings_monthly) AS bookings_last_month
+  FROM (
+    -- Date Spine
+    SELECT
+      DATE_TRUNC('month', ds) AS metric_time__month
+    FROM ***************************.mf_time_spine subq_11
+    GROUP BY
+      DATE_TRUNC('month', ds)
+  ) subq_10
+  INNER JOIN
+    ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+  ON
+    DATEADD(month, -1, subq_10.metric_time__month) = DATE_TRUNC('month', bookings_monthly_source_src_10024.ds)
+  GROUP BY
+    subq_10.metric_time__month
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0.sql
@@ -1,0 +1,100 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__month
+    , subq_6.bookings_monthly AS bookings_last_month
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__month
+      , SUM(subq_5.bookings_monthly) AS bookings_monthly
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings_monthly', 'metric_time__month']
+      SELECT
+        subq_4.metric_time__month
+        , subq_4.bookings_monthly
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__month AS metric_time__month
+          , subq_1.monthly_ds__month AS monthly_ds__month
+          , subq_1.monthly_ds__quarter AS monthly_ds__quarter
+          , subq_1.monthly_ds__year AS monthly_ds__year
+          , subq_1.monthly_ds__extract_year AS monthly_ds__extract_year
+          , subq_1.monthly_ds__extract_quarter AS monthly_ds__extract_quarter
+          , subq_1.monthly_ds__extract_month AS monthly_ds__extract_month
+          , subq_1.booking__monthly_ds__month AS booking__monthly_ds__month
+          , subq_1.booking__monthly_ds__quarter AS booking__monthly_ds__quarter
+          , subq_1.booking__monthly_ds__year AS booking__monthly_ds__year
+          , subq_1.booking__monthly_ds__extract_year AS booking__monthly_ds__extract_year
+          , subq_1.booking__monthly_ds__extract_quarter AS booking__monthly_ds__extract_quarter
+          , subq_1.booking__monthly_ds__extract_month AS booking__monthly_ds__extract_month
+          , subq_1.listing AS listing
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.bookings_monthly AS bookings_monthly
+        FROM (
+          -- Date Spine
+          SELECT
+            DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_3
+          GROUP BY
+            DATE_TRUNC('month', subq_3.ds)
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'monthly_ds'
+          SELECT
+            subq_0.monthly_ds__month
+            , subq_0.monthly_ds__quarter
+            , subq_0.monthly_ds__year
+            , subq_0.monthly_ds__extract_year
+            , subq_0.monthly_ds__extract_quarter
+            , subq_0.monthly_ds__extract_month
+            , subq_0.booking__monthly_ds__month
+            , subq_0.booking__monthly_ds__quarter
+            , subq_0.booking__monthly_ds__year
+            , subq_0.booking__monthly_ds__extract_year
+            , subq_0.booking__monthly_ds__extract_quarter
+            , subq_0.booking__monthly_ds__extract_month
+            , subq_0.monthly_ds__month AS metric_time__month
+            , subq_0.monthly_ds__quarter AS metric_time__quarter
+            , subq_0.monthly_ds__year AS metric_time__year
+            , subq_0.monthly_ds__extract_year AS metric_time__extract_year
+            , subq_0.monthly_ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.monthly_ds__extract_month AS metric_time__extract_month
+            , subq_0.listing
+            , subq_0.booking__listing
+            , subq_0.bookings_monthly
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_monthly_source'
+            SELECT
+              bookings_monthly_source_src_10024.bookings_monthly
+              , DATE_TRUNC('month', bookings_monthly_source_src_10024.ds) AS monthly_ds__month
+              , DATE_TRUNC('quarter', bookings_monthly_source_src_10024.ds) AS monthly_ds__quarter
+              , DATE_TRUNC('year', bookings_monthly_source_src_10024.ds) AS monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS monthly_ds__extract_month
+              , DATE_TRUNC('month', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__month
+              , DATE_TRUNC('quarter', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__quarter
+              , DATE_TRUNC('year', bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__year
+              , EXTRACT(year FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_year
+              , EXTRACT(quarter FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_quarter
+              , EXTRACT(month FROM bookings_monthly_source_src_10024.ds) AS booking__monthly_ds__extract_month
+              , bookings_monthly_source_src_10024.listing_id AS listing
+              , bookings_monthly_source_src_10024.listing_id AS booking__listing
+            FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+          ) subq_0
+        ) subq_1
+        ON
+          DATEADD(month, -1, subq_2.metric_time__month) = subq_1.metric_time__month
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      subq_5.metric_time__month
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric_with_month_dimension_and_offset_window__plan0_optimized.sql
@@ -1,0 +1,28 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__month
+  , bookings_last_month AS bookings_last_month
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings_monthly', 'metric_time__month']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__month AS metric_time__month
+    , SUM(bookings_monthly_source_src_10024.bookings_monthly) AS bookings_last_month
+  FROM (
+    -- Date Spine
+    SELECT
+      DATE_TRUNC('month', ds) AS metric_time__month
+    FROM ***************************.mf_time_spine subq_11
+    GROUP BY
+      DATE_TRUNC('month', ds)
+  ) subq_10
+  INNER JOIN
+    ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_10024
+  ON
+    DATEADD(month, -1, subq_10.metric_time__month) = DATE_TRUNC('month', bookings_monthly_source_src_10024.ds)
+  GROUP BY
+    subq_10.metric_time__month
+) subq_15


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Added this test case to make sure it would work for [a customer's use case](https://getdbt.slack.com/archives/C046L0VTVR6/p1699548838051619) - a derived metric with an input metric that uses month granularity.
Also cleaned up the messaging in an error message I encountered along the way.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
