### PR TITLE
Consolidate Measure Time Spine Join Conditional Behavior Into `MetricInputMeasureSpec`

### DIFF
--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -445,7 +445,11 @@ class AggregateMeasuresNode(AggregatedMeasuresOutput):
     constraints applied to the measure.
     """
 
-    def __init__(self, parent_node: BaseOutput, metric_input_measure_specs: Tuple[MetricInputMeasureSpec, ...]) -> None:
+    def __init__(
+        self,
+        parent_node: BaseOutput,
+        metric_input_measure_specs: Tuple[MetricInputMeasureSpec, ...],
+    ) -> None:
         """Initializer for AggregateMeasuresNode.
 
         The input measure specs are required for downstream nodes to be aware of any input measures with

--- a/metricflow/test/test_instance_serialization.py
+++ b/metricflow/test/test_instance_serialization.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 from dbt_semantic_interfaces.dataclass_serialization import DataClassDeserializer, DataclassSerializer
 
 from metricflow.instances import InstanceSet
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description

I found the `DataflowPlanBuilder` hard to follow in regards to when the measure would be joined to the time spine. There was conditional logic that depended on several parameters scattered throughout methods. This PR encapsulates the join condition in `MetricInputMeasureSpec`, and the consolidates filling out those fields when that spec is constructed. Once the behavior is encapsulated, the signature for methods `_build_aggregated_measure_from_measure_source_node()` can be simplified.

There's additional consolidation that can be done for cumulative measure parameters, but putting that off for now as consolidating this logic has been complex as it is. Also, there's a potential edge case with nested derived offset metrics that was found, but it is not addressed here.