### PR TITLE
Relax version pin on typing-extensions to ~=4.4

### DIFF
--- a/.changes/unreleased/Dependencies-20231115-144849.yaml
+++ b/.changes/unreleased/Dependencies-20231115-144849.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Relax version pin on typing extensions to allow >=4.4, <5
+time: 2023-11-15T14:48:49.411998-08:00
+custom:
+  Author: tlento
+  PR: "875"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "rapidfuzz~=3.0",
   "ruamel.yaml~=0.17.21",
   "tabulate>=0.8.9",
-  "typing_extensions~=4.4.0",
+  "typing_extensions~=4.4",
   "update-checker~=0.18.0",
 ]
 


### PR DESCRIPTION
Due to my persistent inability to understand the semantics of
Python's `~=` version syntax I accidentally pinned typing extensions
to 4.4.x instead of >= 4.4, < 5.

This addresses the error.
