### PR TITLE
Bug fix: apply offset for nested derived metrics

### DIFF
--- a/.changes/unreleased/Fixes-20231116-153955.yaml
+++ b/.changes/unreleased/Fixes-20231116-153955.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Apply time offset for nested dervied & ratio metrics
+time: 2023-11-16T15:39:55.211195-08:00
+custom:
+  Author: courtneyholcomb
+  Issue: "882"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -58,6 +58,7 @@ from metricflow.specs.specs import (
     LinkableInstanceSpec,
     LinkableSpecSet,
     LinklessEntitySpec,
+    MeasureCulminationDescription,
     MeasureSpec,
     MetricFlowQuerySpec,
     MetricInputMeasureSpec,

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -58,7 +58,6 @@ from metricflow.specs.specs import (
     LinkableInstanceSpec,
     LinkableSpecSet,
     LinklessEntitySpec,
-    MeasureCulminationDescription,
     MeasureSpec,
     MetricFlowQuerySpec,
     MetricInputMeasureSpec,

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -650,7 +650,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         time_range_constraint: Optional[TimeRangeConstraint] = None,
         offset_window: Optional[MetricTimeWindow] = None,
         offset_to_grain: Optional[TimeGranularity] = None,
-    ) -> None:  # noqa: D
+    ) -> None:
         """Constructor.
 
         Args:
@@ -679,27 +679,27 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         return DATAFLOW_NODE_JOIN_TO_TIME_SPINE_ID_PREFIX
 
     @property
-    def requested_metric_time_dimension_specs(self) -> List[TimeDimensionSpec]:  # noqa: D
+    def requested_metric_time_dimension_specs(self) -> List[TimeDimensionSpec]:
         """Time dimension specs to use when creating time spine table."""
         return self._requested_metric_time_dimension_specs
 
     @property
-    def time_range_constraint(self) -> Optional[TimeRangeConstraint]:  # noqa: D
+    def time_range_constraint(self) -> Optional[TimeRangeConstraint]:
         """Time range constraint to apply when querying time spine table."""
         return self._time_range_constraint
 
     @property
-    def offset_window(self) -> Optional[MetricTimeWindow]:  # noqa: D
+    def offset_window(self) -> Optional[MetricTimeWindow]:
         """Time range constraint to apply when querying time spine table."""
         return self._offset_window
 
     @property
-    def offset_to_grain(self) -> Optional[TimeGranularity]:  # noqa: D
+    def offset_to_grain(self) -> Optional[TimeGranularity]:
         """Time range constraint to apply when querying time spine table."""
         return self._offset_to_grain
 
     @property
-    def join_type(self) -> SqlJoinType:  # noqa: D
+    def join_type(self) -> SqlJoinType:
         """Join type to use when joining to time spine."""
         return self._join_type
 

--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -972,3 +972,29 @@ def test_dont_join_to_time_spine_if_no_time_dimension_requested(  # noqa: D
         mf_test_session_state=mf_test_session_state,
         dag_graph=dataflow_plan,
     )
+
+
+def test_nested_derived_metric_with_outer_offset(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_offset_twice"),),
+            time_dimension_specs=(DataSet.metric_time_dimension_spec(TimeGranularity.DAY),),
+        )
+    )
+
+    assert_plan_snapshot_text_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        plan=dataflow_plan,
+        plan_snapshot_text=dataflow_plan_as_text(dataflow_plan),
+    )
+
+    display_graph_if_requested(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dag_graph=dataflow_plan,
+    )

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/metrics.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/metrics.yaml
@@ -578,3 +578,35 @@ metric:
       - name: bookings
         offset_window: 14 days
         alias: bookings_2_weeks_ago
+---
+metric:
+  name: "bookings_offset_once"
+  description: bookings metric offset once.
+  type: derived
+  type_params:
+    expr: 2 * bookings
+    metrics:
+      - name: bookings
+        offset_window: 5 days
+---
+metric:
+  name: "bookings_offset_twice"
+  description: bookings metric offset twice.
+  type: derived
+  type_params:
+    expr: 2 * bookings_offset_once
+    metrics:
+      - name: bookings_offset_once
+        offset_window: 5 days
+---
+metric:
+  name: booking_fees_since_start_of_month
+  description: nested derived metric with offset and multiple input metrics
+  type: derived
+  type_params:
+    expr: booking_fees - booking_fees_start_of_month
+    metrics:
+      - name: booking_fees
+        offset_to_grain: month
+        alias: booking_fees_start_of_month
+      - name: booking_fees

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/metrics.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/metrics.yaml
@@ -597,7 +597,7 @@ metric:
     expr: 2 * bookings_offset_once
     metrics:
       - name: bookings_offset_once
-        offset_window: 5 days
+        offset_window: 2 days
 ---
 metric:
   name: booking_fees_since_start_of_month

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -1558,3 +1558,77 @@ integration_test:
       GROUP BY
         COALESCE(subq_8.metric_time__day, subq_14.metric_time__day)
     ) subq_15
+---
+integration_test:
+  name: nested_derived_metric_offset_with_where_constraint
+  description: Tests a nested derived metric where the outer metric has an offset and a constraint is applied to metric_time via where clause.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_offset_twice"]
+  group_by_objs: [{"name": "metric_time", "grain": "day"}]
+  where_filter: "{{ render_time_constraint('metric_time__day', '2020-01-12', '2020-01-13') }}"
+  check_query: |
+    SELECT
+      subq_9.ds AS metric_time__day
+      , 2 * bookings_offset_once AS bookings_offset_twice
+    FROM {{ source_schema }}.mf_time_spine subq_9
+    INNER JOIN (
+      SELECT
+        metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        SELECT
+          subq_3.ds AS metric_time__day
+          , SUM(subq_1.bookings) AS bookings
+        FROM {{ source_schema }}.mf_time_spine subq_3
+        INNER JOIN (
+          SELECT
+            {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS metric_time__day
+            , 1 AS bookings
+          FROM {{ source_schema }}.fct_bookings bookings_source_src_1
+        ) subq_1
+        ON
+          {{ render_date_sub("subq_3", "ds", 5, TimeGranularity.DAY) }} = subq_1.metric_time__day
+        GROUP BY
+          subq_3.ds
+      ) subq_7
+    ) subq_8
+    ON
+      {{ render_date_sub("subq_9", "ds", 5, TimeGranularity.DAY) }} = subq_8.metric_time__day
+    WHERE {{ render_time_constraint('subq_9.ds', '2020-01-12', '2020-01-13') }}
+---
+integration_test:
+  name: nested_derived_metric_offset_with_time_constraint
+  description: Tests a nested derived metric where the outer metric has an offset and a constraint is applied to metric_time via time constraint params.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_offset_twice"]
+  group_by_objs: [{"name": "metric_time", "grain": "day"}]
+  time_constraint: ["2020-01-12", "2020-01-13"]
+  check_query: |
+    SELECT
+      subq_9.ds AS metric_time__day
+      , 2 * bookings_offset_once AS bookings_offset_twice
+    FROM {{ source_schema }}.mf_time_spine subq_9
+    INNER JOIN (
+      SELECT
+        metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        SELECT
+          subq_3.ds AS metric_time__day
+          , SUM(subq_1.bookings) AS bookings
+        FROM {{ source_schema }}.mf_time_spine subq_3
+        INNER JOIN (
+          SELECT
+            {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS metric_time__day
+            , 1 AS bookings
+          FROM {{ source_schema }}.fct_bookings bookings_source_src_1
+        ) subq_1
+        ON
+          {{ render_date_sub("subq_3", "ds", 5, TimeGranularity.DAY) }} = subq_1.metric_time__day
+        GROUP BY
+          subq_3.ds
+      ) subq_7
+    ) subq_8
+    ON
+      {{ render_date_sub("subq_9", "ds", 5, TimeGranularity.DAY) }} = subq_8.metric_time__day
+    WHERE {{ render_time_constraint('subq_9.ds', '2020-01-12', '2020-01-13') }}

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -1502,7 +1502,7 @@ integration_test:
       ) subq_7
     ) subq_8
     ON
-      {{ render_date_sub("subq_9", "ds", 5, TimeGranularity.DAY) }} = subq_8.metric_time__day
+      {{ render_date_sub("subq_9", "ds", 2, TimeGranularity.DAY) }} = subq_8.metric_time__day
 ---
 integration_test:
   name: nested_derived_metric_outer_offset_multiple_input_metrics
@@ -1565,7 +1565,7 @@ integration_test:
   model: SIMPLE_MODEL
   metrics: ["bookings_offset_twice"]
   group_by_objs: [{"name": "metric_time", "grain": "day"}]
-  where_filter: "{{ render_time_constraint('metric_time__day', '2020-01-12', '2020-01-13') }}"
+  where_filter: "{{ render_time_constraint('metric_time__day', '2020-01-08', '2020-01-09') }}"
   check_query: |
     SELECT
       subq_9.ds AS metric_time__day
@@ -1593,8 +1593,8 @@ integration_test:
       ) subq_7
     ) subq_8
     ON
-      {{ render_date_sub("subq_9", "ds", 5, TimeGranularity.DAY) }} = subq_8.metric_time__day
-    WHERE {{ render_time_constraint('subq_9.ds', '2020-01-12', '2020-01-13') }}
+      {{ render_date_sub("subq_9", "ds", 2, TimeGranularity.DAY) }} = subq_8.metric_time__day
+    WHERE {{ render_time_constraint('subq_9.ds', '2020-01-08', '2020-01-09') }}
 ---
 integration_test:
   name: nested_derived_metric_offset_with_time_constraint
@@ -1602,7 +1602,7 @@ integration_test:
   model: SIMPLE_MODEL
   metrics: ["bookings_offset_twice"]
   group_by_objs: [{"name": "metric_time", "grain": "day"}]
-  time_constraint: ["2020-01-12", "2020-01-13"]
+  time_constraint: ["2020-01-08", "2020-01-09"]
   check_query: |
     SELECT
       subq_9.ds AS metric_time__day
@@ -1630,5 +1630,5 @@ integration_test:
       ) subq_7
     ) subq_8
     ON
-      {{ render_date_sub("subq_9", "ds", 5, TimeGranularity.DAY) }} = subq_8.metric_time__day
-    WHERE {{ render_time_constraint('subq_9.ds', '2020-01-12', '2020-01-13') }}
+      {{ render_date_sub("subq_9", "ds", 2, TimeGranularity.DAY) }} = subq_8.metric_time__day
+    WHERE {{ render_time_constraint('subq_9.ds', '2020-01-08', '2020-01-09') }}

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -1468,3 +1468,93 @@ integration_test:
     GROUP BY
       COALESCE(subq_9.metric_time__day, subq_19.metric_time__day)
       , COALESCE(subq_9.listing__is_lux_latest, subq_19.listing__is_lux_latest)
+---
+integration_test:
+  name: nested_derived_metric_outer_offset
+  description: Tests a nested derived metric where the outer metric has an input metric with offset_window.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_offset_twice"]
+  group_by_objs: [{"name": "metric_time"}]
+  check_query: |
+    SELECT
+      subq_9.ds AS metric_time__day
+      , 2 * bookings_offset_once AS bookings_offset_twice
+    FROM {{ source_schema }}.mf_time_spine subq_9
+    INNER JOIN (
+      SELECT
+        metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        SELECT
+          subq_3.ds AS metric_time__day
+          , SUM(subq_1.bookings) AS bookings
+        FROM {{ source_schema }}.mf_time_spine subq_3
+        INNER JOIN (
+          SELECT
+            {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS metric_time__day
+            , 1 AS bookings
+          FROM {{ source_schema }}.fct_bookings bookings_source_src_1
+        ) subq_1
+        ON
+          {{ render_date_sub("subq_3", "ds", 5, TimeGranularity.DAY) }} = subq_1.metric_time__day
+        GROUP BY
+          subq_3.ds
+      ) subq_7
+    ) subq_8
+    ON
+      {{ render_date_sub("subq_9", "ds", 5, TimeGranularity.DAY) }} = subq_8.metric_time__day
+---
+integration_test:
+  name: nested_derived_metric_outer_offset_multiple_input_metrics
+  description: Tests a nested derived metric where the outer metric has one input metric with offset_to_grain and another with no offset.
+  model: SIMPLE_MODEL
+  metrics: ["booking_fees_since_start_of_month"]
+  group_by_objs: [{"name": "metric_time"}]
+  check_query: |
+    SELECT
+      metric_time__day
+      , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+    FROM (
+      SELECT
+        COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+        , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month
+        , MAX(subq_14.booking_fees) AS booking_fees
+      FROM (
+        SELECT
+          subq_7.ds AS metric_time__day
+          , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
+        FROM {{ source_schema }}.mf_time_spine subq_7
+        INNER JOIN (
+          SELECT
+            metric_time__day
+            , booking_value * 0.05 AS booking_fees_start_of_month
+          FROM (
+            SELECT
+              {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS metric_time__day
+              , SUM(booking_value) AS booking_value
+            FROM {{ source_schema }}.fct_bookings bookings_source_src_1
+            GROUP BY
+              {{ render_date_trunc("ds", TimeGranularity.DAY) }}
+          ) subq_4
+        ) subq_5
+        ON
+          {{ render_date_trunc("subq_7.ds", TimeGranularity.MONTH) }} = subq_5.metric_time__day
+      ) subq_8
+      FULL OUTER JOIN (
+        SELECT
+          metric_time__day
+          , booking_value * 0.05 AS booking_fees
+        FROM (
+          SELECT
+            {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS metric_time__day
+            , SUM(booking_value) AS booking_value
+          FROM {{ source_schema }}.fct_bookings bookings_source_src_1
+          GROUP BY
+            {{ render_date_trunc("ds", TimeGranularity.DAY) }}
+        ) subq_13
+      ) subq_14
+      ON
+        subq_8.metric_time__day = subq_14.metric_time__day
+      GROUP BY
+        COALESCE(subq_8.metric_time__day, subq_14.metric_time__day)
+    ) subq_15

--- a/metricflow/test/query_rendering/test_derived_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_derived_metric_rendering.py
@@ -323,3 +323,53 @@ def test_derived_offset_cumulative_metric(  # noqa: D
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
     )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_nested_offsets(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        query_spec=MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_offset_twice"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_nested_derived_metric_with_offset_multiple_input_metrics(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        query_spec=MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="booking_fees_since_start_of_month"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )

--- a/metricflow/test/query_rendering/test_derived_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_derived_metric_rendering.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import datetime
+
 import pytest
 from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.implementations.filters.where_filter import PydanticWhereFilter
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
+from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.specs.column_assoc import ColumnAssociationResolver
@@ -363,6 +366,70 @@ def test_nested_derived_metric_with_offset_multiple_input_metrics(  # noqa: D
         query_spec=MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="booking_fees_since_start_of_month"),),
             time_dimension_specs=(MTD_SPEC_DAY,),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_nested_offsets_with_where_constraint(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    column_association_resolver: ColumnAssociationResolver,
+    create_source_tables: bool,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        query_spec=MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_offset_twice"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+            where_constraint=WhereSpecFactory(
+                column_association_resolver=column_association_resolver,
+            ).create_from_where_filter(
+                PydanticWhereFilter(
+                    where_sql_template=(
+                        "{{ TimeDimension('metric_time', 'day') }} = '2020-01-12' "
+                        "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-13'"
+                    )
+                ),
+            ),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_nested_offsets_with_time_constraint(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        query_spec=MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_offset_twice"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+            time_range_constraint=TimeRangeConstraint(
+                start_time=datetime.datetime(2020, 1, 12), end_time=datetime.datetime(2020, 1, 13)
+            ),
         )
     )
 

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -16,12 +16,12 @@
                 <!-- description = Join to Time Spine Dataset -->
                 <!-- node_id = jts_1 -->
                 <!-- requested_metric_time_dimension_specs =       -->
-                <!--   ({'class': 'TimeDimensionSpec',             -->
+                <!--   [{'class': 'TimeDimensionSpec',             -->
                 <!--     'element_name': 'metric_time',            -->
                 <!--     'entity_links': (),                       -->
                 <!--     'time_granularity': TimeGranularity.DAY,  -->
                 <!--     'date_part': None,                        -->
-                <!--     'aggregation_state': None},)              -->
+                <!--     'aggregation_state': None}]               -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = count=5 granularity=TimeGranularity.DAY -->
                 <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -1,0 +1,107 @@
+<DataflowPlan>
+    <WriteToResultDataframeNode>
+        <!-- description = Write to Dataframe -->
+        <!-- node_id = wrd_0 -->
+        <ComputeMetricsNode>
+            <!-- description = Compute Metrics via Expressions -->
+            <!-- node_id = cm_2 -->
+            <!-- metric_spec =                                -->
+            <!--   {'class': 'MetricSpec',                    -->
+            <!--    'element_name': 'bookings_offset_twice',  -->
+            <!--    'constraint': None,                       -->
+            <!--    'alias': None,                            -->
+            <!--    'offset_window': None,                    -->
+            <!--    'offset_to_grain': None}                  -->
+            <JoinToTimeSpineNode>
+                <!-- description = Join to Time Spine Dataset -->
+                <!-- node_id = jts_1 -->
+                <!-- requested_metric_time_dimension_specs =       -->
+                <!--   ({'class': 'TimeDimensionSpec',             -->
+                <!--     'element_name': 'metric_time',            -->
+                <!--     'entity_links': (),                       -->
+                <!--     'time_granularity': TimeGranularity.DAY,  -->
+                <!--     'date_part': None,                        -->
+                <!--     'aggregation_state': None},)              -->
+                <!-- time_range_constraint = None -->
+                <!-- offset_window = count=5 granularity=TimeGranularity.DAY -->
+                <!-- offset_to_grain = None -->
+                <!-- join_type = SqlJoinType.INNER -->
+                <ComputeMetricsNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = cm_1 -->
+                    <!-- metric_spec =                                              -->
+                    <!--   {'class': 'MetricSpec',                                  -->
+                    <!--    'element_name': 'bookings_offset_once',                 -->
+                    <!--    'constraint': None,                                     -->
+                    <!--    'alias': None,                                          -->
+                    <!--    'offset_window': {'class': 'PydanticMetricTimeWindow',  -->
+                    <!--                      'count': 5,                           -->
+                    <!--                      'granularity': TimeGranularity.DAY},  -->
+                    <!--    'offset_to_grain': None}                                -->
+                    <ComputeMetricsNode>
+                        <!-- description = Compute Metrics via Expressions -->
+                        <!-- node_id = cm_0 -->
+                        <!-- metric_spec =                                              -->
+                        <!--   {'class': 'MetricSpec',                                  -->
+                        <!--    'element_name': 'bookings',                             -->
+                        <!--    'constraint': None,                                     -->
+                        <!--    'alias': None,                                          -->
+                        <!--    'offset_window': {'class': 'PydanticMetricTimeWindow',  -->
+                        <!--                      'count': 5,                           -->
+                        <!--                      'granularity': TimeGranularity.DAY},  -->
+                        <!--    'offset_to_grain': None}                                -->
+                        <AggregateMeasuresNode>
+                            <!-- description = Aggregate Measures -->
+                            <!-- node_id = am_0 -->
+                            <FilterElementsNode>
+                                <!-- description =                         -->
+                                <!--   Pass Only Elements:                 -->
+                                <!--     ['bookings', 'metric_time__day']  -->
+                                <!-- node_id = pfe_0 -->
+                                <!-- include_spec =                           -->
+                                <!--   {'class': 'MeasureSpec',               -->
+                                <!--    'element_name': 'bookings',           -->
+                                <!--    'non_additive_dimension_spec': None}  -->
+                                <!-- include_spec =                               -->
+                                <!--   {'class': 'TimeDimensionSpec',             -->
+                                <!--    'element_name': 'metric_time',            -->
+                                <!--    'entity_links': (),                       -->
+                                <!--    'time_granularity': TimeGranularity.DAY,  -->
+                                <!--    'date_part': None,                        -->
+                                <!--    'aggregation_state': None}                -->
+                                <!-- distinct = False -->
+                                <JoinToTimeSpineNode>
+                                    <!-- description = Join to Time Spine Dataset -->
+                                    <!-- node_id = jts_0 -->
+                                    <!-- requested_metric_time_dimension_specs =       -->
+                                    <!--   [{'class': 'TimeDimensionSpec',             -->
+                                    <!--     'element_name': 'metric_time',            -->
+                                    <!--     'entity_links': (),                       -->
+                                    <!--     'time_granularity': TimeGranularity.DAY,  -->
+                                    <!--     'date_part': None,                        -->
+                                    <!--     'aggregation_state': None}]               -->
+                                    <!-- time_range_constraint = None -->
+                                    <!-- offset_window = count=5 granularity=TimeGranularity.DAY -->
+                                    <!-- offset_to_grain = None -->
+                                    <!-- join_type = SqlJoinType.INNER -->
+                                    <MetricTimeDimensionTransformNode>
+                                        <!-- description = Metric Time Dimension 'ds' -->
+                                        <!-- node_id = sma_10001 -->
+                                        <!-- aggregation_time_dimension = ds -->
+                                        <ReadSqlSourceNode>
+                                            <!-- description =                                                                                    -->
+                                            <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                            <!-- node_id = rss_10011 -->
+                                            <!-- data_set =                                                                             -->
+                                            <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                        </ReadSqlSourceNode>
+                                    </MetricTimeDimensionTransformNode>
+                                </JoinToTimeSpineNode>
+                            </FilterElementsNode>
+                        </AggregateMeasuresNode>
+                    </ComputeMetricsNode>
+                </ComputeMetricsNode>
+            </JoinToTimeSpineNode>
+        </ComputeMetricsNode>
+    </WriteToResultDataframeNode>
+</DataflowPlan>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -61,7 +61,8 @@
                                 <!-- include_spec =                           -->
                                 <!--   {'class': 'MeasureSpec',               -->
                                 <!--    'element_name': 'bookings',           -->
-                                <!--    'non_additive_dimension_spec': None}  -->
+                                <!--    'non_additive_dimension_spec': None,  -->
+                                <!--    'fill_nulls_with': None}              -->
                                 <!-- include_spec =                               -->
                                 <!--   {'class': 'TimeDimensionSpec',             -->
                                 <!--    'element_name': 'metric_time',            -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -23,7 +23,7 @@
                 <!--     'date_part': None,                        -->
                 <!--     'aggregation_state': None}]               -->
                 <!-- time_range_constraint = None -->
-                <!-- offset_window = count=5 granularity=TimeGranularity.DAY -->
+                <!-- offset_window = count=2 granularity=TimeGranularity.DAY -->
                 <!-- offset_to_grain = None -->
                 <!-- join_type = SqlJoinType.INNER -->
                 <ComputeMetricsNode>
@@ -35,7 +35,7 @@
                     <!--    'constraint': None,                                     -->
                     <!--    'alias': None,                                          -->
                     <!--    'offset_window': {'class': 'PydanticMetricTimeWindow',  -->
-                    <!--                      'count': 5,                           -->
+                    <!--                      'count': 2,                           -->
                     <!--                      'granularity': TimeGranularity.DAY},  -->
                     <!--    'offset_to_grain': None}                                -->
                     <ComputeMetricsNode>

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -1,0 +1,473 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_14.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_4.metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_3.metric_time__day
+          , subq_3.booking_value
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_2.metric_time__day
+            , SUM(subq_2.booking_value) AS booking_value
+          FROM (
+            -- Pass Only Elements:
+            --   ['booking_value', 'metric_time__day']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.booking_value
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          GROUP BY
+            metric_time__day
+        ) subq_3
+      ) subq_4
+    ) subq_5
+    ON
+      DATE_TRUNC(subq_6.metric_time__day, month) = subq_5.metric_time__day
+  ) subq_8
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_12.metric_time__day
+        , subq_12.booking_value
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_11.metric_time__day
+          , SUM(subq_11.booking_value) AS booking_value
+        FROM (
+          -- Pass Only Elements:
+          --   ['booking_value', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.booking_value
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_9.ds__day
+              , subq_9.ds__week
+              , subq_9.ds__month
+              , subq_9.ds__quarter
+              , subq_9.ds__year
+              , subq_9.ds__extract_year
+              , subq_9.ds__extract_quarter
+              , subq_9.ds__extract_month
+              , subq_9.ds__extract_day
+              , subq_9.ds__extract_dow
+              , subq_9.ds__extract_doy
+              , subq_9.ds_partitioned__day
+              , subq_9.ds_partitioned__week
+              , subq_9.ds_partitioned__month
+              , subq_9.ds_partitioned__quarter
+              , subq_9.ds_partitioned__year
+              , subq_9.ds_partitioned__extract_year
+              , subq_9.ds_partitioned__extract_quarter
+              , subq_9.ds_partitioned__extract_month
+              , subq_9.ds_partitioned__extract_day
+              , subq_9.ds_partitioned__extract_dow
+              , subq_9.ds_partitioned__extract_doy
+              , subq_9.paid_at__day
+              , subq_9.paid_at__week
+              , subq_9.paid_at__month
+              , subq_9.paid_at__quarter
+              , subq_9.paid_at__year
+              , subq_9.paid_at__extract_year
+              , subq_9.paid_at__extract_quarter
+              , subq_9.paid_at__extract_month
+              , subq_9.paid_at__extract_day
+              , subq_9.paid_at__extract_dow
+              , subq_9.paid_at__extract_doy
+              , subq_9.booking__ds__day
+              , subq_9.booking__ds__week
+              , subq_9.booking__ds__month
+              , subq_9.booking__ds__quarter
+              , subq_9.booking__ds__year
+              , subq_9.booking__ds__extract_year
+              , subq_9.booking__ds__extract_quarter
+              , subq_9.booking__ds__extract_month
+              , subq_9.booking__ds__extract_day
+              , subq_9.booking__ds__extract_dow
+              , subq_9.booking__ds__extract_doy
+              , subq_9.booking__ds_partitioned__day
+              , subq_9.booking__ds_partitioned__week
+              , subq_9.booking__ds_partitioned__month
+              , subq_9.booking__ds_partitioned__quarter
+              , subq_9.booking__ds_partitioned__year
+              , subq_9.booking__ds_partitioned__extract_year
+              , subq_9.booking__ds_partitioned__extract_quarter
+              , subq_9.booking__ds_partitioned__extract_month
+              , subq_9.booking__ds_partitioned__extract_day
+              , subq_9.booking__ds_partitioned__extract_dow
+              , subq_9.booking__ds_partitioned__extract_doy
+              , subq_9.booking__paid_at__day
+              , subq_9.booking__paid_at__week
+              , subq_9.booking__paid_at__month
+              , subq_9.booking__paid_at__quarter
+              , subq_9.booking__paid_at__year
+              , subq_9.booking__paid_at__extract_year
+              , subq_9.booking__paid_at__extract_quarter
+              , subq_9.booking__paid_at__extract_month
+              , subq_9.booking__paid_at__extract_day
+              , subq_9.booking__paid_at__extract_dow
+              , subq_9.booking__paid_at__extract_doy
+              , subq_9.ds__day AS metric_time__day
+              , subq_9.ds__week AS metric_time__week
+              , subq_9.ds__month AS metric_time__month
+              , subq_9.ds__quarter AS metric_time__quarter
+              , subq_9.ds__year AS metric_time__year
+              , subq_9.ds__extract_year AS metric_time__extract_year
+              , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_9.ds__extract_month AS metric_time__extract_month
+              , subq_9.ds__extract_day AS metric_time__extract_day
+              , subq_9.ds__extract_dow AS metric_time__extract_dow
+              , subq_9.ds__extract_doy AS metric_time__extract_doy
+              , subq_9.listing
+              , subq_9.guest
+              , subq_9.host
+              , subq_9.booking__listing
+              , subq_9.booking__guest
+              , subq_9.booking__host
+              , subq_9.is_instant
+              , subq_9.booking__is_instant
+              , subq_9.bookings
+              , subq_9.instant_bookings
+              , subq_9.booking_value
+              , subq_9.max_booking_value
+              , subq_9.min_booking_value
+              , subq_9.bookers
+              , subq_9.average_booking_value
+              , subq_9.referred_bookings
+              , subq_9.median_booking_value
+              , subq_9.booking_value_p99
+              , subq_9.discrete_booking_value_p99
+              , subq_9.approximate_continuous_booking_value_p99
+              , subq_9.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_9
+          ) subq_10
+        ) subq_11
+        GROUP BY
+          metric_time__day
+      ) subq_12
+    ) subq_13
+  ) subq_14
+  ON
+    subq_8.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    metric_time__day
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -3,7 +3,7 @@ SELECT
   subq_15.metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
     , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,7 +3,7 @@ SELECT
   metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -1,0 +1,64 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_30.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['booking_value', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          DATE_TRUNC(ds, day) AS metric_time__day
+          , SUM(booking_value) AS booking_value
+        FROM ***************************.fct_bookings bookings_source_src_10001
+        GROUP BY
+          metric_time__day
+      ) subq_20
+    ) subq_21
+    ON
+      DATE_TRUNC(subq_23.ds, month) = subq_21.metric_time__day
+  ) subq_24
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['booking_value', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        DATE_TRUNC(ds, day) AS metric_time__day
+        , SUM(booking_value) AS booking_value
+      FROM ***************************.fct_bookings bookings_source_src_10001
+      GROUP BY
+        metric_time__day
+    ) subq_29
+  ) subq_30
+  ON
+    subq_24.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    metric_time__day
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0.sql
@@ -1,0 +1,340 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_11.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_6.metric_time__day
+        , subq_6.bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_4.metric_time__day
+            , subq_4.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0.sql
@@ -336,5 +336,5 @@ FROM (
     ) subq_7
   ) subq_8
   ON
-    DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_8.metric_time__day
+    DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_8.metric_time__day
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0_optimized.sql
@@ -38,5 +38,5 @@ FROM (
     ) subq_19
   ) subq_20
   ON
-    DATE_SUB(CAST(subq_22.ds AS DATETIME), INTERVAL 5 day) = subq_20.metric_time__day
+    DATE_SUB(CAST(subq_22.ds AS DATETIME), INTERVAL 2 day) = subq_20.metric_time__day
 ) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC(ds, day) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_13
+      ON
+        DATE_SUB(CAST(subq_15.ds AS DATETIME), INTERVAL 5 day) = subq_13.metric_time__day
+      GROUP BY
+        metric_time__day
+    ) subq_19
+  ) subq_20
+  ON
+    DATE_SUB(CAST(subq_22.ds AS DATETIME), INTERVAL 5 day) = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,0 +1,348 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
@@ -342,7 +342,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_8.metric_time__day
+      DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_8.metric_time__day
   ) subq_11
   WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -45,6 +45,6 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    DATE_SUB(CAST(subq_22.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_21.metric_time__day
+    DATE_SUB(CAST(subq_22.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_21.metric_time__day
   WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,50 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_22.metric_time__day AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_23
+    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC(ds, day) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_14
+      ON
+        DATE_SUB(CAST(subq_16.ds AS DATETIME), INTERVAL 5 day) = subq_14.metric_time__day
+      GROUP BY
+        metric_time__day
+    ) subq_20
+  ) subq_21
+  ON
+    DATE_SUB(CAST(subq_22.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_21.metric_time__day
+  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
@@ -341,7 +341,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_8.metric_time__day
+      DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_8.metric_time__day
   ) subq_11
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0.sql
@@ -1,0 +1,347 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
       ) subq_20
     ) subq_21
     ON
-      DATE_SUB(CAST(subq_23.ds AS DATETIME), INTERVAL 5 day) = subq_21.metric_time__day
+      DATE_SUB(CAST(subq_23.ds AS DATETIME), INTERVAL 2 day) = subq_21.metric_time__day
   ) subq_24
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.bookings_offset_once AS bookings_offset_once
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_16.ds AS metric_time__day
+          , SUM(subq_14.bookings) AS bookings
+        FROM ***************************.mf_time_spine subq_16
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC(ds, day) AS metric_time__day
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_10001
+        ) subq_14
+        ON
+          DATE_SUB(CAST(subq_16.ds AS DATETIME), INTERVAL 5 day) = subq_14.metric_time__day
+        GROUP BY
+          metric_time__day
+      ) subq_20
+    ) subq_21
+    ON
+      DATE_SUB(CAST(subq_23.ds AS DATETIME), INTERVAL 5 day) = subq_21.metric_time__day
+  ) subq_24
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -1,0 +1,473 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_14.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_4.metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_3.metric_time__day
+          , subq_3.booking_value
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_2.metric_time__day
+            , SUM(subq_2.booking_value) AS booking_value
+          FROM (
+            -- Pass Only Elements:
+            --   ['booking_value', 'metric_time__day']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.booking_value
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          GROUP BY
+            subq_2.metric_time__day
+        ) subq_3
+      ) subq_4
+    ) subq_5
+    ON
+      DATE_TRUNC('month', subq_6.metric_time__day) = subq_5.metric_time__day
+  ) subq_8
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_12.metric_time__day
+        , subq_12.booking_value
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_11.metric_time__day
+          , SUM(subq_11.booking_value) AS booking_value
+        FROM (
+          -- Pass Only Elements:
+          --   ['booking_value', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.booking_value
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_9.ds__day
+              , subq_9.ds__week
+              , subq_9.ds__month
+              , subq_9.ds__quarter
+              , subq_9.ds__year
+              , subq_9.ds__extract_year
+              , subq_9.ds__extract_quarter
+              , subq_9.ds__extract_month
+              , subq_9.ds__extract_day
+              , subq_9.ds__extract_dow
+              , subq_9.ds__extract_doy
+              , subq_9.ds_partitioned__day
+              , subq_9.ds_partitioned__week
+              , subq_9.ds_partitioned__month
+              , subq_9.ds_partitioned__quarter
+              , subq_9.ds_partitioned__year
+              , subq_9.ds_partitioned__extract_year
+              , subq_9.ds_partitioned__extract_quarter
+              , subq_9.ds_partitioned__extract_month
+              , subq_9.ds_partitioned__extract_day
+              , subq_9.ds_partitioned__extract_dow
+              , subq_9.ds_partitioned__extract_doy
+              , subq_9.paid_at__day
+              , subq_9.paid_at__week
+              , subq_9.paid_at__month
+              , subq_9.paid_at__quarter
+              , subq_9.paid_at__year
+              , subq_9.paid_at__extract_year
+              , subq_9.paid_at__extract_quarter
+              , subq_9.paid_at__extract_month
+              , subq_9.paid_at__extract_day
+              , subq_9.paid_at__extract_dow
+              , subq_9.paid_at__extract_doy
+              , subq_9.booking__ds__day
+              , subq_9.booking__ds__week
+              , subq_9.booking__ds__month
+              , subq_9.booking__ds__quarter
+              , subq_9.booking__ds__year
+              , subq_9.booking__ds__extract_year
+              , subq_9.booking__ds__extract_quarter
+              , subq_9.booking__ds__extract_month
+              , subq_9.booking__ds__extract_day
+              , subq_9.booking__ds__extract_dow
+              , subq_9.booking__ds__extract_doy
+              , subq_9.booking__ds_partitioned__day
+              , subq_9.booking__ds_partitioned__week
+              , subq_9.booking__ds_partitioned__month
+              , subq_9.booking__ds_partitioned__quarter
+              , subq_9.booking__ds_partitioned__year
+              , subq_9.booking__ds_partitioned__extract_year
+              , subq_9.booking__ds_partitioned__extract_quarter
+              , subq_9.booking__ds_partitioned__extract_month
+              , subq_9.booking__ds_partitioned__extract_day
+              , subq_9.booking__ds_partitioned__extract_dow
+              , subq_9.booking__ds_partitioned__extract_doy
+              , subq_9.booking__paid_at__day
+              , subq_9.booking__paid_at__week
+              , subq_9.booking__paid_at__month
+              , subq_9.booking__paid_at__quarter
+              , subq_9.booking__paid_at__year
+              , subq_9.booking__paid_at__extract_year
+              , subq_9.booking__paid_at__extract_quarter
+              , subq_9.booking__paid_at__extract_month
+              , subq_9.booking__paid_at__extract_day
+              , subq_9.booking__paid_at__extract_dow
+              , subq_9.booking__paid_at__extract_doy
+              , subq_9.ds__day AS metric_time__day
+              , subq_9.ds__week AS metric_time__week
+              , subq_9.ds__month AS metric_time__month
+              , subq_9.ds__quarter AS metric_time__quarter
+              , subq_9.ds__year AS metric_time__year
+              , subq_9.ds__extract_year AS metric_time__extract_year
+              , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_9.ds__extract_month AS metric_time__extract_month
+              , subq_9.ds__extract_day AS metric_time__extract_day
+              , subq_9.ds__extract_dow AS metric_time__extract_dow
+              , subq_9.ds__extract_doy AS metric_time__extract_doy
+              , subq_9.listing
+              , subq_9.guest
+              , subq_9.host
+              , subq_9.booking__listing
+              , subq_9.booking__guest
+              , subq_9.booking__host
+              , subq_9.is_instant
+              , subq_9.booking__is_instant
+              , subq_9.bookings
+              , subq_9.instant_bookings
+              , subq_9.booking_value
+              , subq_9.max_booking_value
+              , subq_9.min_booking_value
+              , subq_9.bookers
+              , subq_9.average_booking_value
+              , subq_9.referred_bookings
+              , subq_9.median_booking_value
+              , subq_9.booking_value_p99
+              , subq_9.discrete_booking_value_p99
+              , subq_9.approximate_continuous_booking_value_p99
+              , subq_9.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_9
+          ) subq_10
+        ) subq_11
+        GROUP BY
+          subq_11.metric_time__day
+      ) subq_12
+    ) subq_13
+  ) subq_14
+  ON
+    subq_8.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day)
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -3,7 +3,7 @@ SELECT
   subq_15.metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
     , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -1,0 +1,64 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_30.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['booking_value', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , SUM(booking_value) AS booking_value
+        FROM ***************************.fct_bookings bookings_source_src_10001
+        GROUP BY
+          DATE_TRUNC('day', ds)
+      ) subq_20
+    ) subq_21
+    ON
+      DATE_TRUNC('month', subq_23.ds) = subq_21.metric_time__day
+  ) subq_24
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['booking_value', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , SUM(booking_value) AS booking_value
+      FROM ***************************.fct_bookings bookings_source_src_10001
+      GROUP BY
+        DATE_TRUNC('day', ds)
+    ) subq_29
+  ) subq_30
+  ON
+    subq_24.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,7 +3,7 @@ SELECT
   metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0.sql
@@ -336,5 +336,5 @@ FROM (
     ) subq_7
   ) subq_8
   ON
-    DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0.sql
@@ -1,0 +1,340 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_11.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_6.metric_time__day
+        , subq_6.bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_4.metric_time__day
+            , subq_4.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          subq_5.metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_13
+      ON
+        DATEADD(day, -5, subq_15.ds) = subq_13.metric_time__day
+      GROUP BY
+        subq_15.ds
+    ) subq_19
+  ) subq_20
+  ON
+    DATEADD(day, -5, subq_22.ds) = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets__plan0_optimized.sql
@@ -38,5 +38,5 @@ FROM (
     ) subq_19
   ) subq_20
   ON
-    DATEADD(day, -5, subq_22.ds) = subq_20.metric_time__day
+    DATEADD(day, -2, subq_22.ds) = subq_20.metric_time__day
 ) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
@@ -342,7 +342,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
   ) subq_11
   WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,0 +1,348 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -45,6 +45,6 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    DATEADD(day, -5, subq_22.metric_time__day) = subq_21.metric_time__day
+    DATEADD(day, -2, subq_22.metric_time__day) = subq_21.metric_time__day
   WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,50 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_22.metric_time__day AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_23
+    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_14
+      ON
+        DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
+      GROUP BY
+        subq_16.ds
+    ) subq_20
+  ) subq_21
+  ON
+    DATEADD(day, -5, subq_22.metric_time__day) = subq_21.metric_time__day
+  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
@@ -1,0 +1,347 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0.sql
@@ -341,7 +341,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
   ) subq_11
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
       ) subq_20
     ) subq_21
     ON
-      DATEADD(day, -5, subq_23.ds) = subq_21.metric_time__day
+      DATEADD(day, -2, subq_23.ds) = subq_21.metric_time__day
   ) subq_24
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.bookings_offset_once AS bookings_offset_once
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_16.ds AS metric_time__day
+          , SUM(subq_14.bookings) AS bookings
+        FROM ***************************.mf_time_spine subq_16
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_10001
+        ) subq_14
+        ON
+          DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
+        GROUP BY
+          subq_16.ds
+      ) subq_20
+    ) subq_21
+    ON
+      DATEADD(day, -5, subq_23.ds) = subq_21.metric_time__day
+  ) subq_24
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -1,0 +1,473 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_14.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_4.metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_3.metric_time__day
+          , subq_3.booking_value
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_2.metric_time__day
+            , SUM(subq_2.booking_value) AS booking_value
+          FROM (
+            -- Pass Only Elements:
+            --   ['booking_value', 'metric_time__day']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.booking_value
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          GROUP BY
+            subq_2.metric_time__day
+        ) subq_3
+      ) subq_4
+    ) subq_5
+    ON
+      DATE_TRUNC('month', subq_6.metric_time__day) = subq_5.metric_time__day
+  ) subq_8
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_12.metric_time__day
+        , subq_12.booking_value
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_11.metric_time__day
+          , SUM(subq_11.booking_value) AS booking_value
+        FROM (
+          -- Pass Only Elements:
+          --   ['booking_value', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.booking_value
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_9.ds__day
+              , subq_9.ds__week
+              , subq_9.ds__month
+              , subq_9.ds__quarter
+              , subq_9.ds__year
+              , subq_9.ds__extract_year
+              , subq_9.ds__extract_quarter
+              , subq_9.ds__extract_month
+              , subq_9.ds__extract_day
+              , subq_9.ds__extract_dow
+              , subq_9.ds__extract_doy
+              , subq_9.ds_partitioned__day
+              , subq_9.ds_partitioned__week
+              , subq_9.ds_partitioned__month
+              , subq_9.ds_partitioned__quarter
+              , subq_9.ds_partitioned__year
+              , subq_9.ds_partitioned__extract_year
+              , subq_9.ds_partitioned__extract_quarter
+              , subq_9.ds_partitioned__extract_month
+              , subq_9.ds_partitioned__extract_day
+              , subq_9.ds_partitioned__extract_dow
+              , subq_9.ds_partitioned__extract_doy
+              , subq_9.paid_at__day
+              , subq_9.paid_at__week
+              , subq_9.paid_at__month
+              , subq_9.paid_at__quarter
+              , subq_9.paid_at__year
+              , subq_9.paid_at__extract_year
+              , subq_9.paid_at__extract_quarter
+              , subq_9.paid_at__extract_month
+              , subq_9.paid_at__extract_day
+              , subq_9.paid_at__extract_dow
+              , subq_9.paid_at__extract_doy
+              , subq_9.booking__ds__day
+              , subq_9.booking__ds__week
+              , subq_9.booking__ds__month
+              , subq_9.booking__ds__quarter
+              , subq_9.booking__ds__year
+              , subq_9.booking__ds__extract_year
+              , subq_9.booking__ds__extract_quarter
+              , subq_9.booking__ds__extract_month
+              , subq_9.booking__ds__extract_day
+              , subq_9.booking__ds__extract_dow
+              , subq_9.booking__ds__extract_doy
+              , subq_9.booking__ds_partitioned__day
+              , subq_9.booking__ds_partitioned__week
+              , subq_9.booking__ds_partitioned__month
+              , subq_9.booking__ds_partitioned__quarter
+              , subq_9.booking__ds_partitioned__year
+              , subq_9.booking__ds_partitioned__extract_year
+              , subq_9.booking__ds_partitioned__extract_quarter
+              , subq_9.booking__ds_partitioned__extract_month
+              , subq_9.booking__ds_partitioned__extract_day
+              , subq_9.booking__ds_partitioned__extract_dow
+              , subq_9.booking__ds_partitioned__extract_doy
+              , subq_9.booking__paid_at__day
+              , subq_9.booking__paid_at__week
+              , subq_9.booking__paid_at__month
+              , subq_9.booking__paid_at__quarter
+              , subq_9.booking__paid_at__year
+              , subq_9.booking__paid_at__extract_year
+              , subq_9.booking__paid_at__extract_quarter
+              , subq_9.booking__paid_at__extract_month
+              , subq_9.booking__paid_at__extract_day
+              , subq_9.booking__paid_at__extract_dow
+              , subq_9.booking__paid_at__extract_doy
+              , subq_9.ds__day AS metric_time__day
+              , subq_9.ds__week AS metric_time__week
+              , subq_9.ds__month AS metric_time__month
+              , subq_9.ds__quarter AS metric_time__quarter
+              , subq_9.ds__year AS metric_time__year
+              , subq_9.ds__extract_year AS metric_time__extract_year
+              , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_9.ds__extract_month AS metric_time__extract_month
+              , subq_9.ds__extract_day AS metric_time__extract_day
+              , subq_9.ds__extract_dow AS metric_time__extract_dow
+              , subq_9.ds__extract_doy AS metric_time__extract_doy
+              , subq_9.listing
+              , subq_9.guest
+              , subq_9.host
+              , subq_9.booking__listing
+              , subq_9.booking__guest
+              , subq_9.booking__host
+              , subq_9.is_instant
+              , subq_9.booking__is_instant
+              , subq_9.bookings
+              , subq_9.instant_bookings
+              , subq_9.booking_value
+              , subq_9.max_booking_value
+              , subq_9.min_booking_value
+              , subq_9.bookers
+              , subq_9.average_booking_value
+              , subq_9.referred_bookings
+              , subq_9.median_booking_value
+              , subq_9.booking_value_p99
+              , subq_9.discrete_booking_value_p99
+              , subq_9.approximate_continuous_booking_value_p99
+              , subq_9.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_9
+          ) subq_10
+        ) subq_11
+        GROUP BY
+          subq_11.metric_time__day
+      ) subq_12
+    ) subq_13
+  ) subq_14
+  ON
+    subq_8.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day)
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -3,7 +3,7 @@ SELECT
   subq_15.metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
     , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -1,0 +1,64 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_30.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['booking_value', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , SUM(booking_value) AS booking_value
+        FROM ***************************.fct_bookings bookings_source_src_10001
+        GROUP BY
+          DATE_TRUNC('day', ds)
+      ) subq_20
+    ) subq_21
+    ON
+      DATE_TRUNC('month', subq_23.ds) = subq_21.metric_time__day
+  ) subq_24
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['booking_value', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , SUM(booking_value) AS booking_value
+      FROM ***************************.fct_bookings bookings_source_src_10001
+      GROUP BY
+        DATE_TRUNC('day', ds)
+    ) subq_29
+  ) subq_30
+  ON
+    subq_24.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,7 +3,7 @@ SELECT
   metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0.sql
@@ -336,5 +336,5 @@ FROM (
     ) subq_7
   ) subq_8
   ON
-    subq_9.metric_time__day - INTERVAL 5 day = subq_8.metric_time__day
+    subq_9.metric_time__day - INTERVAL 2 day = subq_8.metric_time__day
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0.sql
@@ -1,0 +1,340 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_11.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_6.metric_time__day
+        , subq_6.bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_4.metric_time__day
+            , subq_4.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          subq_5.metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    subq_9.metric_time__day - INTERVAL 5 day = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_13
+      ON
+        subq_15.ds - INTERVAL 5 day = subq_13.metric_time__day
+      GROUP BY
+        subq_15.ds
+    ) subq_19
+  ) subq_20
+  ON
+    subq_22.ds - INTERVAL 5 day = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets__plan0_optimized.sql
@@ -38,5 +38,5 @@ FROM (
     ) subq_19
   ) subq_20
   ON
-    subq_22.ds - INTERVAL 5 day = subq_20.metric_time__day
+    subq_22.ds - INTERVAL 2 day = subq_20.metric_time__day
 ) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,0 +1,348 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      subq_9.metric_time__day - INTERVAL 5 day = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
@@ -342,7 +342,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      subq_9.metric_time__day - INTERVAL 5 day = subq_8.metric_time__day
+      subq_9.metric_time__day - INTERVAL 2 day = subq_8.metric_time__day
   ) subq_11
   WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,50 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_22.metric_time__day AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_23
+    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_14
+      ON
+        subq_16.ds - INTERVAL 5 day = subq_14.metric_time__day
+      GROUP BY
+        subq_16.ds
+    ) subq_20
+  ) subq_21
+  ON
+    subq_22.metric_time__day - INTERVAL 5 day = subq_21.metric_time__day
+  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -45,6 +45,6 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    subq_22.metric_time__day - INTERVAL 5 day = subq_21.metric_time__day
+    subq_22.metric_time__day - INTERVAL 2 day = subq_21.metric_time__day
   WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
@@ -341,7 +341,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      subq_9.metric_time__day - INTERVAL 5 day = subq_8.metric_time__day
+      subq_9.metric_time__day - INTERVAL 2 day = subq_8.metric_time__day
   ) subq_11
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0.sql
@@ -1,0 +1,347 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      subq_9.metric_time__day - INTERVAL 5 day = subq_8.metric_time__day
+  ) subq_11
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.bookings_offset_once AS bookings_offset_once
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_16.ds AS metric_time__day
+          , SUM(subq_14.bookings) AS bookings
+        FROM ***************************.mf_time_spine subq_16
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_10001
+        ) subq_14
+        ON
+          subq_16.ds - INTERVAL 5 day = subq_14.metric_time__day
+        GROUP BY
+          subq_16.ds
+      ) subq_20
+    ) subq_21
+    ON
+      subq_23.ds - INTERVAL 5 day = subq_21.metric_time__day
+  ) subq_24
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
       ) subq_20
     ) subq_21
     ON
-      subq_23.ds - INTERVAL 5 day = subq_21.metric_time__day
+      subq_23.ds - INTERVAL 2 day = subq_21.metric_time__day
   ) subq_24
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -1,0 +1,473 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_14.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_4.metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_3.metric_time__day
+          , subq_3.booking_value
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_2.metric_time__day
+            , SUM(subq_2.booking_value) AS booking_value
+          FROM (
+            -- Pass Only Elements:
+            --   ['booking_value', 'metric_time__day']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.booking_value
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          GROUP BY
+            subq_2.metric_time__day
+        ) subq_3
+      ) subq_4
+    ) subq_5
+    ON
+      DATE_TRUNC('month', subq_6.metric_time__day) = subq_5.metric_time__day
+  ) subq_8
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_12.metric_time__day
+        , subq_12.booking_value
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_11.metric_time__day
+          , SUM(subq_11.booking_value) AS booking_value
+        FROM (
+          -- Pass Only Elements:
+          --   ['booking_value', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.booking_value
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_9.ds__day
+              , subq_9.ds__week
+              , subq_9.ds__month
+              , subq_9.ds__quarter
+              , subq_9.ds__year
+              , subq_9.ds__extract_year
+              , subq_9.ds__extract_quarter
+              , subq_9.ds__extract_month
+              , subq_9.ds__extract_day
+              , subq_9.ds__extract_dow
+              , subq_9.ds__extract_doy
+              , subq_9.ds_partitioned__day
+              , subq_9.ds_partitioned__week
+              , subq_9.ds_partitioned__month
+              , subq_9.ds_partitioned__quarter
+              , subq_9.ds_partitioned__year
+              , subq_9.ds_partitioned__extract_year
+              , subq_9.ds_partitioned__extract_quarter
+              , subq_9.ds_partitioned__extract_month
+              , subq_9.ds_partitioned__extract_day
+              , subq_9.ds_partitioned__extract_dow
+              , subq_9.ds_partitioned__extract_doy
+              , subq_9.paid_at__day
+              , subq_9.paid_at__week
+              , subq_9.paid_at__month
+              , subq_9.paid_at__quarter
+              , subq_9.paid_at__year
+              , subq_9.paid_at__extract_year
+              , subq_9.paid_at__extract_quarter
+              , subq_9.paid_at__extract_month
+              , subq_9.paid_at__extract_day
+              , subq_9.paid_at__extract_dow
+              , subq_9.paid_at__extract_doy
+              , subq_9.booking__ds__day
+              , subq_9.booking__ds__week
+              , subq_9.booking__ds__month
+              , subq_9.booking__ds__quarter
+              , subq_9.booking__ds__year
+              , subq_9.booking__ds__extract_year
+              , subq_9.booking__ds__extract_quarter
+              , subq_9.booking__ds__extract_month
+              , subq_9.booking__ds__extract_day
+              , subq_9.booking__ds__extract_dow
+              , subq_9.booking__ds__extract_doy
+              , subq_9.booking__ds_partitioned__day
+              , subq_9.booking__ds_partitioned__week
+              , subq_9.booking__ds_partitioned__month
+              , subq_9.booking__ds_partitioned__quarter
+              , subq_9.booking__ds_partitioned__year
+              , subq_9.booking__ds_partitioned__extract_year
+              , subq_9.booking__ds_partitioned__extract_quarter
+              , subq_9.booking__ds_partitioned__extract_month
+              , subq_9.booking__ds_partitioned__extract_day
+              , subq_9.booking__ds_partitioned__extract_dow
+              , subq_9.booking__ds_partitioned__extract_doy
+              , subq_9.booking__paid_at__day
+              , subq_9.booking__paid_at__week
+              , subq_9.booking__paid_at__month
+              , subq_9.booking__paid_at__quarter
+              , subq_9.booking__paid_at__year
+              , subq_9.booking__paid_at__extract_year
+              , subq_9.booking__paid_at__extract_quarter
+              , subq_9.booking__paid_at__extract_month
+              , subq_9.booking__paid_at__extract_day
+              , subq_9.booking__paid_at__extract_dow
+              , subq_9.booking__paid_at__extract_doy
+              , subq_9.ds__day AS metric_time__day
+              , subq_9.ds__week AS metric_time__week
+              , subq_9.ds__month AS metric_time__month
+              , subq_9.ds__quarter AS metric_time__quarter
+              , subq_9.ds__year AS metric_time__year
+              , subq_9.ds__extract_year AS metric_time__extract_year
+              , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_9.ds__extract_month AS metric_time__extract_month
+              , subq_9.ds__extract_day AS metric_time__extract_day
+              , subq_9.ds__extract_dow AS metric_time__extract_dow
+              , subq_9.ds__extract_doy AS metric_time__extract_doy
+              , subq_9.listing
+              , subq_9.guest
+              , subq_9.host
+              , subq_9.booking__listing
+              , subq_9.booking__guest
+              , subq_9.booking__host
+              , subq_9.is_instant
+              , subq_9.booking__is_instant
+              , subq_9.bookings
+              , subq_9.instant_bookings
+              , subq_9.booking_value
+              , subq_9.max_booking_value
+              , subq_9.min_booking_value
+              , subq_9.bookers
+              , subq_9.average_booking_value
+              , subq_9.referred_bookings
+              , subq_9.median_booking_value
+              , subq_9.booking_value_p99
+              , subq_9.discrete_booking_value_p99
+              , subq_9.approximate_continuous_booking_value_p99
+              , subq_9.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_9
+          ) subq_10
+        ) subq_11
+        GROUP BY
+          subq_11.metric_time__day
+      ) subq_12
+    ) subq_13
+  ) subq_14
+  ON
+    subq_8.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day)
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -3,7 +3,7 @@ SELECT
   subq_15.metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
     , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -1,0 +1,64 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_30.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['booking_value', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , SUM(booking_value) AS booking_value
+        FROM ***************************.fct_bookings bookings_source_src_10001
+        GROUP BY
+          DATE_TRUNC('day', ds)
+      ) subq_20
+    ) subq_21
+    ON
+      DATE_TRUNC('month', subq_23.ds) = subq_21.metric_time__day
+  ) subq_24
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['booking_value', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , SUM(booking_value) AS booking_value
+      FROM ***************************.fct_bookings bookings_source_src_10001
+      GROUP BY
+        DATE_TRUNC('day', ds)
+    ) subq_29
+  ) subq_30
+  ON
+    subq_24.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,7 +3,7 @@ SELECT
   metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0.sql
@@ -336,5 +336,5 @@ FROM (
     ) subq_7
   ) subq_8
   ON
-    subq_9.metric_time__day - MAKE_INTERVAL(days => 5) = subq_8.metric_time__day
+    subq_9.metric_time__day - MAKE_INTERVAL(days => 2) = subq_8.metric_time__day
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0.sql
@@ -1,0 +1,340 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_11.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_6.metric_time__day
+        , subq_6.bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_4.metric_time__day
+            , subq_4.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              subq_2.metric_time__day - MAKE_INTERVAL(days => 5) = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          subq_5.metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    subq_9.metric_time__day - MAKE_INTERVAL(days => 5) = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0_optimized.sql
@@ -38,5 +38,5 @@ FROM (
     ) subq_19
   ) subq_20
   ON
-    subq_22.ds - MAKE_INTERVAL(days => 5) = subq_20.metric_time__day
+    subq_22.ds - MAKE_INTERVAL(days => 2) = subq_20.metric_time__day
 ) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_13
+      ON
+        subq_15.ds - MAKE_INTERVAL(days => 5) = subq_13.metric_time__day
+      GROUP BY
+        subq_15.ds
+    ) subq_19
+  ) subq_20
+  ON
+    subq_22.ds - MAKE_INTERVAL(days => 5) = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
@@ -342,7 +342,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      subq_9.metric_time__day - MAKE_INTERVAL(days => 5) = subq_8.metric_time__day
+      subq_9.metric_time__day - MAKE_INTERVAL(days => 2) = subq_8.metric_time__day
   ) subq_11
   WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,0 +1,348 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                subq_2.metric_time__day - MAKE_INTERVAL(days => 5) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      subq_9.metric_time__day - MAKE_INTERVAL(days => 5) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,50 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_22.metric_time__day AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_23
+    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_14
+      ON
+        subq_16.ds - MAKE_INTERVAL(days => 5) = subq_14.metric_time__day
+      GROUP BY
+        subq_16.ds
+    ) subq_20
+  ) subq_21
+  ON
+    subq_22.metric_time__day - MAKE_INTERVAL(days => 5) = subq_21.metric_time__day
+  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -45,6 +45,6 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    subq_22.metric_time__day - MAKE_INTERVAL(days => 5) = subq_21.metric_time__day
+    subq_22.metric_time__day - MAKE_INTERVAL(days => 2) = subq_21.metric_time__day
   WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
@@ -1,0 +1,347 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                subq_2.metric_time__day - MAKE_INTERVAL(days => 5) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      subq_9.metric_time__day - MAKE_INTERVAL(days => 5) = subq_8.metric_time__day
+  ) subq_11
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0.sql
@@ -341,7 +341,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      subq_9.metric_time__day - MAKE_INTERVAL(days => 5) = subq_8.metric_time__day
+      subq_9.metric_time__day - MAKE_INTERVAL(days => 2) = subq_8.metric_time__day
   ) subq_11
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.bookings_offset_once AS bookings_offset_once
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_16.ds AS metric_time__day
+          , SUM(subq_14.bookings) AS bookings
+        FROM ***************************.mf_time_spine subq_16
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_10001
+        ) subq_14
+        ON
+          subq_16.ds - MAKE_INTERVAL(days => 5) = subq_14.metric_time__day
+        GROUP BY
+          subq_16.ds
+      ) subq_20
+    ) subq_21
+    ON
+      subq_23.ds - MAKE_INTERVAL(days => 5) = subq_21.metric_time__day
+  ) subq_24
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
       ) subq_20
     ) subq_21
     ON
-      subq_23.ds - MAKE_INTERVAL(days => 5) = subq_21.metric_time__day
+      subq_23.ds - MAKE_INTERVAL(days => 2) = subq_21.metric_time__day
   ) subq_24
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -1,0 +1,473 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_14.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_4.metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_3.metric_time__day
+          , subq_3.booking_value
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_2.metric_time__day
+            , SUM(subq_2.booking_value) AS booking_value
+          FROM (
+            -- Pass Only Elements:
+            --   ['booking_value', 'metric_time__day']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.booking_value
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          GROUP BY
+            subq_2.metric_time__day
+        ) subq_3
+      ) subq_4
+    ) subq_5
+    ON
+      DATE_TRUNC('month', subq_6.metric_time__day) = subq_5.metric_time__day
+  ) subq_8
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_12.metric_time__day
+        , subq_12.booking_value
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_11.metric_time__day
+          , SUM(subq_11.booking_value) AS booking_value
+        FROM (
+          -- Pass Only Elements:
+          --   ['booking_value', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.booking_value
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_9.ds__day
+              , subq_9.ds__week
+              , subq_9.ds__month
+              , subq_9.ds__quarter
+              , subq_9.ds__year
+              , subq_9.ds__extract_year
+              , subq_9.ds__extract_quarter
+              , subq_9.ds__extract_month
+              , subq_9.ds__extract_day
+              , subq_9.ds__extract_dow
+              , subq_9.ds__extract_doy
+              , subq_9.ds_partitioned__day
+              , subq_9.ds_partitioned__week
+              , subq_9.ds_partitioned__month
+              , subq_9.ds_partitioned__quarter
+              , subq_9.ds_partitioned__year
+              , subq_9.ds_partitioned__extract_year
+              , subq_9.ds_partitioned__extract_quarter
+              , subq_9.ds_partitioned__extract_month
+              , subq_9.ds_partitioned__extract_day
+              , subq_9.ds_partitioned__extract_dow
+              , subq_9.ds_partitioned__extract_doy
+              , subq_9.paid_at__day
+              , subq_9.paid_at__week
+              , subq_9.paid_at__month
+              , subq_9.paid_at__quarter
+              , subq_9.paid_at__year
+              , subq_9.paid_at__extract_year
+              , subq_9.paid_at__extract_quarter
+              , subq_9.paid_at__extract_month
+              , subq_9.paid_at__extract_day
+              , subq_9.paid_at__extract_dow
+              , subq_9.paid_at__extract_doy
+              , subq_9.booking__ds__day
+              , subq_9.booking__ds__week
+              , subq_9.booking__ds__month
+              , subq_9.booking__ds__quarter
+              , subq_9.booking__ds__year
+              , subq_9.booking__ds__extract_year
+              , subq_9.booking__ds__extract_quarter
+              , subq_9.booking__ds__extract_month
+              , subq_9.booking__ds__extract_day
+              , subq_9.booking__ds__extract_dow
+              , subq_9.booking__ds__extract_doy
+              , subq_9.booking__ds_partitioned__day
+              , subq_9.booking__ds_partitioned__week
+              , subq_9.booking__ds_partitioned__month
+              , subq_9.booking__ds_partitioned__quarter
+              , subq_9.booking__ds_partitioned__year
+              , subq_9.booking__ds_partitioned__extract_year
+              , subq_9.booking__ds_partitioned__extract_quarter
+              , subq_9.booking__ds_partitioned__extract_month
+              , subq_9.booking__ds_partitioned__extract_day
+              , subq_9.booking__ds_partitioned__extract_dow
+              , subq_9.booking__ds_partitioned__extract_doy
+              , subq_9.booking__paid_at__day
+              , subq_9.booking__paid_at__week
+              , subq_9.booking__paid_at__month
+              , subq_9.booking__paid_at__quarter
+              , subq_9.booking__paid_at__year
+              , subq_9.booking__paid_at__extract_year
+              , subq_9.booking__paid_at__extract_quarter
+              , subq_9.booking__paid_at__extract_month
+              , subq_9.booking__paid_at__extract_day
+              , subq_9.booking__paid_at__extract_dow
+              , subq_9.booking__paid_at__extract_doy
+              , subq_9.ds__day AS metric_time__day
+              , subq_9.ds__week AS metric_time__week
+              , subq_9.ds__month AS metric_time__month
+              , subq_9.ds__quarter AS metric_time__quarter
+              , subq_9.ds__year AS metric_time__year
+              , subq_9.ds__extract_year AS metric_time__extract_year
+              , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_9.ds__extract_month AS metric_time__extract_month
+              , subq_9.ds__extract_day AS metric_time__extract_day
+              , subq_9.ds__extract_dow AS metric_time__extract_dow
+              , subq_9.ds__extract_doy AS metric_time__extract_doy
+              , subq_9.listing
+              , subq_9.guest
+              , subq_9.host
+              , subq_9.booking__listing
+              , subq_9.booking__guest
+              , subq_9.booking__host
+              , subq_9.is_instant
+              , subq_9.booking__is_instant
+              , subq_9.bookings
+              , subq_9.instant_bookings
+              , subq_9.booking_value
+              , subq_9.max_booking_value
+              , subq_9.min_booking_value
+              , subq_9.bookers
+              , subq_9.average_booking_value
+              , subq_9.referred_bookings
+              , subq_9.median_booking_value
+              , subq_9.booking_value_p99
+              , subq_9.discrete_booking_value_p99
+              , subq_9.approximate_continuous_booking_value_p99
+              , subq_9.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_9
+          ) subq_10
+        ) subq_11
+        GROUP BY
+          subq_11.metric_time__day
+      ) subq_12
+    ) subq_13
+  ) subq_14
+  ON
+    subq_8.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day)
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -3,7 +3,7 @@ SELECT
   subq_15.metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
     , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -1,0 +1,64 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_30.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['booking_value', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , SUM(booking_value) AS booking_value
+        FROM ***************************.fct_bookings bookings_source_src_10001
+        GROUP BY
+          DATE_TRUNC('day', ds)
+      ) subq_20
+    ) subq_21
+    ON
+      DATE_TRUNC('month', subq_23.ds) = subq_21.metric_time__day
+  ) subq_24
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['booking_value', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , SUM(booking_value) AS booking_value
+      FROM ***************************.fct_bookings bookings_source_src_10001
+      GROUP BY
+        DATE_TRUNC('day', ds)
+    ) subq_29
+  ) subq_30
+  ON
+    subq_24.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,7 +3,7 @@ SELECT
   metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0.sql
@@ -1,0 +1,340 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_11.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_6.metric_time__day
+        , subq_6.bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_4.metric_time__day
+            , subq_4.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          subq_5.metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0.sql
@@ -336,5 +336,5 @@ FROM (
     ) subq_7
   ) subq_8
   ON
-    DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_13
+      ON
+        DATEADD(day, -5, subq_15.ds) = subq_13.metric_time__day
+      GROUP BY
+        subq_15.ds
+    ) subq_19
+  ) subq_20
+  ON
+    DATEADD(day, -5, subq_22.ds) = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets__plan0_optimized.sql
@@ -38,5 +38,5 @@ FROM (
     ) subq_19
   ) subq_20
   ON
-    DATEADD(day, -5, subq_22.ds) = subq_20.metric_time__day
+    DATEADD(day, -2, subq_22.ds) = subq_20.metric_time__day
 ) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
@@ -342,7 +342,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
   ) subq_11
   WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,0 +1,348 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -45,6 +45,6 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    DATEADD(day, -5, subq_22.metric_time__day) = subq_21.metric_time__day
+    DATEADD(day, -2, subq_22.metric_time__day) = subq_21.metric_time__day
   WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,50 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_22.metric_time__day AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_23
+    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_14
+      ON
+        DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
+      GROUP BY
+        subq_16.ds
+    ) subq_20
+  ) subq_21
+  ON
+    DATEADD(day, -5, subq_22.metric_time__day) = subq_21.metric_time__day
+  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
@@ -1,0 +1,347 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0.sql
@@ -341,7 +341,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
   ) subq_11
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
       ) subq_20
     ) subq_21
     ON
-      DATEADD(day, -5, subq_23.ds) = subq_21.metric_time__day
+      DATEADD(day, -2, subq_23.ds) = subq_21.metric_time__day
   ) subq_24
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.bookings_offset_once AS bookings_offset_once
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_16.ds AS metric_time__day
+          , SUM(subq_14.bookings) AS bookings
+        FROM ***************************.mf_time_spine subq_16
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_10001
+        ) subq_14
+        ON
+          DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
+        GROUP BY
+          subq_16.ds
+      ) subq_20
+    ) subq_21
+    ON
+      DATEADD(day, -5, subq_23.ds) = subq_21.metric_time__day
+  ) subq_24
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -3,7 +3,7 @@ SELECT
   subq_15.metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
     , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0.sql
@@ -1,0 +1,473 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_15.metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day) AS metric_time__day
+    , MAX(subq_8.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_14.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_6.metric_time__day AS metric_time__day
+      , subq_5.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_7.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_7
+    ) subq_6
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_4.metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_3.metric_time__day
+          , subq_3.booking_value
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_2.metric_time__day
+            , SUM(subq_2.booking_value) AS booking_value
+          FROM (
+            -- Pass Only Elements:
+            --   ['booking_value', 'metric_time__day']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.booking_value
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          GROUP BY
+            subq_2.metric_time__day
+        ) subq_3
+      ) subq_4
+    ) subq_5
+    ON
+      DATE_TRUNC('month', subq_6.metric_time__day) = subq_5.metric_time__day
+  ) subq_8
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_12.metric_time__day
+        , subq_12.booking_value
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_11.metric_time__day
+          , SUM(subq_11.booking_value) AS booking_value
+        FROM (
+          -- Pass Only Elements:
+          --   ['booking_value', 'metric_time__day']
+          SELECT
+            subq_10.metric_time__day
+            , subq_10.booking_value
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_9.ds__day
+              , subq_9.ds__week
+              , subq_9.ds__month
+              , subq_9.ds__quarter
+              , subq_9.ds__year
+              , subq_9.ds__extract_year
+              , subq_9.ds__extract_quarter
+              , subq_9.ds__extract_month
+              , subq_9.ds__extract_day
+              , subq_9.ds__extract_dow
+              , subq_9.ds__extract_doy
+              , subq_9.ds_partitioned__day
+              , subq_9.ds_partitioned__week
+              , subq_9.ds_partitioned__month
+              , subq_9.ds_partitioned__quarter
+              , subq_9.ds_partitioned__year
+              , subq_9.ds_partitioned__extract_year
+              , subq_9.ds_partitioned__extract_quarter
+              , subq_9.ds_partitioned__extract_month
+              , subq_9.ds_partitioned__extract_day
+              , subq_9.ds_partitioned__extract_dow
+              , subq_9.ds_partitioned__extract_doy
+              , subq_9.paid_at__day
+              , subq_9.paid_at__week
+              , subq_9.paid_at__month
+              , subq_9.paid_at__quarter
+              , subq_9.paid_at__year
+              , subq_9.paid_at__extract_year
+              , subq_9.paid_at__extract_quarter
+              , subq_9.paid_at__extract_month
+              , subq_9.paid_at__extract_day
+              , subq_9.paid_at__extract_dow
+              , subq_9.paid_at__extract_doy
+              , subq_9.booking__ds__day
+              , subq_9.booking__ds__week
+              , subq_9.booking__ds__month
+              , subq_9.booking__ds__quarter
+              , subq_9.booking__ds__year
+              , subq_9.booking__ds__extract_year
+              , subq_9.booking__ds__extract_quarter
+              , subq_9.booking__ds__extract_month
+              , subq_9.booking__ds__extract_day
+              , subq_9.booking__ds__extract_dow
+              , subq_9.booking__ds__extract_doy
+              , subq_9.booking__ds_partitioned__day
+              , subq_9.booking__ds_partitioned__week
+              , subq_9.booking__ds_partitioned__month
+              , subq_9.booking__ds_partitioned__quarter
+              , subq_9.booking__ds_partitioned__year
+              , subq_9.booking__ds_partitioned__extract_year
+              , subq_9.booking__ds_partitioned__extract_quarter
+              , subq_9.booking__ds_partitioned__extract_month
+              , subq_9.booking__ds_partitioned__extract_day
+              , subq_9.booking__ds_partitioned__extract_dow
+              , subq_9.booking__ds_partitioned__extract_doy
+              , subq_9.booking__paid_at__day
+              , subq_9.booking__paid_at__week
+              , subq_9.booking__paid_at__month
+              , subq_9.booking__paid_at__quarter
+              , subq_9.booking__paid_at__year
+              , subq_9.booking__paid_at__extract_year
+              , subq_9.booking__paid_at__extract_quarter
+              , subq_9.booking__paid_at__extract_month
+              , subq_9.booking__paid_at__extract_day
+              , subq_9.booking__paid_at__extract_dow
+              , subq_9.booking__paid_at__extract_doy
+              , subq_9.ds__day AS metric_time__day
+              , subq_9.ds__week AS metric_time__week
+              , subq_9.ds__month AS metric_time__month
+              , subq_9.ds__quarter AS metric_time__quarter
+              , subq_9.ds__year AS metric_time__year
+              , subq_9.ds__extract_year AS metric_time__extract_year
+              , subq_9.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_9.ds__extract_month AS metric_time__extract_month
+              , subq_9.ds__extract_day AS metric_time__extract_day
+              , subq_9.ds__extract_dow AS metric_time__extract_dow
+              , subq_9.ds__extract_doy AS metric_time__extract_doy
+              , subq_9.listing
+              , subq_9.guest
+              , subq_9.host
+              , subq_9.booking__listing
+              , subq_9.booking__guest
+              , subq_9.booking__host
+              , subq_9.is_instant
+              , subq_9.booking__is_instant
+              , subq_9.bookings
+              , subq_9.instant_bookings
+              , subq_9.booking_value
+              , subq_9.max_booking_value
+              , subq_9.min_booking_value
+              , subq_9.bookers
+              , subq_9.average_booking_value
+              , subq_9.referred_bookings
+              , subq_9.median_booking_value
+              , subq_9.booking_value_p99
+              , subq_9.discrete_booking_value_p99
+              , subq_9.approximate_continuous_booking_value_p99
+              , subq_9.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_9
+          ) subq_10
+        ) subq_11
+        GROUP BY
+          subq_11.metric_time__day
+      ) subq_12
+    ) subq_13
+  ) subq_14
+  ON
+    subq_8.metric_time__day = subq_14.metric_time__day
+  GROUP BY
+    COALESCE(subq_8.metric_time__day, subq_14.metric_time__day)
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -1,0 +1,64 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
+FROM (
+  -- Combine Metrics
+  SELECT
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month
+    , MAX(subq_30.booking_fees) AS booking_fees
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.booking_fees_start_of_month AS booking_fees_start_of_month
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , booking_value * 0.05 AS booking_fees_start_of_month
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements:
+        --   ['booking_value', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , SUM(booking_value) AS booking_value
+        FROM ***************************.fct_bookings bookings_source_src_10001
+        GROUP BY
+          DATE_TRUNC('day', ds)
+      ) subq_20
+    ) subq_21
+    ON
+      DATE_TRUNC('month', subq_23.ds) = subq_21.metric_time__day
+  ) subq_24
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , booking_value * 0.05 AS booking_fees
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements:
+      --   ['booking_value', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , SUM(booking_value) AS booking_value
+      FROM ***************************.fct_bookings bookings_source_src_10001
+      GROUP BY
+        DATE_TRUNC('day', ds)
+    ) subq_29
+  ) subq_30
+  ON
+    subq_24.metric_time__day = subq_30.metric_time__day
+  GROUP BY
+    COALESCE(subq_24.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric_with_offset_multiple_input_metrics__plan0_optimized.sql
@@ -3,7 +3,7 @@ SELECT
   metric_time__day
   , booking_fees - booking_fees_start_of_month AS booking_fees_since_start_of_month
 FROM (
-  -- Combine Metrics
+  -- Combine Aggregated Outputs
   SELECT
     COALESCE(subq_24.metric_time__day, subq_30.metric_time__day) AS metric_time__day
     , MAX(subq_24.booking_fees_start_of_month) AS booking_fees_start_of_month

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0.sql
@@ -1,0 +1,340 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_11.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_6.metric_time__day
+        , subq_6.bookings
+      FROM (
+        -- Aggregate Measures
+        SELECT
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
+          SELECT
+            subq_4.metric_time__day
+            , subq_4.bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+            FROM (
+              -- Date Spine
+              SELECT
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          subq_5.metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0.sql
@@ -336,5 +336,5 @@ FROM (
     ) subq_7
   ) subq_8
   ON
-    DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
+  FROM ***************************.mf_time_spine subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_13
+      ON
+        DATEADD(day, -5, subq_15.ds) = subq_13.metric_time__day
+      GROUP BY
+        subq_15.ds
+    ) subq_19
+  ) subq_20
+  ON
+    DATEADD(day, -5, subq_22.ds) = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets__plan0_optimized.sql
@@ -38,5 +38,5 @@ FROM (
     ) subq_19
   ) subq_20
   ON
-    DATEADD(day, -5, subq_22.ds) = subq_20.metric_time__day
+    DATEADD(day, -2, subq_22.ds) = subq_20.metric_time__day
 ) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
@@ -342,7 +342,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
   ) subq_11
   WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,0 +1,348 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -45,6 +45,6 @@ FROM (
     ) subq_20
   ) subq_21
   ON
-    DATEADD(day, -5, subq_22.metric_time__day) = subq_21.metric_time__day
+    DATEADD(day, -2, subq_22.metric_time__day) = subq_21.metric_time__day
   WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,50 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  SELECT
+    subq_22.metric_time__day AS metric_time__day
+    , subq_21.bookings_offset_once AS bookings_offset_once
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_23
+    WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_22
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , 2 * bookings AS bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_16.ds AS metric_time__day
+        , SUM(subq_14.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_16
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_10001
+      ) subq_14
+      ON
+        DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
+      GROUP BY
+        subq_16.ds
+    ) subq_20
+  ) subq_21
+  ON
+    DATEADD(day, -5, subq_22.metric_time__day) = subq_21.metric_time__day
+  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
+) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
@@ -1,0 +1,347 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_9.metric_time__day AS metric_time__day
+      , subq_8.bookings_offset_once AS bookings_offset_once
+    FROM (
+      -- Date Spine
+      SELECT
+        subq_10.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_10
+    ) subq_9
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        subq_7.metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.bookings
+        FROM (
+          -- Aggregate Measures
+          SELECT
+            subq_5.metric_time__day
+            , SUM(subq_5.bookings) AS bookings
+          FROM (
+            -- Pass Only Elements:
+            --   ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Join to Time Spine Dataset
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Date Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_10001.booking_value
+                    , bookings_source_src_10001.booking_value AS max_booking_value
+                    , bookings_source_src_10001.booking_value AS min_booking_value
+                    , bookings_source_src_10001.guest_id AS bookers
+                    , bookings_source_src_10001.booking_value AS average_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_10001.booking_value AS median_booking_value
+                    , bookings_source_src_10001.booking_value AS booking_value_p99
+                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_10001.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_10001.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_10001.listing_id AS listing
+                    , bookings_source_src_10001.guest_id AS guest
+                    , bookings_source_src_10001.host_id AS host
+                    , bookings_source_src_10001.listing_id AS booking__listing
+                    , bookings_source_src_10001.guest_id AS booking__guest
+                    , bookings_source_src_10001.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_10001
+                ) subq_0
+              ) subq_1
+              ON
+                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+            ) subq_4
+          ) subq_5
+          GROUP BY
+            subq_5.metric_time__day
+        ) subq_6
+      ) subq_7
+    ) subq_8
+    ON
+      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+  ) subq_11
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0.sql
@@ -341,7 +341,7 @@ FROM (
       ) subq_7
     ) subq_8
     ON
-      DATEADD(day, -5, subq_9.metric_time__day) = subq_8.metric_time__day
+      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
   ) subq_11
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_12

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
       ) subq_20
     ) subq_21
     ON
-      DATEADD(day, -5, subq_23.ds) = subq_21.metric_time__day
+      DATEADD(day, -2, subq_23.ds) = subq_21.metric_time__day
   ) subq_24
   WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
 ) subq_25

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_where_constraint__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_23.ds AS metric_time__day
+      , subq_21.bookings_offset_once AS bookings_offset_once
+    FROM ***************************.mf_time_spine subq_23
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements:
+        --   ['bookings', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_16.ds AS metric_time__day
+          , SUM(subq_14.bookings) AS bookings
+        FROM ***************************.mf_time_spine subq_16
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_10001
+        ) subq_14
+        ON
+          DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
+        GROUP BY
+          subq_16.ds
+      ) subq_20
+    ) subq_21
+    ON
+      DATEADD(day, -5, subq_23.ds) = subq_21.metric_time__day
+  ) subq_24
+  WHERE metric_time__day = '2020-01-12' or metric_time__day = '2020-01-13'
+) subq_25


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves #882


### Description
Apply time offset for nested ratio or derived input metrics. Previously, we were only applying offset during measure aggregation. For these metrics, the offset needs to be applied post-metric aggregation.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
