### PR TITLE
Remove RudderStack logging from MetricFlow telemetry

### DIFF
--- a/.changes/unreleased/Dependencies-20231113-181503.yaml
+++ b/.changes/unreleased/Dependencies-20231113-181503.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Remove Rudderstack client and associated dependencies
+time: 2023-11-13T18:15:03.406145-08:00
+custom:
+  Author: tlento
+  PR: "866"

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -49,7 +49,6 @@ logger = logging.getLogger(__name__)
 pass_config = click.make_pass_decorator(CLIContext, ensure=True)
 _telemetry_reporter = TelemetryReporter(report_levels_higher_or_equal_to=TelemetryLevel.USAGE)
 _telemetry_reporter.add_python_log_handler()
-_telemetry_reporter.add_rudderstack_handler()
 
 
 @click.group()

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -64,7 +64,6 @@ from metricflow.time.time_source import TimeSource
 logger = logging.getLogger(__name__)
 _telemetry_reporter = TelemetryReporter(report_levels_higher_or_equal_to=TelemetryLevel.USAGE)
 _telemetry_reporter.add_python_log_handler()
-_telemetry_reporter.add_rudderstack_handler()
 
 
 @dataclass(frozen=True)

--- a/metricflow/telemetry/handlers/handlers.py
+++ b/metricflow/telemetry/handlers/handlers.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from datetime import datetime
 from typing import Any, Dict, List, Optional, Sequence
-
-from rudder_analytics.client import Client as RudderstackClient
 
 from metricflow.telemetry.models import FunctionEndEvent, FunctionStartEvent, TelemetryPayload
 
@@ -35,44 +32,6 @@ class TelemetryHandler(ABC):
         )
         self._write_log(client_id, payload.dict())
         return True
-
-
-class RudderstackTelemetryHandler(TelemetryHandler):
-    """A telemetry client that logs data to Rudderstack."""
-
-    RUDDERSTACK_EVENT_NAME = "MF_OSS"
-
-    # Key for logging to Transform
-    TFD_WRITE_KEY: str = "2777X6I2uHwXmCM9hB6GPKcegdn"
-    TFD_DATA_PLANE: str = "https://transformdprul.dataplane.rudderstack.com"
-
-    def __init__(  # noqa: D
-        self,
-        data_plane_url: str = TFD_DATA_PLANE,
-        write_key: str = TFD_WRITE_KEY,
-    ) -> None:
-        self._rudderstack_client = RudderstackClient(
-            write_key=write_key, host=data_plane_url, debug=False, on_error=None, send=True, sync_mode=False
-        )
-
-    def _write_log(self, client_id: str, payload: PayloadType) -> None:  # noqa: D
-        """Write log to rudderstack.
-
-        Added context to handle the error, but seems odd.
-
-        >       msg['context']['traits']['anonymousId'] = msg['anonymousId']
-        E       KeyError: 'traits'
-
-        /usr/local/lib/python3.8/site-packages/rudder_analytics/client.py:243: KeyError
-        """
-        context: PayloadType = {"traits": {}}
-        self._rudderstack_client.track(
-            anonymous_id=client_id,
-            event=RudderstackTelemetryHandler.RUDDERSTACK_EVENT_NAME,
-            timestamp=datetime.now(),
-            properties=payload,
-            context=context,
-        )
 
 
 class ToMemoryTelemetryHandler(TelemetryHandler):

--- a/metricflow/telemetry/reporter.py
+++ b/metricflow/telemetry/reporter.py
@@ -16,7 +16,6 @@ from typing_extensions import ParamSpec
 
 from metricflow.random_id import random_id
 from metricflow.telemetry.handlers.handlers import (
-    RudderstackTelemetryHandler,
     TelemetryHandler,
     ToMemoryTelemetryHandler,
 )
@@ -64,9 +63,6 @@ class TelemetryReporter:
 
     def add_python_log_handler(self) -> None:  # noqa: D
         self._handlers.append(PythonLoggerTelemetryHandler(logger_level=logging.INFO))
-
-    def add_rudderstack_handler(self) -> None:  # noqa: D
-        self._handlers.append(RudderstackTelemetryHandler())
 
     def add_test_handler(self) -> None:
         """See test_handler."""

--- a/metricflow/test/telemetry/test_telemetry.py
+++ b/metricflow/test/telemetry/test_telemetry.py
@@ -78,24 +78,3 @@ def test_telemetry_off() -> None:  # noqa: D
         test_exception_function()
 
     assert len(reporter.test_handler.payloads) == 0
-
-
-@pytest.mark.skip("Sends events to Rudderstack")
-def test_rudderstack_logging() -> None:  # noqa: D
-    reporter = TelemetryReporter(report_levels_higher_or_equal_to=TelemetryLevel.USAGE)
-    reporter.add_python_log_handler()
-    reporter.add_rudderstack_handler()
-
-    @log_call(telemetry_reporter=reporter, module_name=__name__)
-    def test_function() -> str:
-        return "foo"
-
-    test_function()
-
-    with pytest.raises(ValueError):
-
-        @log_call(telemetry_reporter=reporter, module_name=__name__)
-        def test_exception_function() -> str:
-            raise ValueError("foo")
-
-        test_exception_function()

--- a/mypy.ini
+++ b/mypy.ini
@@ -51,8 +51,5 @@ follow_imports = skip
 [mypy-halo]
 ignore_missing_imports = True
 
-[mypy-rudder_analytics.*]
-ignore_missing_imports = True
-
 [mypy-update_checker]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
   "python-dateutil~=2.8.2",
   "rapidfuzz~=3.0",
   "ruamel.yaml~=0.17.21",
-  "rudder-sdk-python~=1.0.3",
   "tabulate>=0.8.9",
   "typing_extensions~=4.4.0",
   "update-checker~=0.18.0",


### PR DESCRIPTION
Prior to its acquisition by dbt Labs, Transform used Rudderstack
for analytics event log handling. As a result, the MetricFlow
telemetry system included the option to log data to Rudderstack.

Nowadays there is no longer a need to support this route, and indeed
the Rudderstack client itself causes some small problems, such as
the occasional irrepressible warning about SSL sockets failing
to close properly after running queries in the MetricFlow CLI.
