### PR TITLE
Bug fix: use FULL OUTER JOIN when querying dimensions only

### DIFF
--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -93,6 +93,7 @@ class LinkableInstanceSatisfiabilityEvaluation:
     joinable_linkable_specs: Tuple[LinkableInstanceSpec, ...]
     join_recipes: Tuple[JoinLinkableInstancesRecipe, ...]
     unjoinable_linkable_specs: Tuple[LinkableInstanceSpec, ...]
+    # cross_joinable_linkable_specs: Tuple[LinkableInstanceSpec, ...]
 
 
 class NodeEvaluatorForLinkableInstances:

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -381,6 +381,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
 
         # The dataflow plan describes how the data sets coming from the parent nodes should be joined together. Use
         # those descriptions to convert them to join descriptions for the SQL query plan.
+        # Should there be a different join type for each join description?
         for join_description in node.join_targets:
             join_on_entity = join_description.join_on_entity
 
@@ -393,6 +394,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                     left_data_set=AnnotatedSqlDataSet(data_set=from_data_set, alias=from_data_set_alias),
                     right_data_set=AnnotatedSqlDataSet(data_set=right_data_set, alias=right_data_set_alias),
                     join_description=join_description,
+                    join_type=node.join_type,
                 )
             )
 

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -21,6 +21,7 @@ from metricflow.model.semantics.semantic_model_join_evaluator import MAX_JOIN_HO
 from metricflow.protocols.semantics import SemanticModelAccessor
 from metricflow.specs.spec_set_transforms import ToElementNameSet
 from metricflow.specs.specs import InstanceSpecSet, LinkableInstanceSpec, LinklessEntitySpec
+from metricflow.sql.sql_plan import SqlJoinType
 
 logger = logging.getLogger(__name__)
 
@@ -149,9 +150,7 @@ class PreJoinNodeProcessor:
         return False
 
     def _get_candidates_nodes_for_multi_hop(
-        self,
-        desired_linkable_spec: LinkableInstanceSpec,
-        nodes: Sequence[BaseOutput],
+        self, desired_linkable_spec: LinkableInstanceSpec, nodes: Sequence[BaseOutput], join_type: SqlJoinType
     ) -> Sequence[MultiHopJoinCandidate]:
         """Assemble nodes representing all possible one-hop joins."""
         if len(desired_linkable_spec.entity_links) > MAX_JOIN_HOPS:
@@ -251,6 +250,7 @@ class PreJoinNodeProcessor:
                                     join_on_partition_time_dimensions=join_on_partition_time_dimensions,
                                 )
                             ],
