### PR TITLE
Bug fix: Keep filter column until used for nested derived offset metrics

### DIFF
--- a/metricflow/specs/specs.py
+++ b/metricflow/specs/specs.py
@@ -552,6 +552,10 @@ class MetricSpec(InstanceSpec):  # noqa: D
         """Return the reference object that is used for referencing the associated metric in the manifest."""
         return MetricReference(element_name=self.element_name)
 
+    def without_offset(self) -> MetricSpec:
+        """Represents the metric spec with any time offsets removed."""
+        return MetricSpec(element_name=self.element_name, constraint=self.constraint, alias=self.alias)
+
 
 @dataclass(frozen=True)
 class CumulativeMeasureDescription:

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -1632,3 +1632,53 @@ integration_test:
     ON
       {{ render_date_sub("subq_9", "ds", 2, TimeGranularity.DAY) }} = subq_8.metric_time__day
     WHERE {{ render_time_constraint('subq_9.ds', '2020-01-08', '2020-01-09') }}
+---
+integration_test:
+  name: nested_derived_metric_offset_with_joined_where_constraint_not_selected
+  description: Tests a nested derived metric where the outer metric has an offset and where constraint that requires an additional join, and is not used in the select statement.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_offset_twice"]
+  group_by_objs: [{"name": "metric_time", "grain": "day"}]
+  where_filter: "{{ render_dimension_template('booking__is_instant') }}"
+  check_query: |
+    SELECT
+      metric_time__day
+      , 2 * bookings_offset_once AS bookings_offset_twice
+    FROM (
+      SELECT
+        metric_time__day
+        , bookings_offset_once
+      FROM (
+        SELECT
+          subq_10.ds AS metric_time__day
+          , subq_8.booking__is_instant AS booking__is_instant
+          , subq_8.bookings_offset_once AS bookings_offset_once
+        FROM {{ source_schema }}.mf_time_spine subq_10
+        INNER JOIN (
+          SELECT
+            metric_time__day
+            , booking__is_instant
+            , 2 * bookings AS bookings_offset_once
+          FROM (
+            SELECT
+              subq_3.ds AS metric_time__day
+              , subq_1.booking__is_instant AS booking__is_instant
+              , SUM(subq_1.bookings) AS bookings
+            FROM {{ source_schema }}.mf_time_spine subq_3
+            INNER JOIN (
+              SELECT
+                {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS metric_time__day
+                , is_instant AS booking__is_instant
+                , 1 AS bookings
+              FROM {{ source_schema }}.fct_bookings
+            ) subq_1
+            ON subq_3.ds - INTERVAL 5 day = subq_1.metric_time__day
+            GROUP BY
+              subq_3.ds
+              , subq_1.booking__is_instant
+          ) subq_7
+        ) subq_8
+        ON subq_10.ds - INTERVAL 2 day = subq_8.metric_time__day
+      ) subq_11
+      WHERE booking__is_instant
+    )

--- a/metricflow/test/query_rendering/test_derived_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_derived_metric_rendering.py
@@ -440,3 +440,34 @@ def test_nested_offsets_with_time_constraint(  # noqa: D
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
     )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+    column_association_resolver: ColumnAssociationResolver,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        query_spec=MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_offset_twice"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+            where_constraint=WhereSpecFactory(
+                column_association_resolver=column_association_resolver,
+            ).create_from_where_filter(
+                PydanticWhereFilter(where_sql_template=("{{ Dimension('booking__is_instant') }} "))
+            ),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0.sql
@@ -1,0 +1,361 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Pass Only Elements:
+  --   ['metric_time__day', 'bookings_offset_once']
+  SELECT
+    subq_12.metric_time__day
+    , subq_12.bookings_offset_once
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_11.metric_time__day
+      , subq_11.booking__is_instant
+      , subq_11.bookings_offset_once
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_9.metric_time__day AS metric_time__day
+        , subq_8.booking__is_instant AS booking__is_instant
+        , subq_8.bookings_offset_once AS bookings_offset_once
+      FROM (
+        -- Date Spine
+        SELECT
+          subq_10.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_10
+      ) subq_9
+      INNER JOIN (
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_7.metric_time__day
+          , subq_7.booking__is_instant
+          , 2 * bookings AS bookings_offset_once
+        FROM (
+          -- Compute Metrics via Expressions
+          SELECT
+            subq_6.metric_time__day
+            , subq_6.booking__is_instant
+            , subq_6.bookings
+          FROM (
+            -- Aggregate Measures
+            SELECT
+              subq_5.metric_time__day
+              , subq_5.booking__is_instant
+              , SUM(subq_5.bookings) AS bookings
+            FROM (
+              -- Pass Only Elements:
+              --   ['bookings', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_4.metric_time__day
+                , subq_4.booking__is_instant
+                , subq_4.bookings
+              FROM (
+                -- Join to Time Spine Dataset
+                SELECT
+                  subq_2.metric_time__day AS metric_time__day
+                  , subq_1.ds__day AS ds__day
+                  , subq_1.ds__week AS ds__week
+                  , subq_1.ds__month AS ds__month
+                  , subq_1.ds__quarter AS ds__quarter
+                  , subq_1.ds__year AS ds__year
+                  , subq_1.ds__extract_year AS ds__extract_year
+                  , subq_1.ds__extract_quarter AS ds__extract_quarter
+                  , subq_1.ds__extract_month AS ds__extract_month
+                  , subq_1.ds__extract_day AS ds__extract_day
+                  , subq_1.ds__extract_dow AS ds__extract_dow
+                  , subq_1.ds__extract_doy AS ds__extract_doy
+                  , subq_1.ds_partitioned__day AS ds_partitioned__day
+                  , subq_1.ds_partitioned__week AS ds_partitioned__week
+                  , subq_1.ds_partitioned__month AS ds_partitioned__month
+                  , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                  , subq_1.ds_partitioned__year AS ds_partitioned__year
+                  , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                  , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                  , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                  , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                  , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                  , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                  , subq_1.paid_at__day AS paid_at__day
+                  , subq_1.paid_at__week AS paid_at__week
+                  , subq_1.paid_at__month AS paid_at__month
+                  , subq_1.paid_at__quarter AS paid_at__quarter
+                  , subq_1.paid_at__year AS paid_at__year
+                  , subq_1.paid_at__extract_year AS paid_at__extract_year
+                  , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                  , subq_1.paid_at__extract_month AS paid_at__extract_month
+                  , subq_1.paid_at__extract_day AS paid_at__extract_day
+                  , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                  , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                  , subq_1.booking__ds__day AS booking__ds__day
+                  , subq_1.booking__ds__week AS booking__ds__week
+                  , subq_1.booking__ds__month AS booking__ds__month
+                  , subq_1.booking__ds__quarter AS booking__ds__quarter
+                  , subq_1.booking__ds__year AS booking__ds__year
+                  , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                  , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                  , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                  , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                  , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                  , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                  , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                  , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                  , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                  , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                  , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                  , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                  , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                  , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                  , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                  , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                  , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                  , subq_1.booking__paid_at__day AS booking__paid_at__day
+                  , subq_1.booking__paid_at__week AS booking__paid_at__week
+                  , subq_1.booking__paid_at__month AS booking__paid_at__month
+                  , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                  , subq_1.booking__paid_at__year AS booking__paid_at__year
+                  , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                  , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                  , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                  , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                  , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                  , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                  , subq_1.listing AS listing
+                  , subq_1.guest AS guest
+                  , subq_1.host AS host
+                  , subq_1.booking__listing AS booking__listing
+                  , subq_1.booking__guest AS booking__guest
+                  , subq_1.booking__host AS booking__host
+                  , subq_1.is_instant AS is_instant
+                  , subq_1.booking__is_instant AS booking__is_instant
+                  , subq_1.bookings AS bookings
+                  , subq_1.instant_bookings AS instant_bookings
+                  , subq_1.booking_value AS booking_value
+                  , subq_1.max_booking_value AS max_booking_value
+                  , subq_1.min_booking_value AS min_booking_value
+                  , subq_1.bookers AS bookers
+                  , subq_1.average_booking_value AS average_booking_value
+                  , subq_1.referred_bookings AS referred_bookings
+                  , subq_1.median_booking_value AS median_booking_value
+                  , subq_1.booking_value_p99 AS booking_value_p99
+                  , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                  , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                  , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                FROM (
+                  -- Date Spine
+                  SELECT
+                    subq_3.ds AS metric_time__day
+                  FROM ***************************.mf_time_spine subq_3
+                ) subq_2
+                INNER JOIN (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
+                    , subq_0.referred_bookings
+                    , subq_0.median_booking_value
+                    , subq_0.booking_value_p99
+                    , subq_0.discrete_booking_value_p99
+                    , subq_0.approximate_continuous_booking_value_p99
+                    , subq_0.approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Read Elements From Semantic Model 'bookings_source'
+                    SELECT
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_10001.booking_value
+                      , bookings_source_src_10001.booking_value AS max_booking_value
+                      , bookings_source_src_10001.booking_value AS min_booking_value
+                      , bookings_source_src_10001.guest_id AS bookers
+                      , bookings_source_src_10001.booking_value AS average_booking_value
+                      , bookings_source_src_10001.booking_value AS booking_payments
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                      , bookings_source_src_10001.booking_value AS median_booking_value
+                      , bookings_source_src_10001.booking_value AS booking_value_p99
+                      , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                      , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                      , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                      , bookings_source_src_10001.is_instant
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_10001.is_instant AS booking__is_instant
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_10001.listing_id AS listing
+                      , bookings_source_src_10001.guest_id AS guest
+                      , bookings_source_src_10001.host_id AS host
+                      , bookings_source_src_10001.listing_id AS booking__listing
+                      , bookings_source_src_10001.guest_id AS booking__guest
+                      , bookings_source_src_10001.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_10001
+                  ) subq_0
+                ) subq_1
+                ON
+                  subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
+              ) subq_4
+            ) subq_5
+            GROUP BY
+              subq_5.metric_time__day
+              , subq_5.booking__is_instant
+          ) subq_6
+        ) subq_7
+      ) subq_8
+      ON
+        subq_9.metric_time__day - INTERVAL 2 day = subq_8.metric_time__day
+    ) subq_11
+    WHERE booking__is_instant
+  ) subq_12
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric_offset_with_joined_where_constraint_not_selected__plan0_optimized.sql
@@ -1,0 +1,56 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , 2 * bookings_offset_once AS bookings_offset_twice
+FROM (
+  -- Constrain Output with WHERE
+  -- Pass Only Elements:
+  --   ['metric_time__day', 'bookings_offset_once']
+  SELECT
+    metric_time__day
+    , bookings_offset_once
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_24.ds AS metric_time__day
+      , subq_22.booking__is_instant AS booking__is_instant
+      , subq_22.bookings_offset_once AS bookings_offset_once
+    FROM ***************************.mf_time_spine subq_24
+    INNER JOIN (
+      -- Compute Metrics via Expressions
+      SELECT
+        metric_time__day
+        , booking__is_instant
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements:
+        --   ['bookings', 'booking__is_instant', 'metric_time__day']
+        -- Aggregate Measures
+        -- Compute Metrics via Expressions
+        SELECT
+          subq_17.ds AS metric_time__day
+          , subq_15.booking__is_instant AS booking__is_instant
+          , SUM(subq_15.bookings) AS bookings
+        FROM ***************************.mf_time_spine subq_17
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_10001
+        ) subq_15
+        ON
+          subq_17.ds - INTERVAL 5 day = subq_15.metric_time__day
+        GROUP BY
+          subq_17.ds
+          , subq_15.booking__is_instant
+      ) subq_21
+    ) subq_22
+    ON
+      subq_24.ds - INTERVAL 2 day = subq_22.metric_time__day
+  ) subq_25
+  WHERE booking__is_instant
+) subq_27


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves #930
Resolves SL-1375


### Description
Nested derived offset metrics had the [same bug as dimension-only queries](https://github.com/dbt-labs/metricflow/issues/923). The linkable instance used in the where constraint was being filtered out before the where constraint was actually applied, resulting in a SQL error. Not encountered frequently since it's a pretty niche query: a nested derived offset metric queried with a where filter that requires an additional join and is not used in the select statement. This fixes that.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