+                            join_type=join_type,
                         ),
                         lineage=MultiHopJoinCandidateLineage(
                             first_node_to_join=first_node_that_could_be_joined,
@@ -276,7 +276,10 @@ class PreJoinNodeProcessor:
         return multi_hop_join_candidates
 
     def add_multi_hop_joins(
-        self, desired_linkable_specs: Sequence[LinkableInstanceSpec], nodes: Sequence[BaseOutput]
+        self,
+        desired_linkable_specs: Sequence[LinkableInstanceSpec],
+        nodes: Sequence[BaseOutput],
+        join_type: SqlJoinType,
     ) -> Sequence[BaseOutput]:
         """Assemble nodes representing all possible one-hop joins."""
         all_multi_hop_join_candidates: List[MultiHopJoinCandidate] = []
@@ -284,8 +287,7 @@ class PreJoinNodeProcessor:
 
         for desired_linkable_spec in desired_linkable_specs:
             for multi_hop_join_candidate in self._get_candidates_nodes_for_multi_hop(
-                desired_linkable_spec=desired_linkable_spec,
-                nodes=nodes,
+                desired_linkable_spec=desired_linkable_spec, nodes=nodes, join_type=join_type
             ):
                 # Dedupe candidates that are the same join.
                 if multi_hop_join_candidate.lineage not in lineage_for_all_multi_hop_join_candidates:

--- a/metricflow/plan_conversion/sql_join_builder.py
+++ b/metricflow/plan_conversion/sql_join_builder.py
@@ -141,6 +141,7 @@ class SqlQueryPlanJoinBuilder:
         left_data_set: AnnotatedSqlDataSet,
         right_data_set: AnnotatedSqlDataSet,
         join_description: JoinDescription,
+        join_type: SqlJoinType,
     ) -> SqlJoinDescription:
         """Make a join description to link two base output DataSets by matching entities.
 
@@ -207,7 +208,7 @@ class SqlQueryPlanJoinBuilder:
             left_source_alias=left_data_set.alias,
             right_source_alias=right_data_set.alias,
             column_equality_descriptions=column_equality_descriptions,
-            join_type=SqlJoinType.LEFT_OUTER,
+            join_type=join_type,
             additional_on_conditions=validity_conditions,
         )
 

--- a/metricflow/test/dataflow/builder/test_node_data_set.py
+++ b/metricflow/test/dataflow/builder/test_node_data_set.py
@@ -23,7 +23,7 @@ from metricflow.specs.specs import (
     MeasureSpec,
 )
 from metricflow.sql.sql_exprs import SqlColumnReference, SqlColumnReferenceExpression
-from metricflow.sql.sql_plan import SqlSelectColumn, SqlSelectStatementNode, SqlTableFromClauseNode
+from metricflow.sql.sql_plan import SqlJoinType, SqlSelectColumn, SqlSelectStatementNode, SqlTableFromClauseNode
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.snapshot_utils import assert_spec_set_snapshot_equal
@@ -113,6 +113,7 @@ def test_joined_node_data_set(  # noqa: D
                 join_on_partition_time_dimensions=(),
             )
         ],
+        join_type=SqlJoinType.LEFT_OUTER,
     )
 
     join_node_output_data_set = resolver.get_output_data_set(join_node)

--- a/metricflow/test/dataflow/builder/test_node_evaluator.py
+++ b/metricflow/test/dataflow/builder/test_node_evaluator.py
@@ -27,6 +27,7 @@ from metricflow.specs.specs import (
     LinklessEntitySpec,
     TimeDimensionSpec,
 )
+from metricflow.sql.sql_plan import SqlJoinType
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
 
 logger = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ def make_multihop_node_evaluator(
     )
 
     nodes_available_for_joins = node_processor.add_multi_hop_joins(
-        desired_linkable_specs=desired_linkable_specs, nodes=nodes_available_for_joins
+        desired_linkable_specs=desired_linkable_specs, nodes=nodes_available_for_joins, join_type=SqlJoinType.LEFT_OUTER
     )
 
     return NodeEvaluatorForLinkableInstances(

--- a/metricflow/test/integration/test_cases/itest_dimensions.yaml
+++ b/metricflow/test/integration/test_cases/itest_dimensions.yaml
@@ -139,7 +139,7 @@ integration_test:
       u.home_state_latest AS user__home_state_latest
     , l.is_lux AS listing__is_lux_latest
     FROM {{ source_schema }}.dim_listings_latest l
-    LEFT OUTER JOIN {{ source_schema }}.dim_users_latest u
+    FULL OUTER JOIN {{ source_schema }}.dim_users_latest u
       ON u.user_id = l.user_id
     GROUP BY
       u.home_state_latest

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -292,6 +292,7 @@ def test_single_join_node(  # noqa: D
                 join_on_partition_time_dimensions=(),
             )
         ],
+        join_type=SqlJoinType.LEFT_OUTER,
     )
 
     convert_and_check(
@@ -351,6 +352,7 @@ def test_multi_join_node(
                 join_on_partition_time_dimensions=(),
             ),
         ],
+        join_type=SqlJoinType.LEFT_OUTER,
     )
 
     convert_and_check(
@@ -408,6 +410,7 @@ def test_compute_metrics_node(
                 join_on_partition_time_dimensions=(),
             )
         ],
+        join_type=SqlJoinType.LEFT_OUTER,
     )
 
     aggregated_measure_node = AggregateMeasuresNode(
@@ -469,6 +472,7 @@ def test_compute_metrics_node_simple_expr(
                 join_on_partition_time_dimensions=(),
             )
         ],
+        join_type=SqlJoinType.LEFT_OUTER,
     )
 
     aggregated_measures_node = AggregateMeasuresNode(
@@ -749,6 +753,7 @@ def test_compute_metrics_node_ratio_from_single_semantic_model(
                 join_on_partition_time_dimensions=(),
             )
         ],
+        join_type=SqlJoinType.LEFT_OUTER,
     )
 
     aggregated_measures_node = AggregateMeasuresNode(

--- a/metricflow/test/snapshots/test_cyclic_join.py/DataflowPlan/test_cyclic_join__dfp_0.xml
+++ b/metricflow/test/snapshots/test_cyclic_join.py/DataflowPlan/test_cyclic_join__dfp_0.xml
@@ -42,6 +42,7 @@
                         <!--    'join_on_partition_dimensions': (),                  -->
                         <!--    'join_on_partition_time_dimensions': (),             -->
                         <!--    'validity_window': None}                             -->
+                        <!-- join_type = SqlJoinType.LEFT_OUTER -->
                         <FilterElementsNode>
                             <!-- description =                      -->
                             <!--   Pass Only Elements:              -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_common_semantic_model__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_common_semantic_model__dfp_0.xml
@@ -51,6 +51,7 @@
                             <!--    'join_on_partition_dimensions': (),                -->
                             <!--    'join_on_partition_time_dimensions': (),           -->
                             <!--    'validity_window': None}                           -->
+                            <!-- join_type = SqlJoinType.LEFT_OUTER -->
                             <FilterElementsNode>
                                 <!-- description =                                    -->
                                 <!--   Pass Only Elements:                            -->
@@ -154,6 +155,7 @@
                             <!--    'join_on_partition_dimensions': (),                -->
                             <!--    'join_on_partition_time_dimensions': (),           -->
                             <!--    'validity_window': None}                           -->
+                            <!-- join_type = SqlJoinType.LEFT_OUTER -->
                             <FilterElementsNode>
                                 <!-- description =                                         -->
                                 <!--   Pass Only Elements:                                 -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
@@ -53,6 +53,7 @@
                         <!--    'join_on_partition_dimensions': (),                -->
                         <!--    'join_on_partition_time_dimensions': (),           -->
                         <!--    'validity_window': None}                           -->
+                        <!-- join_type = SqlJoinType.FULL_OUTER -->
                         <ReadSqlSourceNode>
                             <!-- description =                                                                                    -->
                             <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='listings_latest'))  -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_joined_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_joined_plan__dfp_0.xml
@@ -45,6 +45,7 @@
                         <!--    'join_on_partition_dimensions': (),                -->
                         <!--    'join_on_partition_time_dimensions': (),           -->
                         <!--    'validity_window': None}                           -->
+                        <!-- join_type = SqlJoinType.LEFT_OUTER -->
                         <FilterElementsNode>
                             <!-- description =                                       -->
                             <!--   Pass Only Elements:                               -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -102,6 +102,7 @@
                                         <!--    'join_on_partition_dimensions': (),                -->
                                         <!--    'join_on_partition_time_dimensions': (),           -->
                                         <!--    'validity_window': None}                           -->
+                                        <!-- join_type = SqlJoinType.LEFT_OUTER -->
                                         <FilterElementsNode>
                                             <!-- description =                                                 -->
                                             <!--   Pass Only Elements:                                         -->
@@ -247,6 +248,7 @@
                                         <!--    'join_on_partition_dimensions': (),                -->
                                         <!--    'join_on_partition_time_dimensions': (),           -->
                                         <!--    'validity_window': None}                           -->
+                                        <!-- join_type = SqlJoinType.LEFT_OUTER -->
                                         <FilterElementsNode>
                                             <!-- description =                                    -->
                                             <!--   Pass Only Elements:                            -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_semantic_model_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_semantic_model_ratio_metrics_plan__dfp_0.xml
@@ -61,6 +61,7 @@
                                 <!--    'join_on_partition_dimensions': (),                -->
                                 <!--    'join_on_partition_time_dimensions': (),           -->
                                 <!--    'validity_window': None}                           -->
+                                <!-- join_type = SqlJoinType.LEFT_OUTER -->
                                 <FilterElementsNode>
                                     <!-- description =                                    -->
                                     <!--   Pass Only Elements:                            -->
@@ -164,6 +165,7 @@
                                 <!--    'join_on_partition_dimensions': (),                -->
                                 <!--    'join_on_partition_time_dimensions': (),           -->
                                 <!--    'validity_window': None}                           -->
+                                <!-- join_type = SqlJoinType.LEFT_OUTER -->
                                 <FilterElementsNode>
                                     <!-- description =                                 -->
                                     <!--   Pass Only Elements:                         -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
@@ -54,6 +54,7 @@
                         <!--                                                                                'date_part': None,                        -->
                         <!--                                                                                'aggregation_state': None}},),            -->
                         <!--    'validity_window': None}                                                                                              -->
+                        <!-- join_type = SqlJoinType.LEFT_OUTER -->
                         <FilterElementsNode>
                             <!-- description =                                           -->
                             <!--   Pass Only Elements:                                   -->
@@ -133,6 +134,7 @@
                                 <!--                                                                                'date_part': None,                        -->
                                 <!--                                                                                'aggregation_state': None}},),            -->
                                 <!--    'validity_window': None}                                                                                              -->
+                                <!-- join_type = SqlJoinType.LEFT_OUTER -->
                                 <ReadSqlSourceNode>
                                     <!-- description =                                                                                 -->
                                     <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bridge_table'))  -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_semantic_model_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_semantic_model_ratio_metrics_plan__dfp_0.xml
@@ -61,6 +61,7 @@
                                 <!--    'join_on_partition_dimensions': (),                -->
                                 <!--    'join_on_partition_time_dimensions': (),           -->
                                 <!--    'validity_window': None}                           -->
+                                <!-- join_type = SqlJoinType.LEFT_OUTER -->
                                 <FilterElementsNode>
                                     <!-- description =                                    -->
                                     <!--   Pass Only Elements:                            -->
@@ -164,6 +165,7 @@
                                 <!--    'join_on_partition_dimensions': (),                -->
                                 <!--    'join_on_partition_time_dimensions': (),           -->
                                 <!--    'validity_window': None}                           -->
+                                <!-- join_type = SqlJoinType.LEFT_OUTER -->
                                 <FilterElementsNode>
                                     <!-- description =                                   -->
                                     <!--   Pass Only Elements:                           -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -73,6 +73,7 @@
                                 <!--    'join_on_partition_dimensions': (),                -->
                                 <!--    'join_on_partition_time_dimensions': (),           -->
                                 <!--    'validity_window': None}                           -->
+                                <!-- join_type = SqlJoinType.LEFT_OUTER -->
                                 <FilterElementsNode>
                                     <!-- description =                                       -->
                                     <!--   Pass Only Elements:                               -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -55,6 +55,7 @@
                             <!--    'join_on_partition_dimensions': (),                -->
                             <!--    'join_on_partition_time_dimensions': (),           -->
                             <!--    'validity_window': None}                           -->
+                            <!-- join_type = SqlJoinType.LEFT_OUTER -->
                             <FilterElementsNode>
                                 <!-- description =                -->
                                 <!--   Pass Only Elements:        -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_compute_metrics_node_simple_expr__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_compute_metrics_node_simple_expr__plan0.xml
@@ -27,6 +27,7 @@
                     <!--    'join_on_partition_dimensions': (),                -->
                     <!--    'join_on_partition_time_dimensions': (),           -->
                     <!--    'validity_window': None}                           -->
+                    <!-- join_type = SqlJoinType.LEFT_OUTER -->
                     <FilterElementsNode>
                         <!-- description =                     -->
                         <!--   Pass Only Elements:             -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfp_0.xml
@@ -51,6 +51,7 @@
                             <!--    'join_on_partition_dimensions': (),                -->
                             <!--    'join_on_partition_time_dimensions': (),           -->
                             <!--    'validity_window': None}                           -->
+                            <!-- join_type = SqlJoinType.LEFT_OUTER -->
                             <FilterElementsNode>
                                 <!-- description =                                    -->
                                 <!--   Pass Only Elements:                            -->
@@ -154,6 +155,7 @@
                             <!--    'join_on_partition_dimensions': (),                -->
                             <!--    'join_on_partition_time_dimensions': (),           -->
                             <!--    'validity_window': None}                           -->
+                            <!-- join_type = SqlJoinType.LEFT_OUTER -->
                             <FilterElementsNode>
                                 <!-- description =                                         -->
                                 <!--   Pass Only Elements:                                 -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
@@ -59,6 +59,7 @@
                         <!--    'join_on_partition_dimensions': (),                -->
                         <!--    'join_on_partition_time_dimensions': (),           -->
                         <!--    'validity_window': None}                           -->
+                        <!-- join_type = SqlJoinType.LEFT_OUTER -->
                         <FilterElementsNode>
                             <!-- description =                                                     -->
                             <!--   Pass Only Elements:                                             -->


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
maybe: move join_type to the join description (needed for metric_time cross joins)


### Description

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
