### PR TITLE
Bug fix: incorrect time constraint for time offset metrics

### DIFF
--- a/.changes/unreleased/Fixes-20231207-145013.yaml
+++ b/.changes/unreleased/Fixes-20231207-145013.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixes incorrect time constraint applied to derived offset metrics.
+time: 2023-12-07T14:50:13.630957-08:00
+custom:
+  Author: courtneyholcomb
+  Issue: "925"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -230,7 +230,6 @@ class DataflowPlanBuilder:
         )
 
         parent_nodes: List[BaseOutput] = []
-        metric_has_time_offset = bool(metric_spec.offset_window or metric_spec.offset_to_grain)
         for metric_input_spec in metric_input_specs:
             parent_nodes.append(
                 self._build_any_metric_output_node(
@@ -242,9 +241,10 @@ class DataflowPlanBuilder:
                         offset_to_grain=metric_input_spec.offset_to_grain,
                     ),
                     queried_linkable_specs=queried_linkable_specs,
-                    # If metric is offset, we'll apply constraint after offset to avoid removing values unexpectedly.
-                    where_constraint=where_constraint if not metric_has_time_offset else None,
-                    time_range_constraint=time_range_constraint if not metric_has_time_offset else None,
+                    # If metric is offset, we'll apply where constraint after offset to avoid removing values unexpectedly.
+                    # Time constraint will be applied by INNER JOINing to time spine.
+                    where_constraint=where_constraint if not metric_spec.has_time_offset else None,
+                    time_range_constraint=time_range_constraint if not metric_spec.has_time_offset else None,
                 )
             )
 
@@ -254,7 +254,7 @@ class DataflowPlanBuilder:
         output_node: BaseOutput = ComputeMetricsNode(parent_node=parent_node, metric_specs=[metric_spec])
 
         # For nested ratio / derived metrics with time offset, apply offset & where constraint after metric computation.
-        if metric_has_time_offset:
+        if metric_spec.has_time_offset:
             assert (
                 queried_linkable_specs.contains_metric_time
             ), "Joining to time spine requires querying with metric_time."
@@ -266,10 +266,6 @@ class DataflowPlanBuilder:
                 offset_to_grain=metric_spec.offset_to_grain,
                 join_type=SqlJoinType.INNER,
             )
-            if time_range_constraint:
-                output_node = ConstrainTimeRangeNode(
-                    parent_node=output_node, time_range_constraint=time_range_constraint
-                )
             if where_constraint:
                 output_node = WhereConstraintNode(parent_node=output_node, where_constraint=where_constraint)
         return output_node
@@ -855,9 +851,14 @@ class DataflowPlanBuilder:
         )
 
         find_recipe_start_time = time.time()
+        before_aggregation_time_spine_join_description = (
+            metric_input_measure_spec.before_aggregation_time_spine_join_description
+        )
         measure_recipe = self._find_dataflow_recipe(
             measure_spec_properties=measure_properties,
-            time_range_constraint=cumulative_metric_adjusted_time_constraint or time_range_constraint,
+            time_range_constraint=(cumulative_metric_adjusted_time_constraint or time_range_constraint)
+            if not before_aggregation_time_spine_join_description
+            else None,
             linkable_spec_set=required_linkable_specs,
         )
         logger.info(
@@ -881,15 +882,13 @@ class DataflowPlanBuilder:
                 parent_node=measure_recipe.source_node,
                 window=cumulative_window,
                 grain_to_date=cumulative_grain_to_date,
-                time_range_constraint=time_range_constraint,
+                time_range_constraint=time_range_constraint
+                if not before_aggregation_time_spine_join_description
+                else None,
             )
 
-        # If querying an offset metric, join to time spine.
+        # If querying an offset metric, join to time spine before aggregation.
         join_to_time_spine_node: Optional[JoinToTimeSpineNode] = None
-
-        before_aggregation_time_spine_join_description = (
-            metric_input_measure_spec.before_aggregation_time_spine_join_description
-        )
         if before_aggregation_time_spine_join_description is not None:
             assert (
                 queried_linkable_specs.contains_metric_time
@@ -989,6 +988,8 @@ class DataflowPlanBuilder:
             parent_node=pre_aggregate_node,
             metric_input_measure_specs=(metric_input_measure_spec,),
         )
+
+        # Joining to time spine after aggregation is for measures that specify `join_to_timespine`` in the YAML spec.
         after_aggregation_time_spine_join_description = (
             metric_input_measure_spec.after_aggregation_time_spine_join_description
         )

--- a/metricflow/specs/specs.py
+++ b/metricflow/specs/specs.py
@@ -552,6 +552,10 @@ class MetricSpec(InstanceSpec):  # noqa: D
         """Return the reference object that is used for referencing the associated metric in the manifest."""
         return MetricReference(element_name=self.element_name)
 
+    @property
+    def has_time_offset(self) -> bool:  # noqa: D
+        return bool(self.offset_window or self.offset_to_grain)
+
 
 @dataclass(frozen=True)
 class CumulativeMeasureDescription:

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -1632,3 +1632,64 @@ integration_test:
     ON
       {{ render_date_sub("subq_9", "ds", 2, TimeGranularity.DAY) }} = subq_8.metric_time__day
     WHERE {{ render_time_constraint('subq_9.ds', '2020-01-08', '2020-01-09') }}
+---
+integration_test:
+  name: time_offset_metric_with_time_constraint
+  description: Tests a derived offset metric with a time constraint
+  model: SIMPLE_MODEL
+  metrics: ["bookings_5_day_lag"]
+  group_by_objs: [{"name": "metric_time", "grain": "day"}]
+  time_constraint: ["2019-12-19", "2020-01-02"]
+  check_query: |
+    SELECT
+      metric_time__day
+      , bookings_5_days_ago AS bookings_5_day_lag
+    FROM (
+      SELECT
+        subq_3.metric_time__day AS metric_time__day
+        , SUM(subq_2.bookings) AS bookings_5_days_ago
+      FROM (
+        SELECT
+          ds AS metric_time__day
+        FROM {{ source_schema }}.mf_time_spine
+        WHERE {{ render_time_constraint('ds', '2019-12-19', '2020-01-02') }}
+      ) subq_3
+      INNER JOIN (
+        SELECT
+          {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS metric_time__day
+          , 1 AS bookings
+        FROM {{ source_schema }}.fct_bookings
+      ) subq_2
+      ON {{ render_date_sub("subq_3", "metric_time__day", 5, TimeGranularity.DAY) }} = subq_2.metric_time__day
+      GROUP BY subq_3.metric_time__day
+    )
+---
+integration_test:
+  name: cumulative_time_offset_metric_with_time_constraint
+  description: Tests a cumulative derived offset metric with a time constraint
+  model: SIMPLE_MODEL
+  metrics: ["every_2_days_bookers_2_days_ago"]
+  group_by_objs: [{"name": "metric_time", "grain": "day"}]
+  time_constraint: ["2019-12-19", "2020-01-02"]
+  check_query: |
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , COUNT(DISTINCT subq_4.bookers) AS every_2_days_bookers_2_days_ago
+    FROM (
+      SELECT
+        ds AS metric_time__day
+      FROM {{ source_schema }}.mf_time_spine subq_6
+      WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+    ) subq_5
+    INNER JOIN (
+      SELECT
+        subq_3.ds AS metric_time__day
+        , b.guest_id AS bookers
+      FROM {{ source_schema }}.mf_time_spine subq_3
+      INNER JOIN
+        {{ source_schema }}.fct_bookings b
+      ON (DATE_TRUNC('day', b.ds) <= subq_3.ds)
+        AND (DATE_TRUNC('day', b.ds) > subq_3.ds - INTERVAL 2 day)
+    ) subq_4
+    ON subq_5.metric_time__day - INTERVAL 2 day = subq_4.metric_time__day
+    GROUP BY subq_5.metric_time__day

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -1688,8 +1688,8 @@ integration_test:
       FROM {{ source_schema }}.mf_time_spine subq_3
       INNER JOIN
         {{ source_schema }}.fct_bookings b
-      ON (DATE_TRUNC('day', b.ds) <= subq_3.ds)
-        AND (DATE_TRUNC('day', b.ds) > subq_3.ds - INTERVAL 2 day)
+      ON ({{ render_date_trunc("b.ds", TimeGranularity.DAY) }} <= subq_3.ds)
+        AND ({{ render_date_trunc("b.ds", TimeGranularity.DAY) }} > {{ render_date_sub("subq_3", "ds", 2, TimeGranularity.DAY) }})
     ) subq_4
-    ON subq_5.metric_time__day - INTERVAL 2 day = subq_4.metric_time__day
+    ON {{ render_date_sub("subq_5", "metric_time__day", 2, TimeGranularity.DAY) }} = subq_4.metric_time__day
     GROUP BY subq_5.metric_time__day

--- a/metricflow/test/query_rendering/test_derived_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_derived_metric_rendering.py
@@ -440,3 +440,59 @@ def test_nested_offsets_with_time_constraint(  # noqa: D
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
     )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_time_offset_metric_with_time_constraint(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        query_spec=MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="bookings_5_day_lag"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+            time_range_constraint=TimeRangeConstraint(
+                start_time=datetime.datetime(2019, 12, 19), end_time=datetime.datetime(2020, 1, 2)
+            ),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_cumulative_time_offset_metric_with_time_constraint(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+) -> None:
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        query_spec=MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="every_2_days_bookers_2_days_ago"),),
+            time_dimension_specs=(MTD_SPEC_DAY,),
+            time_range_constraint=TimeRangeConstraint(
+                start_time=datetime.datetime(2019, 12, 19), end_time=datetime.datetime(2020, 1, 2)
+            ),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,42 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_11.metric_time__day
-  , 2 * bookings_offset_once AS bookings_offset_twice
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
 FROM (
-  -- Join to Time Spine Dataset
+  -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_10.metric_time__day
+    , subq_10.bookers AS every_2_days_bookers_2_days_ago
   FROM (
-    -- Date Spine
+    -- Aggregate Measures
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day
+      , COUNT(DISTINCT subq_9.bookers) AS bookers
     FROM (
-      -- Compute Metrics via Expressions
+      -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_8.metric_time__day
+        , subq_8.bookers
       FROM (
-        -- Aggregate Measures
+        -- Pass Only Elements:
+        --   ['bookers', 'metric_time__day']
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_7.metric_time__day
+          , subq_7.bookers
         FROM (
-          -- Pass Only Elements:
-          --   ['bookings', 'metric_time__day']
+          -- Join to Time Spine Dataset
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.paid_at__day AS paid_at__day
+            , subq_4.paid_at__week AS paid_at__week
+            , subq_4.paid_at__month AS paid_at__month
+            , subq_4.paid_at__quarter AS paid_at__quarter
+            , subq_4.paid_at__year AS paid_at__year
+            , subq_4.paid_at__extract_year AS paid_at__extract_year
+            , subq_4.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_4.paid_at__extract_month AS paid_at__extract_month
+            , subq_4.paid_at__extract_day AS paid_at__extract_day
+            , subq_4.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_4.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_4.booking__ds__day AS booking__ds__day
+            , subq_4.booking__ds__week AS booking__ds__week
+            , subq_4.booking__ds__month AS booking__ds__month
+            , subq_4.booking__ds__quarter AS booking__ds__quarter
+            , subq_4.booking__ds__year AS booking__ds__year
+            , subq_4.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_4.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_4.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_4.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_4.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_4.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_4.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_4.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_4.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_4.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_4.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_4.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_4.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_4.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_4.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_4.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_4.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_4.booking__paid_at__day AS booking__paid_at__day
+            , subq_4.booking__paid_at__week AS booking__paid_at__week
+            , subq_4.booking__paid_at__month AS booking__paid_at__month
+            , subq_4.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_4.booking__paid_at__year AS booking__paid_at__year
+            , subq_4.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_4.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_4.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.listing AS listing
+            , subq_4.guest AS guest
+            , subq_4.host AS host
+            , subq_4.booking__listing AS booking__listing
+            , subq_4.booking__guest AS booking__guest
+            , subq_4.booking__host AS booking__host
+            , subq_4.is_instant AS is_instant
+            , subq_4.booking__is_instant AS booking__is_instant
+            , subq_4.bookings AS bookings
+            , subq_4.instant_bookings AS instant_bookings
+            , subq_4.booking_value AS booking_value
+            , subq_4.max_booking_value AS max_booking_value
+            , subq_4.min_booking_value AS min_booking_value
+            , subq_4.bookers AS bookers
+            , subq_4.average_booking_value AS average_booking_value
+            , subq_4.referred_bookings AS referred_bookings
+            , subq_4.median_booking_value AS median_booking_value
+            , subq_4.booking_value_p99 AS booking_value_p99
+            , subq_4.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Join to Time Spine Dataset
+            -- Date Spine
+            SELECT
+              subq_6.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_6
+            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
+          ) subq_5
+          INNER JOIN (
+            -- Join Self Over Time Range
             SELECT
               subq_2.metric_time__day AS metric_time__day
               , subq_1.ds__day AS ds__day
@@ -105,6 +191,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -251,73 +347,73 @@ FROM (
                   , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
                   , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
                   , bookings_source_src_10001.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
                   , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
                   , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
                   , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
                   , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
                   , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
                   , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
                   , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
                   , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
                   , bookings_source_src_10001.host_id AS host
@@ -328,14 +424,19 @@ FROM (
               ) subq_0
             ) subq_1
             ON
-              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+              (
+                subq_1.metric_time__day <= subq_2.metric_time__day
+              ) AND (
+                subq_1.metric_time__day > DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 2 day)
+              )
           ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+          ON
+            DATE_SUB(CAST(subq_5.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_4.metric_time__day
+        ) subq_7
+      ) subq_8
+      WHERE subq_8.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    ) subq_9
+    GROUP BY
+      metric_time__day
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_17.metric_time__day AS metric_time__day
+    , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_18
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_17
+  INNER JOIN (
+    -- Join Self Over Time Range
+    SELECT
+      subq_15.ds AS metric_time__day
+      , bookings_source_src_10001.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_15
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      (
+        DATE_TRUNC(bookings_source_src_10001.ds, day) <= subq_15.ds
+      ) AND (
+        DATE_TRUNC(bookings_source_src_10001.ds, day) > DATE_SUB(CAST(subq_15.ds AS DATETIME), INTERVAL 2 day)
+      )
+  ) subq_16
+  ON
+    DATE_SUB(CAST(subq_17.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_16.metric_time__day
+  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+  GROUP BY
+    metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,348 +1,341 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
+  subq_11.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  -- Join to Time Spine Dataset
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings_offset_once
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Join to Time Spine Dataset
+    -- Date Spine
     SELECT
-      subq_9.metric_time__day AS metric_time__day
-      , subq_8.bookings_offset_once AS bookings_offset_once
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
     FROM (
-      -- Date Spine
-      SELECT
-        subq_10.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_10
-      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-    ) subq_9
-    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_7.metric_time__day
-        , 2 * bookings AS bookings_offset_once
+        subq_6.metric_time__day
+        , subq_6.bookings
       FROM (
-        -- Compute Metrics via Expressions
+        -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , subq_6.bookings
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
         FROM (
-          -- Aggregate Measures
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
           SELECT
-            subq_5.metric_time__day
-            , SUM(subq_5.bookings) AS bookings
+            subq_4.metric_time__day
+            , subq_4.bookings
           FROM (
-            -- Pass Only Elements:
-            --   ['bookings', 'metric_time__day']
+            -- Join to Time Spine Dataset
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Join to Time Spine Dataset
+              -- Date Spine
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
-                , subq_1.ds__week AS ds__week
-                , subq_1.ds__month AS ds__month
-                , subq_1.ds__quarter AS ds__quarter
-                , subq_1.ds__year AS ds__year
-                , subq_1.ds__extract_year AS ds__extract_year
-                , subq_1.ds__extract_quarter AS ds__extract_quarter
-                , subq_1.ds__extract_month AS ds__extract_month
-                , subq_1.ds__extract_day AS ds__extract_day
-                , subq_1.ds__extract_dow AS ds__extract_dow
-                , subq_1.ds__extract_doy AS ds__extract_doy
-                , subq_1.ds_partitioned__day AS ds_partitioned__day
-                , subq_1.ds_partitioned__week AS ds_partitioned__week
-                , subq_1.ds_partitioned__month AS ds_partitioned__month
-                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                , subq_1.ds_partitioned__year AS ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                , subq_1.paid_at__day AS paid_at__day
-                , subq_1.paid_at__week AS paid_at__week
-                , subq_1.paid_at__month AS paid_at__month
-                , subq_1.paid_at__quarter AS paid_at__quarter
-                , subq_1.paid_at__year AS paid_at__year
-                , subq_1.paid_at__extract_year AS paid_at__extract_year
-                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                , subq_1.paid_at__extract_month AS paid_at__extract_month
-                , subq_1.paid_at__extract_day AS paid_at__extract_day
-                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                , subq_1.booking__ds__day AS booking__ds__day
-                , subq_1.booking__ds__week AS booking__ds__week
-                , subq_1.booking__ds__month AS booking__ds__month
-                , subq_1.booking__ds__quarter AS booking__ds__quarter
-                , subq_1.booking__ds__year AS booking__ds__year
-                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day AS booking__paid_at__day
-                , subq_1.booking__paid_at__week AS booking__paid_at__week
-                , subq_1.booking__paid_at__month AS booking__paid_at__month
-                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                , subq_1.booking__paid_at__year AS booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                , subq_1.listing AS listing
-                , subq_1.guest AS guest
-                , subq_1.host AS host
-                , subq_1.booking__listing AS booking__listing
-                , subq_1.booking__guest AS booking__guest
-                , subq_1.booking__host AS booking__host
-                , subq_1.is_instant AS is_instant
-                , subq_1.booking__is_instant AS booking__is_instant
-                , subq_1.bookings AS bookings
-                , subq_1.instant_bookings AS instant_bookings
-                , subq_1.booking_value AS booking_value
-                , subq_1.max_booking_value AS max_booking_value
-                , subq_1.min_booking_value AS min_booking_value
-                , subq_1.bookers AS bookers
-                , subq_1.average_booking_value AS average_booking_value
-                , subq_1.referred_bookings AS referred_bookings
-                , subq_1.median_booking_value AS median_booking_value
-                , subq_1.booking_value_p99 AS booking_value_p99
-                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Date Spine
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_3.ds AS metric_time__day
-                FROM ***************************.mf_time_spine subq_3
-              ) subq_2
-              INNER JOIN (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_10001.booking_value AS median_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_value_p99
-                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_10001.is_instant
-                    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
-                    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
-                    , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
-                    , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_10001.is_instant AS booking__is_instant
-                    , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
-                    , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
-                    , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
-                    , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
-                    , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
-                    , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.listing_id AS booking__listing
-                    , bookings_source_src_10001.guest_id AS booking__guest
-                    , bookings_source_src_10001.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-              ON
-                DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_1.metric_time__day
-            ) subq_4
-          ) subq_5
-          GROUP BY
-            metric_time__day
-        ) subq_6
-      ) subq_7
-    ) subq_8
-    ON
-      DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_8.metric_time__day
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_12
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -4,17 +4,16 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_22.metric_time__day AS metric_time__day
-    , subq_21.bookings_offset_once AS bookings_offset_once
+    subq_21.metric_time__day AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
   FROM (
     -- Date Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_23
+    FROM ***************************.mf_time_spine subq_22
     WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_22
+  ) subq_21
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -27,9 +26,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_16.ds AS metric_time__day
-        , SUM(subq_14.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_16
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -37,14 +36,13 @@ FROM (
           DATE_TRUNC(ds, day) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
-      ) subq_14
+      ) subq_13
       ON
-        DATE_SUB(CAST(subq_16.ds AS DATETIME), INTERVAL 5 day) = subq_14.metric_time__day
+        DATE_SUB(CAST(subq_15.ds AS DATETIME), INTERVAL 5 day) = subq_13.metric_time__day
       GROUP BY
         metric_time__day
-    ) subq_20
-  ) subq_21
+    ) subq_19
+  ) subq_20
   ON
-    DATE_SUB(CAST(subq_22.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_21.metric_time__day
-  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_25
+    DATE_SUB(CAST(subq_21.metric_time__day AS DATETIME), INTERVAL 2 day) = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,0 +1,321 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__day
+    , subq_6.bookings AS bookings_5_days_ago
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_1.metric_time__day
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      metric_time__day
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,33 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings', 'metric_time__day']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__day AS metric_time__day
+    , SUM(subq_9.bookings) AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_11
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_10
+  INNER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    SELECT
+      DATE_TRUNC(ds, day) AS metric_time__day
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_10001
+  ) subq_9
+  ON
+    DATE_SUB(CAST(subq_10.metric_time__day AS DATETIME), INTERVAL 5 day) = subq_9.metric_time__day
+  GROUP BY
+    metric_time__day
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,42 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_11.metric_time__day
-  , 2 * bookings_offset_once AS bookings_offset_twice
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
 FROM (
-  -- Join to Time Spine Dataset
+  -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_10.metric_time__day
+    , subq_10.bookers AS every_2_days_bookers_2_days_ago
   FROM (
-    -- Date Spine
+    -- Aggregate Measures
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day
+      , COUNT(DISTINCT subq_9.bookers) AS bookers
     FROM (
-      -- Compute Metrics via Expressions
+      -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_8.metric_time__day
+        , subq_8.bookers
       FROM (
-        -- Aggregate Measures
+        -- Pass Only Elements:
+        --   ['bookers', 'metric_time__day']
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_7.metric_time__day
+          , subq_7.bookers
         FROM (
-          -- Pass Only Elements:
-          --   ['bookings', 'metric_time__day']
+          -- Join to Time Spine Dataset
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.paid_at__day AS paid_at__day
+            , subq_4.paid_at__week AS paid_at__week
+            , subq_4.paid_at__month AS paid_at__month
+            , subq_4.paid_at__quarter AS paid_at__quarter
+            , subq_4.paid_at__year AS paid_at__year
+            , subq_4.paid_at__extract_year AS paid_at__extract_year
+            , subq_4.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_4.paid_at__extract_month AS paid_at__extract_month
+            , subq_4.paid_at__extract_day AS paid_at__extract_day
+            , subq_4.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_4.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_4.booking__ds__day AS booking__ds__day
+            , subq_4.booking__ds__week AS booking__ds__week
+            , subq_4.booking__ds__month AS booking__ds__month
+            , subq_4.booking__ds__quarter AS booking__ds__quarter
+            , subq_4.booking__ds__year AS booking__ds__year
+            , subq_4.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_4.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_4.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_4.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_4.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_4.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_4.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_4.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_4.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_4.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_4.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_4.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_4.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_4.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_4.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_4.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_4.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_4.booking__paid_at__day AS booking__paid_at__day
+            , subq_4.booking__paid_at__week AS booking__paid_at__week
+            , subq_4.booking__paid_at__month AS booking__paid_at__month
+            , subq_4.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_4.booking__paid_at__year AS booking__paid_at__year
+            , subq_4.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_4.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_4.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.listing AS listing
+            , subq_4.guest AS guest
+            , subq_4.host AS host
+            , subq_4.booking__listing AS booking__listing
+            , subq_4.booking__guest AS booking__guest
+            , subq_4.booking__host AS booking__host
+            , subq_4.is_instant AS is_instant
+            , subq_4.booking__is_instant AS booking__is_instant
+            , subq_4.bookings AS bookings
+            , subq_4.instant_bookings AS instant_bookings
+            , subq_4.booking_value AS booking_value
+            , subq_4.max_booking_value AS max_booking_value
+            , subq_4.min_booking_value AS min_booking_value
+            , subq_4.bookers AS bookers
+            , subq_4.average_booking_value AS average_booking_value
+            , subq_4.referred_bookings AS referred_bookings
+            , subq_4.median_booking_value AS median_booking_value
+            , subq_4.booking_value_p99 AS booking_value_p99
+            , subq_4.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Join to Time Spine Dataset
+            -- Date Spine
+            SELECT
+              subq_6.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_6
+            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
+          ) subq_5
+          INNER JOIN (
+            -- Join Self Over Time Range
             SELECT
               subq_2.metric_time__day AS metric_time__day
               , subq_1.ds__day AS ds__day
@@ -105,6 +191,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -260,7 +356,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
@@ -271,7 +367,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
@@ -282,7 +378,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
                   , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
@@ -294,7 +390,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
@@ -305,7 +401,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
@@ -316,7 +412,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
@@ -328,14 +424,19 @@ FROM (
               ) subq_0
             ) subq_1
             ON
-              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+              (
+                subq_1.metric_time__day <= subq_2.metric_time__day
+              ) AND (
+                subq_1.metric_time__day > DATEADD(day, -2, subq_2.metric_time__day)
+              )
           ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+          ON
+            DATEADD(day, -2, subq_5.metric_time__day) = subq_4.metric_time__day
+        ) subq_7
+      ) subq_8
+      WHERE subq_8.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    ) subq_9
+    GROUP BY
+      subq_9.metric_time__day
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_17.metric_time__day AS metric_time__day
+    , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_18
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_17
+  INNER JOIN (
+    -- Join Self Over Time Range
+    SELECT
+      subq_15.ds AS metric_time__day
+      , bookings_source_src_10001.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_15
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_15.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_10001.ds) > DATEADD(day, -2, subq_15.ds)
+      )
+  ) subq_16
+  ON
+    DATEADD(day, -2, subq_17.metric_time__day) = subq_16.metric_time__day
+  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+  GROUP BY
+    subq_17.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,348 +1,341 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
+  subq_11.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  -- Join to Time Spine Dataset
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings_offset_once
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Join to Time Spine Dataset
+    -- Date Spine
     SELECT
-      subq_9.metric_time__day AS metric_time__day
-      , subq_8.bookings_offset_once AS bookings_offset_once
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
     FROM (
-      -- Date Spine
-      SELECT
-        subq_10.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_10
-      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-    ) subq_9
-    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_7.metric_time__day
-        , 2 * bookings AS bookings_offset_once
+        subq_6.metric_time__day
+        , subq_6.bookings
       FROM (
-        -- Compute Metrics via Expressions
+        -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , subq_6.bookings
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
         FROM (
-          -- Aggregate Measures
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
           SELECT
-            subq_5.metric_time__day
-            , SUM(subq_5.bookings) AS bookings
+            subq_4.metric_time__day
+            , subq_4.bookings
           FROM (
-            -- Pass Only Elements:
-            --   ['bookings', 'metric_time__day']
+            -- Join to Time Spine Dataset
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Join to Time Spine Dataset
+              -- Date Spine
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
-                , subq_1.ds__week AS ds__week
-                , subq_1.ds__month AS ds__month
-                , subq_1.ds__quarter AS ds__quarter
-                , subq_1.ds__year AS ds__year
-                , subq_1.ds__extract_year AS ds__extract_year
-                , subq_1.ds__extract_quarter AS ds__extract_quarter
-                , subq_1.ds__extract_month AS ds__extract_month
-                , subq_1.ds__extract_day AS ds__extract_day
-                , subq_1.ds__extract_dow AS ds__extract_dow
-                , subq_1.ds__extract_doy AS ds__extract_doy
-                , subq_1.ds_partitioned__day AS ds_partitioned__day
-                , subq_1.ds_partitioned__week AS ds_partitioned__week
-                , subq_1.ds_partitioned__month AS ds_partitioned__month
-                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                , subq_1.ds_partitioned__year AS ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                , subq_1.paid_at__day AS paid_at__day
-                , subq_1.paid_at__week AS paid_at__week
-                , subq_1.paid_at__month AS paid_at__month
-                , subq_1.paid_at__quarter AS paid_at__quarter
-                , subq_1.paid_at__year AS paid_at__year
-                , subq_1.paid_at__extract_year AS paid_at__extract_year
-                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                , subq_1.paid_at__extract_month AS paid_at__extract_month
-                , subq_1.paid_at__extract_day AS paid_at__extract_day
-                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                , subq_1.booking__ds__day AS booking__ds__day
-                , subq_1.booking__ds__week AS booking__ds__week
-                , subq_1.booking__ds__month AS booking__ds__month
-                , subq_1.booking__ds__quarter AS booking__ds__quarter
-                , subq_1.booking__ds__year AS booking__ds__year
-                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day AS booking__paid_at__day
-                , subq_1.booking__paid_at__week AS booking__paid_at__week
-                , subq_1.booking__paid_at__month AS booking__paid_at__month
-                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                , subq_1.booking__paid_at__year AS booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                , subq_1.listing AS listing
-                , subq_1.guest AS guest
-                , subq_1.host AS host
-                , subq_1.booking__listing AS booking__listing
-                , subq_1.booking__guest AS booking__guest
-                , subq_1.booking__host AS booking__host
-                , subq_1.is_instant AS is_instant
-                , subq_1.booking__is_instant AS booking__is_instant
-                , subq_1.bookings AS bookings
-                , subq_1.instant_bookings AS instant_bookings
-                , subq_1.booking_value AS booking_value
-                , subq_1.max_booking_value AS max_booking_value
-                , subq_1.min_booking_value AS min_booking_value
-                , subq_1.bookers AS bookers
-                , subq_1.average_booking_value AS average_booking_value
-                , subq_1.referred_bookings AS referred_bookings
-                , subq_1.median_booking_value AS median_booking_value
-                , subq_1.booking_value_p99 AS booking_value_p99
-                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Date Spine
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_3.ds AS metric_time__day
-                FROM ***************************.mf_time_spine subq_3
-              ) subq_2
-              INNER JOIN (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_10001.booking_value AS median_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_value_p99
-                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_10001.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_10001.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.listing_id AS booking__listing
-                    , bookings_source_src_10001.guest_id AS booking__guest
-                    , bookings_source_src_10001.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-              ON
-                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
-            ) subq_4
-          ) subq_5
-          GROUP BY
-            subq_5.metric_time__day
-        ) subq_6
-      ) subq_7
-    ) subq_8
-    ON
-      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_12
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          subq_5.metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -4,17 +4,16 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_22.metric_time__day AS metric_time__day
-    , subq_21.bookings_offset_once AS bookings_offset_once
+    subq_21.metric_time__day AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
   FROM (
     -- Date Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_23
+    FROM ***************************.mf_time_spine subq_22
     WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_22
+  ) subq_21
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -27,9 +26,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_16.ds AS metric_time__day
-        , SUM(subq_14.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_16
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -37,14 +36,13 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
-      ) subq_14
+      ) subq_13
       ON
-        DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
+        DATEADD(day, -5, subq_15.ds) = subq_13.metric_time__day
       GROUP BY
-        subq_16.ds
-    ) subq_20
-  ) subq_21
+        subq_15.ds
+    ) subq_19
+  ) subq_20
   ON
-    DATEADD(day, -2, subq_22.metric_time__day) = subq_21.metric_time__day
-  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_25
+    DATEADD(day, -2, subq_21.metric_time__day) = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,0 +1,321 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__day
+    , subq_6.bookings AS bookings_5_days_ago
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,33 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings', 'metric_time__day']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__day AS metric_time__day
+    , SUM(subq_9.bookings) AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_11
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_10
+  INNER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_10001
+  ) subq_9
+  ON
+    DATEADD(day, -5, subq_10.metric_time__day) = subq_9.metric_time__day
+  GROUP BY
+    subq_10.metric_time__day
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,42 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_11.metric_time__day
-  , 2 * bookings_offset_once AS bookings_offset_twice
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
 FROM (
-  -- Join to Time Spine Dataset
+  -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_10.metric_time__day
+    , subq_10.bookers AS every_2_days_bookers_2_days_ago
   FROM (
-    -- Date Spine
+    -- Aggregate Measures
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day
+      , COUNT(DISTINCT subq_9.bookers) AS bookers
     FROM (
-      -- Compute Metrics via Expressions
+      -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_8.metric_time__day
+        , subq_8.bookers
       FROM (
-        -- Aggregate Measures
+        -- Pass Only Elements:
+        --   ['bookers', 'metric_time__day']
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_7.metric_time__day
+          , subq_7.bookers
         FROM (
-          -- Pass Only Elements:
-          --   ['bookings', 'metric_time__day']
+          -- Join to Time Spine Dataset
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.paid_at__day AS paid_at__day
+            , subq_4.paid_at__week AS paid_at__week
+            , subq_4.paid_at__month AS paid_at__month
+            , subq_4.paid_at__quarter AS paid_at__quarter
+            , subq_4.paid_at__year AS paid_at__year
+            , subq_4.paid_at__extract_year AS paid_at__extract_year
+            , subq_4.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_4.paid_at__extract_month AS paid_at__extract_month
+            , subq_4.paid_at__extract_day AS paid_at__extract_day
+            , subq_4.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_4.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_4.booking__ds__day AS booking__ds__day
+            , subq_4.booking__ds__week AS booking__ds__week
+            , subq_4.booking__ds__month AS booking__ds__month
+            , subq_4.booking__ds__quarter AS booking__ds__quarter
+            , subq_4.booking__ds__year AS booking__ds__year
+            , subq_4.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_4.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_4.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_4.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_4.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_4.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_4.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_4.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_4.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_4.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_4.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_4.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_4.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_4.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_4.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_4.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_4.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_4.booking__paid_at__day AS booking__paid_at__day
+            , subq_4.booking__paid_at__week AS booking__paid_at__week
+            , subq_4.booking__paid_at__month AS booking__paid_at__month
+            , subq_4.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_4.booking__paid_at__year AS booking__paid_at__year
+            , subq_4.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_4.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_4.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.listing AS listing
+            , subq_4.guest AS guest
+            , subq_4.host AS host
+            , subq_4.booking__listing AS booking__listing
+            , subq_4.booking__guest AS booking__guest
+            , subq_4.booking__host AS booking__host
+            , subq_4.is_instant AS is_instant
+            , subq_4.booking__is_instant AS booking__is_instant
+            , subq_4.bookings AS bookings
+            , subq_4.instant_bookings AS instant_bookings
+            , subq_4.booking_value AS booking_value
+            , subq_4.max_booking_value AS max_booking_value
+            , subq_4.min_booking_value AS min_booking_value
+            , subq_4.bookers AS bookers
+            , subq_4.average_booking_value AS average_booking_value
+            , subq_4.referred_bookings AS referred_bookings
+            , subq_4.median_booking_value AS median_booking_value
+            , subq_4.booking_value_p99 AS booking_value_p99
+            , subq_4.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Join to Time Spine Dataset
+            -- Date Spine
+            SELECT
+              subq_6.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_6
+            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
+          ) subq_5
+          INNER JOIN (
+            -- Join Self Over Time Range
             SELECT
               subq_2.metric_time__day AS metric_time__day
               , subq_1.ds__day AS ds__day
@@ -105,6 +191,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -260,7 +356,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
@@ -271,7 +367,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
@@ -282,7 +378,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
                   , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
@@ -294,7 +390,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
@@ -305,7 +401,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
@@ -316,7 +412,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
@@ -328,14 +424,19 @@ FROM (
               ) subq_0
             ) subq_1
             ON
-              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+              (
+                subq_1.metric_time__day <= subq_2.metric_time__day
+              ) AND (
+                subq_1.metric_time__day > subq_2.metric_time__day - INTERVAL 2 day
+              )
           ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+          ON
+            subq_5.metric_time__day - INTERVAL 2 day = subq_4.metric_time__day
+        ) subq_7
+      ) subq_8
+      WHERE subq_8.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    ) subq_9
+    GROUP BY
+      subq_9.metric_time__day
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_17.metric_time__day AS metric_time__day
+    , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_18
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_17
+  INNER JOIN (
+    -- Join Self Over Time Range
+    SELECT
+      subq_15.ds AS metric_time__day
+      , bookings_source_src_10001.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_15
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_15.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_10001.ds) > subq_15.ds - INTERVAL 2 day
+      )
+  ) subq_16
+  ON
+    subq_17.metric_time__day - INTERVAL 2 day = subq_16.metric_time__day
+  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+  GROUP BY
+    subq_17.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,348 +1,341 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
+  subq_11.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  -- Join to Time Spine Dataset
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings_offset_once
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Join to Time Spine Dataset
+    -- Date Spine
     SELECT
-      subq_9.metric_time__day AS metric_time__day
-      , subq_8.bookings_offset_once AS bookings_offset_once
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
     FROM (
-      -- Date Spine
-      SELECT
-        subq_10.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_10
-      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-    ) subq_9
-    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_7.metric_time__day
-        , 2 * bookings AS bookings_offset_once
+        subq_6.metric_time__day
+        , subq_6.bookings
       FROM (
-        -- Compute Metrics via Expressions
+        -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , subq_6.bookings
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
         FROM (
-          -- Aggregate Measures
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
           SELECT
-            subq_5.metric_time__day
-            , SUM(subq_5.bookings) AS bookings
+            subq_4.metric_time__day
+            , subq_4.bookings
           FROM (
-            -- Pass Only Elements:
-            --   ['bookings', 'metric_time__day']
+            -- Join to Time Spine Dataset
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Join to Time Spine Dataset
+              -- Date Spine
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
-                , subq_1.ds__week AS ds__week
-                , subq_1.ds__month AS ds__month
-                , subq_1.ds__quarter AS ds__quarter
-                , subq_1.ds__year AS ds__year
-                , subq_1.ds__extract_year AS ds__extract_year
-                , subq_1.ds__extract_quarter AS ds__extract_quarter
-                , subq_1.ds__extract_month AS ds__extract_month
-                , subq_1.ds__extract_day AS ds__extract_day
-                , subq_1.ds__extract_dow AS ds__extract_dow
-                , subq_1.ds__extract_doy AS ds__extract_doy
-                , subq_1.ds_partitioned__day AS ds_partitioned__day
-                , subq_1.ds_partitioned__week AS ds_partitioned__week
-                , subq_1.ds_partitioned__month AS ds_partitioned__month
-                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                , subq_1.ds_partitioned__year AS ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                , subq_1.paid_at__day AS paid_at__day
-                , subq_1.paid_at__week AS paid_at__week
-                , subq_1.paid_at__month AS paid_at__month
-                , subq_1.paid_at__quarter AS paid_at__quarter
-                , subq_1.paid_at__year AS paid_at__year
-                , subq_1.paid_at__extract_year AS paid_at__extract_year
-                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                , subq_1.paid_at__extract_month AS paid_at__extract_month
-                , subq_1.paid_at__extract_day AS paid_at__extract_day
-                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                , subq_1.booking__ds__day AS booking__ds__day
-                , subq_1.booking__ds__week AS booking__ds__week
-                , subq_1.booking__ds__month AS booking__ds__month
-                , subq_1.booking__ds__quarter AS booking__ds__quarter
-                , subq_1.booking__ds__year AS booking__ds__year
-                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day AS booking__paid_at__day
-                , subq_1.booking__paid_at__week AS booking__paid_at__week
-                , subq_1.booking__paid_at__month AS booking__paid_at__month
-                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                , subq_1.booking__paid_at__year AS booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                , subq_1.listing AS listing
-                , subq_1.guest AS guest
-                , subq_1.host AS host
-                , subq_1.booking__listing AS booking__listing
-                , subq_1.booking__guest AS booking__guest
-                , subq_1.booking__host AS booking__host
-                , subq_1.is_instant AS is_instant
-                , subq_1.booking__is_instant AS booking__is_instant
-                , subq_1.bookings AS bookings
-                , subq_1.instant_bookings AS instant_bookings
-                , subq_1.booking_value AS booking_value
-                , subq_1.max_booking_value AS max_booking_value
-                , subq_1.min_booking_value AS min_booking_value
-                , subq_1.bookers AS bookers
-                , subq_1.average_booking_value AS average_booking_value
-                , subq_1.referred_bookings AS referred_bookings
-                , subq_1.median_booking_value AS median_booking_value
-                , subq_1.booking_value_p99 AS booking_value_p99
-                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Date Spine
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_3.ds AS metric_time__day
-                FROM ***************************.mf_time_spine subq_3
-              ) subq_2
-              INNER JOIN (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_10001.booking_value AS median_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_value_p99
-                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_10001.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_10001.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.listing_id AS booking__listing
-                    , bookings_source_src_10001.guest_id AS booking__guest
-                    , bookings_source_src_10001.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-              ON
-                subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
-            ) subq_4
-          ) subq_5
-          GROUP BY
-            subq_5.metric_time__day
-        ) subq_6
-      ) subq_7
-    ) subq_8
-    ON
-      subq_9.metric_time__day - INTERVAL 2 day = subq_8.metric_time__day
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_12
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          subq_5.metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    subq_9.metric_time__day - INTERVAL 2 day = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -4,17 +4,16 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_22.metric_time__day AS metric_time__day
-    , subq_21.bookings_offset_once AS bookings_offset_once
+    subq_21.metric_time__day AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
   FROM (
     -- Date Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_23
+    FROM ***************************.mf_time_spine subq_22
     WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_22
+  ) subq_21
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -27,9 +26,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_16.ds AS metric_time__day
-        , SUM(subq_14.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_16
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -37,14 +36,13 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
-      ) subq_14
+      ) subq_13
       ON
-        subq_16.ds - INTERVAL 5 day = subq_14.metric_time__day
+        subq_15.ds - INTERVAL 5 day = subq_13.metric_time__day
       GROUP BY
-        subq_16.ds
-    ) subq_20
-  ) subq_21
+        subq_15.ds
+    ) subq_19
+  ) subq_20
   ON
-    subq_22.metric_time__day - INTERVAL 2 day = subq_21.metric_time__day
-  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_25
+    subq_21.metric_time__day - INTERVAL 2 day = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,0 +1,321 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__day
+    , subq_6.bookings AS bookings_5_days_ago
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          subq_2.metric_time__day - INTERVAL 5 day = subq_1.metric_time__day
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,33 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings', 'metric_time__day']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__day AS metric_time__day
+    , SUM(subq_9.bookings) AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_11
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_10
+  INNER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_10001
+  ) subq_9
+  ON
+    subq_10.metric_time__day - INTERVAL 5 day = subq_9.metric_time__day
+  GROUP BY
+    subq_10.metric_time__day
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,42 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_11.metric_time__day
-  , 2 * bookings_offset_once AS bookings_offset_twice
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
 FROM (
-  -- Join to Time Spine Dataset
+  -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_10.metric_time__day
+    , subq_10.bookers AS every_2_days_bookers_2_days_ago
   FROM (
-    -- Date Spine
+    -- Aggregate Measures
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day
+      , COUNT(DISTINCT subq_9.bookers) AS bookers
     FROM (
-      -- Compute Metrics via Expressions
+      -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_8.metric_time__day
+        , subq_8.bookers
       FROM (
-        -- Aggregate Measures
+        -- Pass Only Elements:
+        --   ['bookers', 'metric_time__day']
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_7.metric_time__day
+          , subq_7.bookers
         FROM (
-          -- Pass Only Elements:
-          --   ['bookings', 'metric_time__day']
+          -- Join to Time Spine Dataset
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.paid_at__day AS paid_at__day
+            , subq_4.paid_at__week AS paid_at__week
+            , subq_4.paid_at__month AS paid_at__month
+            , subq_4.paid_at__quarter AS paid_at__quarter
+            , subq_4.paid_at__year AS paid_at__year
+            , subq_4.paid_at__extract_year AS paid_at__extract_year
+            , subq_4.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_4.paid_at__extract_month AS paid_at__extract_month
+            , subq_4.paid_at__extract_day AS paid_at__extract_day
+            , subq_4.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_4.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_4.booking__ds__day AS booking__ds__day
+            , subq_4.booking__ds__week AS booking__ds__week
+            , subq_4.booking__ds__month AS booking__ds__month
+            , subq_4.booking__ds__quarter AS booking__ds__quarter
+            , subq_4.booking__ds__year AS booking__ds__year
+            , subq_4.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_4.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_4.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_4.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_4.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_4.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_4.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_4.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_4.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_4.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_4.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_4.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_4.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_4.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_4.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_4.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_4.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_4.booking__paid_at__day AS booking__paid_at__day
+            , subq_4.booking__paid_at__week AS booking__paid_at__week
+            , subq_4.booking__paid_at__month AS booking__paid_at__month
+            , subq_4.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_4.booking__paid_at__year AS booking__paid_at__year
+            , subq_4.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_4.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_4.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.listing AS listing
+            , subq_4.guest AS guest
+            , subq_4.host AS host
+            , subq_4.booking__listing AS booking__listing
+            , subq_4.booking__guest AS booking__guest
+            , subq_4.booking__host AS booking__host
+            , subq_4.is_instant AS is_instant
+            , subq_4.booking__is_instant AS booking__is_instant
+            , subq_4.bookings AS bookings
+            , subq_4.instant_bookings AS instant_bookings
+            , subq_4.booking_value AS booking_value
+            , subq_4.max_booking_value AS max_booking_value
+            , subq_4.min_booking_value AS min_booking_value
+            , subq_4.bookers AS bookers
+            , subq_4.average_booking_value AS average_booking_value
+            , subq_4.referred_bookings AS referred_bookings
+            , subq_4.median_booking_value AS median_booking_value
+            , subq_4.booking_value_p99 AS booking_value_p99
+            , subq_4.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Join to Time Spine Dataset
+            -- Date Spine
+            SELECT
+              subq_6.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_6
+            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
+          ) subq_5
+          INNER JOIN (
+            -- Join Self Over Time Range
             SELECT
               subq_2.metric_time__day AS metric_time__day
               , subq_1.ds__day AS ds__day
@@ -105,6 +191,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -260,7 +356,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
@@ -271,7 +367,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
@@ -282,7 +378,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
                   , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
@@ -294,7 +390,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
@@ -305,7 +401,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
@@ -316,7 +412,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
@@ -328,14 +424,19 @@ FROM (
               ) subq_0
             ) subq_1
             ON
-              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+              (
+                subq_1.metric_time__day <= subq_2.metric_time__day
+              ) AND (
+                subq_1.metric_time__day > subq_2.metric_time__day - MAKE_INTERVAL(days => 2)
+              )
           ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+          ON
+            subq_5.metric_time__day - MAKE_INTERVAL(days => 2) = subq_4.metric_time__day
+        ) subq_7
+      ) subq_8
+      WHERE subq_8.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    ) subq_9
+    GROUP BY
+      subq_9.metric_time__day
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_17.metric_time__day AS metric_time__day
+    , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_18
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_17
+  INNER JOIN (
+    -- Join Self Over Time Range
+    SELECT
+      subq_15.ds AS metric_time__day
+      , bookings_source_src_10001.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_15
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_15.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_10001.ds) > subq_15.ds - MAKE_INTERVAL(days => 2)
+      )
+  ) subq_16
+  ON
+    subq_17.metric_time__day - MAKE_INTERVAL(days => 2) = subq_16.metric_time__day
+  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+  GROUP BY
+    subq_17.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,348 +1,341 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
+  subq_11.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  -- Join to Time Spine Dataset
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings_offset_once
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Join to Time Spine Dataset
+    -- Date Spine
     SELECT
-      subq_9.metric_time__day AS metric_time__day
-      , subq_8.bookings_offset_once AS bookings_offset_once
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
     FROM (
-      -- Date Spine
-      SELECT
-        subq_10.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_10
-      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-    ) subq_9
-    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_7.metric_time__day
-        , 2 * bookings AS bookings_offset_once
+        subq_6.metric_time__day
+        , subq_6.bookings
       FROM (
-        -- Compute Metrics via Expressions
+        -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , subq_6.bookings
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
         FROM (
-          -- Aggregate Measures
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
           SELECT
-            subq_5.metric_time__day
-            , SUM(subq_5.bookings) AS bookings
+            subq_4.metric_time__day
+            , subq_4.bookings
           FROM (
-            -- Pass Only Elements:
-            --   ['bookings', 'metric_time__day']
+            -- Join to Time Spine Dataset
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Join to Time Spine Dataset
+              -- Date Spine
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
-                , subq_1.ds__week AS ds__week
-                , subq_1.ds__month AS ds__month
-                , subq_1.ds__quarter AS ds__quarter
-                , subq_1.ds__year AS ds__year
-                , subq_1.ds__extract_year AS ds__extract_year
-                , subq_1.ds__extract_quarter AS ds__extract_quarter
-                , subq_1.ds__extract_month AS ds__extract_month
-                , subq_1.ds__extract_day AS ds__extract_day
-                , subq_1.ds__extract_dow AS ds__extract_dow
-                , subq_1.ds__extract_doy AS ds__extract_doy
-                , subq_1.ds_partitioned__day AS ds_partitioned__day
-                , subq_1.ds_partitioned__week AS ds_partitioned__week
-                , subq_1.ds_partitioned__month AS ds_partitioned__month
-                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                , subq_1.ds_partitioned__year AS ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                , subq_1.paid_at__day AS paid_at__day
-                , subq_1.paid_at__week AS paid_at__week
-                , subq_1.paid_at__month AS paid_at__month
-                , subq_1.paid_at__quarter AS paid_at__quarter
-                , subq_1.paid_at__year AS paid_at__year
-                , subq_1.paid_at__extract_year AS paid_at__extract_year
-                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                , subq_1.paid_at__extract_month AS paid_at__extract_month
-                , subq_1.paid_at__extract_day AS paid_at__extract_day
-                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                , subq_1.booking__ds__day AS booking__ds__day
-                , subq_1.booking__ds__week AS booking__ds__week
-                , subq_1.booking__ds__month AS booking__ds__month
-                , subq_1.booking__ds__quarter AS booking__ds__quarter
-                , subq_1.booking__ds__year AS booking__ds__year
-                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day AS booking__paid_at__day
-                , subq_1.booking__paid_at__week AS booking__paid_at__week
-                , subq_1.booking__paid_at__month AS booking__paid_at__month
-                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                , subq_1.booking__paid_at__year AS booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                , subq_1.listing AS listing
-                , subq_1.guest AS guest
-                , subq_1.host AS host
-                , subq_1.booking__listing AS booking__listing
-                , subq_1.booking__guest AS booking__guest
-                , subq_1.booking__host AS booking__host
-                , subq_1.is_instant AS is_instant
-                , subq_1.booking__is_instant AS booking__is_instant
-                , subq_1.bookings AS bookings
-                , subq_1.instant_bookings AS instant_bookings
-                , subq_1.booking_value AS booking_value
-                , subq_1.max_booking_value AS max_booking_value
-                , subq_1.min_booking_value AS min_booking_value
-                , subq_1.bookers AS bookers
-                , subq_1.average_booking_value AS average_booking_value
-                , subq_1.referred_bookings AS referred_bookings
-                , subq_1.median_booking_value AS median_booking_value
-                , subq_1.booking_value_p99 AS booking_value_p99
-                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Date Spine
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_3.ds AS metric_time__day
-                FROM ***************************.mf_time_spine subq_3
-              ) subq_2
-              INNER JOIN (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_10001.booking_value AS median_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_value_p99
-                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_10001.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_10001.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.listing_id AS booking__listing
-                    , bookings_source_src_10001.guest_id AS booking__guest
-                    , bookings_source_src_10001.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-              ON
-                subq_2.metric_time__day - MAKE_INTERVAL(days => 5) = subq_1.metric_time__day
-            ) subq_4
-          ) subq_5
-          GROUP BY
-            subq_5.metric_time__day
-        ) subq_6
-      ) subq_7
-    ) subq_8
-    ON
-      subq_9.metric_time__day - MAKE_INTERVAL(days => 2) = subq_8.metric_time__day
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_12
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              subq_2.metric_time__day - MAKE_INTERVAL(days => 5) = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          subq_5.metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    subq_9.metric_time__day - MAKE_INTERVAL(days => 2) = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -4,17 +4,16 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_22.metric_time__day AS metric_time__day
-    , subq_21.bookings_offset_once AS bookings_offset_once
+    subq_21.metric_time__day AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
   FROM (
     -- Date Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_23
+    FROM ***************************.mf_time_spine subq_22
     WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_22
+  ) subq_21
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -27,9 +26,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_16.ds AS metric_time__day
-        , SUM(subq_14.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_16
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -37,14 +36,13 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
-      ) subq_14
+      ) subq_13
       ON
-        subq_16.ds - MAKE_INTERVAL(days => 5) = subq_14.metric_time__day
+        subq_15.ds - MAKE_INTERVAL(days => 5) = subq_13.metric_time__day
       GROUP BY
-        subq_16.ds
-    ) subq_20
-  ) subq_21
+        subq_15.ds
+    ) subq_19
+  ) subq_20
   ON
-    subq_22.metric_time__day - MAKE_INTERVAL(days => 2) = subq_21.metric_time__day
-  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_25
+    subq_21.metric_time__day - MAKE_INTERVAL(days => 2) = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,0 +1,321 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__day
+    , subq_6.bookings AS bookings_5_days_ago
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          subq_2.metric_time__day - MAKE_INTERVAL(days => 5) = subq_1.metric_time__day
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,33 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings', 'metric_time__day']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__day AS metric_time__day
+    , SUM(subq_9.bookings) AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_11
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_10
+  INNER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_10001
+  ) subq_9
+  ON
+    subq_10.metric_time__day - MAKE_INTERVAL(days => 5) = subq_9.metric_time__day
+  GROUP BY
+    subq_10.metric_time__day
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,42 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_11.metric_time__day
-  , 2 * bookings_offset_once AS bookings_offset_twice
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
 FROM (
-  -- Join to Time Spine Dataset
+  -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_10.metric_time__day
+    , subq_10.bookers AS every_2_days_bookers_2_days_ago
   FROM (
-    -- Date Spine
+    -- Aggregate Measures
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day
+      , COUNT(DISTINCT subq_9.bookers) AS bookers
     FROM (
-      -- Compute Metrics via Expressions
+      -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_8.metric_time__day
+        , subq_8.bookers
       FROM (
-        -- Aggregate Measures
+        -- Pass Only Elements:
+        --   ['bookers', 'metric_time__day']
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_7.metric_time__day
+          , subq_7.bookers
         FROM (
-          -- Pass Only Elements:
-          --   ['bookings', 'metric_time__day']
+          -- Join to Time Spine Dataset
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.paid_at__day AS paid_at__day
+            , subq_4.paid_at__week AS paid_at__week
+            , subq_4.paid_at__month AS paid_at__month
+            , subq_4.paid_at__quarter AS paid_at__quarter
+            , subq_4.paid_at__year AS paid_at__year
+            , subq_4.paid_at__extract_year AS paid_at__extract_year
+            , subq_4.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_4.paid_at__extract_month AS paid_at__extract_month
+            , subq_4.paid_at__extract_day AS paid_at__extract_day
+            , subq_4.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_4.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_4.booking__ds__day AS booking__ds__day
+            , subq_4.booking__ds__week AS booking__ds__week
+            , subq_4.booking__ds__month AS booking__ds__month
+            , subq_4.booking__ds__quarter AS booking__ds__quarter
+            , subq_4.booking__ds__year AS booking__ds__year
+            , subq_4.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_4.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_4.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_4.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_4.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_4.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_4.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_4.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_4.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_4.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_4.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_4.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_4.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_4.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_4.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_4.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_4.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_4.booking__paid_at__day AS booking__paid_at__day
+            , subq_4.booking__paid_at__week AS booking__paid_at__week
+            , subq_4.booking__paid_at__month AS booking__paid_at__month
+            , subq_4.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_4.booking__paid_at__year AS booking__paid_at__year
+            , subq_4.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_4.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_4.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.listing AS listing
+            , subq_4.guest AS guest
+            , subq_4.host AS host
+            , subq_4.booking__listing AS booking__listing
+            , subq_4.booking__guest AS booking__guest
+            , subq_4.booking__host AS booking__host
+            , subq_4.is_instant AS is_instant
+            , subq_4.booking__is_instant AS booking__is_instant
+            , subq_4.bookings AS bookings
+            , subq_4.instant_bookings AS instant_bookings
+            , subq_4.booking_value AS booking_value
+            , subq_4.max_booking_value AS max_booking_value
+            , subq_4.min_booking_value AS min_booking_value
+            , subq_4.bookers AS bookers
+            , subq_4.average_booking_value AS average_booking_value
+            , subq_4.referred_bookings AS referred_bookings
+            , subq_4.median_booking_value AS median_booking_value
+            , subq_4.booking_value_p99 AS booking_value_p99
+            , subq_4.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Join to Time Spine Dataset
+            -- Date Spine
+            SELECT
+              subq_6.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_6
+            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
+          ) subq_5
+          INNER JOIN (
+            -- Join Self Over Time Range
             SELECT
               subq_2.metric_time__day AS metric_time__day
               , subq_1.ds__day AS ds__day
@@ -105,6 +191,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -260,7 +356,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
@@ -271,7 +367,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
@@ -282,7 +378,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
                   , bookings_source_src_10001.is_instant AS booking__is_instant
                   , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
@@ -294,7 +390,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
                   , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
@@ -305,7 +401,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
                   , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
                   , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
@@ -316,7 +412,7 @@ FROM (
                   , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
                   , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
                   , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
                   , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
                   , bookings_source_src_10001.listing_id AS listing
                   , bookings_source_src_10001.guest_id AS guest
@@ -328,14 +424,19 @@ FROM (
               ) subq_0
             ) subq_1
             ON
-              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+              (
+                subq_1.metric_time__day <= subq_2.metric_time__day
+              ) AND (
+                subq_1.metric_time__day > DATEADD(day, -2, subq_2.metric_time__day)
+              )
           ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+          ON
+            DATEADD(day, -2, subq_5.metric_time__day) = subq_4.metric_time__day
+        ) subq_7
+      ) subq_8
+      WHERE subq_8.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    ) subq_9
+    GROUP BY
+      subq_9.metric_time__day
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_17.metric_time__day AS metric_time__day
+    , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_18
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_17
+  INNER JOIN (
+    -- Join Self Over Time Range
+    SELECT
+      subq_15.ds AS metric_time__day
+      , bookings_source_src_10001.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_15
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_15.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_10001.ds) > DATEADD(day, -2, subq_15.ds)
+      )
+  ) subq_16
+  ON
+    DATEADD(day, -2, subq_17.metric_time__day) = subq_16.metric_time__day
+  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+  GROUP BY
+    subq_17.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0.sql
@@ -1,348 +1,341 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_12.metric_time__day
+  subq_11.metric_time__day
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
+  -- Join to Time Spine Dataset
   SELECT
-    subq_11.metric_time__day
-    , subq_11.bookings_offset_once
+    subq_9.metric_time__day AS metric_time__day
+    , subq_8.bookings_offset_once AS bookings_offset_once
   FROM (
-    -- Join to Time Spine Dataset
+    -- Date Spine
     SELECT
-      subq_9.metric_time__day AS metric_time__day
-      , subq_8.bookings_offset_once AS bookings_offset_once
+      subq_10.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_10
+    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
+  ) subq_9
+  INNER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_7.metric_time__day
+      , 2 * bookings AS bookings_offset_once
     FROM (
-      -- Date Spine
-      SELECT
-        subq_10.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_10
-      WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-    ) subq_9
-    INNER JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_7.metric_time__day
-        , 2 * bookings AS bookings_offset_once
+        subq_6.metric_time__day
+        , subq_6.bookings
       FROM (
-        -- Compute Metrics via Expressions
+        -- Aggregate Measures
         SELECT
-          subq_6.metric_time__day
-          , subq_6.bookings
+          subq_5.metric_time__day
+          , SUM(subq_5.bookings) AS bookings
         FROM (
-          -- Aggregate Measures
+          -- Pass Only Elements:
+          --   ['bookings', 'metric_time__day']
           SELECT
-            subq_5.metric_time__day
-            , SUM(subq_5.bookings) AS bookings
+            subq_4.metric_time__day
+            , subq_4.bookings
           FROM (
-            -- Pass Only Elements:
-            --   ['bookings', 'metric_time__day']
+            -- Join to Time Spine Dataset
             SELECT
-              subq_4.metric_time__day
-              , subq_4.bookings
+              subq_2.metric_time__day AS metric_time__day
+              , subq_1.ds__day AS ds__day
+              , subq_1.ds__week AS ds__week
+              , subq_1.ds__month AS ds__month
+              , subq_1.ds__quarter AS ds__quarter
+              , subq_1.ds__year AS ds__year
+              , subq_1.ds__extract_year AS ds__extract_year
+              , subq_1.ds__extract_quarter AS ds__extract_quarter
+              , subq_1.ds__extract_month AS ds__extract_month
+              , subq_1.ds__extract_day AS ds__extract_day
+              , subq_1.ds__extract_dow AS ds__extract_dow
+              , subq_1.ds__extract_doy AS ds__extract_doy
+              , subq_1.ds_partitioned__day AS ds_partitioned__day
+              , subq_1.ds_partitioned__week AS ds_partitioned__week
+              , subq_1.ds_partitioned__month AS ds_partitioned__month
+              , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+              , subq_1.ds_partitioned__year AS ds_partitioned__year
+              , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+              , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+              , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+              , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+              , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+              , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+              , subq_1.paid_at__day AS paid_at__day
+              , subq_1.paid_at__week AS paid_at__week
+              , subq_1.paid_at__month AS paid_at__month
+              , subq_1.paid_at__quarter AS paid_at__quarter
+              , subq_1.paid_at__year AS paid_at__year
+              , subq_1.paid_at__extract_year AS paid_at__extract_year
+              , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+              , subq_1.paid_at__extract_month AS paid_at__extract_month
+              , subq_1.paid_at__extract_day AS paid_at__extract_day
+              , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+              , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+              , subq_1.booking__ds__day AS booking__ds__day
+              , subq_1.booking__ds__week AS booking__ds__week
+              , subq_1.booking__ds__month AS booking__ds__month
+              , subq_1.booking__ds__quarter AS booking__ds__quarter
+              , subq_1.booking__ds__year AS booking__ds__year
+              , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+              , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+              , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+              , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+              , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+              , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+              , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+              , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+              , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+              , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+              , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+              , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+              , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+              , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+              , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+              , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+              , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+              , subq_1.booking__paid_at__day AS booking__paid_at__day
+              , subq_1.booking__paid_at__week AS booking__paid_at__week
+              , subq_1.booking__paid_at__month AS booking__paid_at__month
+              , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+              , subq_1.booking__paid_at__year AS booking__paid_at__year
+              , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+              , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+              , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+              , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+              , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+              , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.listing AS listing
+              , subq_1.guest AS guest
+              , subq_1.host AS host
+              , subq_1.booking__listing AS booking__listing
+              , subq_1.booking__guest AS booking__guest
+              , subq_1.booking__host AS booking__host
+              , subq_1.is_instant AS is_instant
+              , subq_1.booking__is_instant AS booking__is_instant
+              , subq_1.bookings AS bookings
+              , subq_1.instant_bookings AS instant_bookings
+              , subq_1.booking_value AS booking_value
+              , subq_1.max_booking_value AS max_booking_value
+              , subq_1.min_booking_value AS min_booking_value
+              , subq_1.bookers AS bookers
+              , subq_1.average_booking_value AS average_booking_value
+              , subq_1.referred_bookings AS referred_bookings
+              , subq_1.median_booking_value AS median_booking_value
+              , subq_1.booking_value_p99 AS booking_value_p99
+              , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+              , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+              , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
             FROM (
-              -- Join to Time Spine Dataset
+              -- Date Spine
               SELECT
-                subq_2.metric_time__day AS metric_time__day
-                , subq_1.ds__day AS ds__day
-                , subq_1.ds__week AS ds__week
-                , subq_1.ds__month AS ds__month
-                , subq_1.ds__quarter AS ds__quarter
-                , subq_1.ds__year AS ds__year
-                , subq_1.ds__extract_year AS ds__extract_year
-                , subq_1.ds__extract_quarter AS ds__extract_quarter
-                , subq_1.ds__extract_month AS ds__extract_month
-                , subq_1.ds__extract_day AS ds__extract_day
-                , subq_1.ds__extract_dow AS ds__extract_dow
-                , subq_1.ds__extract_doy AS ds__extract_doy
-                , subq_1.ds_partitioned__day AS ds_partitioned__day
-                , subq_1.ds_partitioned__week AS ds_partitioned__week
-                , subq_1.ds_partitioned__month AS ds_partitioned__month
-                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
-                , subq_1.ds_partitioned__year AS ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
-                , subq_1.paid_at__day AS paid_at__day
-                , subq_1.paid_at__week AS paid_at__week
-                , subq_1.paid_at__month AS paid_at__month
-                , subq_1.paid_at__quarter AS paid_at__quarter
-                , subq_1.paid_at__year AS paid_at__year
-                , subq_1.paid_at__extract_year AS paid_at__extract_year
-                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
-                , subq_1.paid_at__extract_month AS paid_at__extract_month
-                , subq_1.paid_at__extract_day AS paid_at__extract_day
-                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
-                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
-                , subq_1.booking__ds__day AS booking__ds__day
-                , subq_1.booking__ds__week AS booking__ds__week
-                , subq_1.booking__ds__month AS booking__ds__month
-                , subq_1.booking__ds__quarter AS booking__ds__quarter
-                , subq_1.booking__ds__year AS booking__ds__year
-                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
-                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day AS booking__paid_at__day
-                , subq_1.booking__paid_at__week AS booking__paid_at__week
-                , subq_1.booking__paid_at__month AS booking__paid_at__month
-                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
-                , subq_1.booking__paid_at__year AS booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
-                , subq_1.listing AS listing
-                , subq_1.guest AS guest
-                , subq_1.host AS host
-                , subq_1.booking__listing AS booking__listing
-                , subq_1.booking__guest AS booking__guest
-                , subq_1.booking__host AS booking__host
-                , subq_1.is_instant AS is_instant
-                , subq_1.booking__is_instant AS booking__is_instant
-                , subq_1.bookings AS bookings
-                , subq_1.instant_bookings AS instant_bookings
-                , subq_1.booking_value AS booking_value
-                , subq_1.max_booking_value AS max_booking_value
-                , subq_1.min_booking_value AS min_booking_value
-                , subq_1.bookers AS bookers
-                , subq_1.average_booking_value AS average_booking_value
-                , subq_1.referred_bookings AS referred_bookings
-                , subq_1.median_booking_value AS median_booking_value
-                , subq_1.booking_value_p99 AS booking_value_p99
-                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                subq_3.ds AS metric_time__day
+              FROM ***************************.mf_time_spine subq_3
+            ) subq_2
+            INNER JOIN (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Date Spine
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_3.ds AS metric_time__day
-                FROM ***************************.mf_time_spine subq_3
-              ) subq_2
-              INNER JOIN (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_10001.booking_value
-                    , bookings_source_src_10001.booking_value AS max_booking_value
-                    , bookings_source_src_10001.booking_value AS min_booking_value
-                    , bookings_source_src_10001.guest_id AS bookers
-                    , bookings_source_src_10001.booking_value AS average_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_10001.booking_value AS median_booking_value
-                    , bookings_source_src_10001.booking_value AS booking_value_p99
-                    , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_10001.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_10001.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_10001.listing_id AS listing
-                    , bookings_source_src_10001.guest_id AS guest
-                    , bookings_source_src_10001.host_id AS host
-                    , bookings_source_src_10001.listing_id AS booking__listing
-                    , bookings_source_src_10001.guest_id AS booking__guest
-                    , bookings_source_src_10001.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_10001
-                ) subq_0
-              ) subq_1
-              ON
-                DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
-            ) subq_4
-          ) subq_5
-          GROUP BY
-            subq_5.metric_time__day
-        ) subq_6
-      ) subq_7
-    ) subq_8
-    ON
-      DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
-  ) subq_11
-  WHERE subq_11.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_12
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_10001.booking_value
+                  , bookings_source_src_10001.booking_value AS max_booking_value
+                  , bookings_source_src_10001.booking_value AS min_booking_value
+                  , bookings_source_src_10001.guest_id AS bookers
+                  , bookings_source_src_10001.booking_value AS average_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_10001.booking_value AS median_booking_value
+                  , bookings_source_src_10001.booking_value AS booking_value_p99
+                  , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_10001.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_10001.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_10001.listing_id AS listing
+                  , bookings_source_src_10001.guest_id AS guest
+                  , bookings_source_src_10001.host_id AS host
+                  , bookings_source_src_10001.listing_id AS booking__listing
+                  , bookings_source_src_10001.guest_id AS booking__guest
+                  , bookings_source_src_10001.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_10001
+              ) subq_0
+            ) subq_1
+            ON
+              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+          ) subq_4
+        ) subq_5
+        GROUP BY
+          subq_5.metric_time__day
+      ) subq_6
+    ) subq_7
+  ) subq_8
+  ON
+    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -4,17 +4,16 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_22.metric_time__day AS metric_time__day
-    , subq_21.bookings_offset_once AS bookings_offset_once
+    subq_21.metric_time__day AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
   FROM (
     -- Date Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_23
+    FROM ***************************.mf_time_spine subq_22
     WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_22
+  ) subq_21
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -27,9 +26,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_16.ds AS metric_time__day
-        , SUM(subq_14.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_16
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -37,14 +36,13 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
-      ) subq_14
+      ) subq_13
       ON
-        DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
+        DATEADD(day, -5, subq_15.ds) = subq_13.metric_time__day
       GROUP BY
-        subq_16.ds
-    ) subq_20
-  ) subq_21
+        subq_15.ds
+    ) subq_19
+  ) subq_20
   ON
-    DATEADD(day, -2, subq_22.metric_time__day) = subq_21.metric_time__day
-  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_25
+    DATEADD(day, -2, subq_21.metric_time__day) = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,0 +1,321 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__day
+    , subq_6.bookings AS bookings_5_days_ago
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,33 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings', 'metric_time__day']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__day AS metric_time__day
+    , SUM(subq_9.bookings) AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_11
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_10
+  INNER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_10001
+  ) subq_9
+  ON
+    DATEADD(day, -5, subq_10.metric_time__day) = subq_9.metric_time__day
+  GROUP BY
+    subq_10.metric_time__day
+) subq_15

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,42 +1,128 @@
 -- Compute Metrics via Expressions
 SELECT
   subq_11.metric_time__day
-  , 2 * bookings_offset_once AS bookings_offset_twice
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
 FROM (
-  -- Join to Time Spine Dataset
+  -- Compute Metrics via Expressions
   SELECT
-    subq_9.metric_time__day AS metric_time__day
-    , subq_8.bookings_offset_once AS bookings_offset_once
+    subq_10.metric_time__day
+    , subq_10.bookers AS every_2_days_bookers_2_days_ago
   FROM (
-    -- Date Spine
+    -- Aggregate Measures
     SELECT
-      subq_10.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_10
-    WHERE subq_10.ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_9
-  INNER JOIN (
-    -- Compute Metrics via Expressions
-    SELECT
-      subq_7.metric_time__day
-      , 2 * bookings AS bookings_offset_once
+      subq_9.metric_time__day
+      , COUNT(DISTINCT subq_9.bookers) AS bookers
     FROM (
-      -- Compute Metrics via Expressions
+      -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
       SELECT
-        subq_6.metric_time__day
-        , subq_6.bookings
+        subq_8.metric_time__day
+        , subq_8.bookers
       FROM (
-        -- Aggregate Measures
+        -- Pass Only Elements:
+        --   ['bookers', 'metric_time__day']
         SELECT
-          subq_5.metric_time__day
-          , SUM(subq_5.bookings) AS bookings
+          subq_7.metric_time__day
+          , subq_7.bookers
         FROM (
-          -- Pass Only Elements:
-          --   ['bookings', 'metric_time__day']
+          -- Join to Time Spine Dataset
           SELECT
-            subq_4.metric_time__day
-            , subq_4.bookings
+            subq_5.metric_time__day AS metric_time__day
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
+            , subq_4.ds_partitioned__week AS ds_partitioned__week
+            , subq_4.ds_partitioned__month AS ds_partitioned__month
+            , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_4.ds_partitioned__year AS ds_partitioned__year
+            , subq_4.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_4.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_4.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_4.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_4.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_4.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_4.paid_at__day AS paid_at__day
+            , subq_4.paid_at__week AS paid_at__week
+            , subq_4.paid_at__month AS paid_at__month
+            , subq_4.paid_at__quarter AS paid_at__quarter
+            , subq_4.paid_at__year AS paid_at__year
+            , subq_4.paid_at__extract_year AS paid_at__extract_year
+            , subq_4.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_4.paid_at__extract_month AS paid_at__extract_month
+            , subq_4.paid_at__extract_day AS paid_at__extract_day
+            , subq_4.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_4.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_4.booking__ds__day AS booking__ds__day
+            , subq_4.booking__ds__week AS booking__ds__week
+            , subq_4.booking__ds__month AS booking__ds__month
+            , subq_4.booking__ds__quarter AS booking__ds__quarter
+            , subq_4.booking__ds__year AS booking__ds__year
+            , subq_4.booking__ds__extract_year AS booking__ds__extract_year
+            , subq_4.booking__ds__extract_quarter AS booking__ds__extract_quarter
+            , subq_4.booking__ds__extract_month AS booking__ds__extract_month
+            , subq_4.booking__ds__extract_day AS booking__ds__extract_day
+            , subq_4.booking__ds__extract_dow AS booking__ds__extract_dow
+            , subq_4.booking__ds__extract_doy AS booking__ds__extract_doy
+            , subq_4.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_4.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_4.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_4.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_4.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_4.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_4.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_4.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_4.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_4.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_4.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_4.booking__paid_at__day AS booking__paid_at__day
+            , subq_4.booking__paid_at__week AS booking__paid_at__week
+            , subq_4.booking__paid_at__month AS booking__paid_at__month
+            , subq_4.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_4.booking__paid_at__year AS booking__paid_at__year
+            , subq_4.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_4.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_4.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_4.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_4.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_4.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_4.listing AS listing
+            , subq_4.guest AS guest
+            , subq_4.host AS host
+            , subq_4.booking__listing AS booking__listing
+            , subq_4.booking__guest AS booking__guest
+            , subq_4.booking__host AS booking__host
+            , subq_4.is_instant AS is_instant
+            , subq_4.booking__is_instant AS booking__is_instant
+            , subq_4.bookings AS bookings
+            , subq_4.instant_bookings AS instant_bookings
+            , subq_4.booking_value AS booking_value
+            , subq_4.max_booking_value AS max_booking_value
+            , subq_4.min_booking_value AS min_booking_value
+            , subq_4.bookers AS bookers
+            , subq_4.average_booking_value AS average_booking_value
+            , subq_4.referred_bookings AS referred_bookings
+            , subq_4.median_booking_value AS median_booking_value
+            , subq_4.booking_value_p99 AS booking_value_p99
+            , subq_4.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_4.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_4.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
           FROM (
-            -- Join to Time Spine Dataset
+            -- Date Spine
+            SELECT
+              subq_6.ds AS metric_time__day
+            FROM ***************************.mf_time_spine subq_6
+            WHERE subq_6.ds BETWEEN '2019-12-19' AND '2020-01-02'
+          ) subq_5
+          INNER JOIN (
+            -- Join Self Over Time Range
             SELECT
               subq_2.metric_time__day AS metric_time__day
               , subq_1.ds__day AS ds__day
@@ -105,6 +191,16 @@ FROM (
               , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
               , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
               , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+              , subq_1.metric_time__week AS metric_time__week
+              , subq_1.metric_time__month AS metric_time__month
+              , subq_1.metric_time__quarter AS metric_time__quarter
+              , subq_1.metric_time__year AS metric_time__year
+              , subq_1.metric_time__extract_year AS metric_time__extract_year
+              , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_1.metric_time__extract_month AS metric_time__extract_month
+              , subq_1.metric_time__extract_day AS metric_time__extract_day
+              , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_1.metric_time__extract_doy AS metric_time__extract_doy
               , subq_1.listing AS listing
               , subq_1.guest AS guest
               , subq_1.host AS host
@@ -328,14 +424,19 @@ FROM (
               ) subq_0
             ) subq_1
             ON
-              DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+              (
+                subq_1.metric_time__day <= subq_2.metric_time__day
+              ) AND (
+                subq_1.metric_time__day > DATEADD(day, -2, subq_2.metric_time__day)
+              )
           ) subq_4
-        ) subq_5
-        GROUP BY
-          subq_5.metric_time__day
-      ) subq_6
-    ) subq_7
-  ) subq_8
-  ON
-    DATEADD(day, -2, subq_9.metric_time__day) = subq_8.metric_time__day
+          ON
+            DATEADD(day, -2, subq_5.metric_time__day) = subq_4.metric_time__day
+        ) subq_7
+      ) subq_8
+      WHERE subq_8.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+    ) subq_9
+    GROUP BY
+      subq_9.metric_time__day
+  ) subq_10
 ) subq_11

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,42 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , every_2_days_bookers_2_days_ago AS every_2_days_bookers_2_days_ago
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookers', 'metric_time__day']
+  -- Constrain Time Range to [2019-12-19T00:00:00, 2020-01-02T00:00:00]
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_17.metric_time__day AS metric_time__day
+    , COUNT(DISTINCT subq_16.bookers) AS every_2_days_bookers_2_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_18
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_17
+  INNER JOIN (
+    -- Join Self Over Time Range
+    SELECT
+      subq_15.ds AS metric_time__day
+      , bookings_source_src_10001.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_15
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_10001.ds) <= subq_15.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_10001.ds) > DATEADD(day, -2, subq_15.ds)
+      )
+  ) subq_16
+  ON
+    DATEADD(day, -2, subq_17.metric_time__day) = subq_16.metric_time__day
+  WHERE subq_17.metric_time__day BETWEEN '2019-12-19' AND '2020-01-02'
+  GROUP BY
+    subq_17.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_offsets_with_time_constraint__plan0_optimized.sql
@@ -4,17 +4,16 @@ SELECT
   , 2 * bookings_offset_once AS bookings_offset_twice
 FROM (
   -- Join to Time Spine Dataset
-  -- Constrain Time Range to [2020-01-12T00:00:00, 2020-01-13T00:00:00]
   SELECT
-    subq_22.metric_time__day AS metric_time__day
-    , subq_21.bookings_offset_once AS bookings_offset_once
+    subq_21.metric_time__day AS metric_time__day
+    , subq_20.bookings_offset_once AS bookings_offset_once
   FROM (
     -- Date Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_23
+    FROM ***************************.mf_time_spine subq_22
     WHERE ds BETWEEN '2020-01-12' AND '2020-01-13'
-  ) subq_22
+  ) subq_21
   INNER JOIN (
     -- Compute Metrics via Expressions
     SELECT
@@ -27,9 +26,9 @@ FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_16.ds AS metric_time__day
-        , SUM(subq_14.bookings) AS bookings
-      FROM ***************************.mf_time_spine subq_16
+        subq_15.ds AS metric_time__day
+        , SUM(subq_13.bookings) AS bookings
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -37,14 +36,13 @@ FROM (
           DATE_TRUNC('day', ds) AS metric_time__day
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_10001
-      ) subq_14
+      ) subq_13
       ON
-        DATEADD(day, -5, subq_16.ds) = subq_14.metric_time__day
+        DATEADD(day, -5, subq_15.ds) = subq_13.metric_time__day
       GROUP BY
-        subq_16.ds
-    ) subq_20
-  ) subq_21
+        subq_15.ds
+    ) subq_19
+  ) subq_20
   ON
-    DATEADD(day, -2, subq_22.metric_time__day) = subq_21.metric_time__day
-  WHERE subq_22.metric_time__day BETWEEN '2020-01-12' AND '2020-01-13'
-) subq_25
+    DATEADD(day, -2, subq_21.metric_time__day) = subq_20.metric_time__day
+) subq_23

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0.sql
@@ -1,0 +1,321 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_7.metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_6.metric_time__day
+    , subq_6.bookings AS bookings_5_days_ago
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_5.metric_time__day
+      , SUM(subq_5.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements:
+      --   ['bookings', 'metric_time__day']
+      SELECT
+        subq_4.metric_time__day
+        , subq_4.bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        SELECT
+          subq_2.metric_time__day AS metric_time__day
+          , subq_1.ds__day AS ds__day
+          , subq_1.ds__week AS ds__week
+          , subq_1.ds__month AS ds__month
+          , subq_1.ds__quarter AS ds__quarter
+          , subq_1.ds__year AS ds__year
+          , subq_1.ds__extract_year AS ds__extract_year
+          , subq_1.ds__extract_quarter AS ds__extract_quarter
+          , subq_1.ds__extract_month AS ds__extract_month
+          , subq_1.ds__extract_day AS ds__extract_day
+          , subq_1.ds__extract_dow AS ds__extract_dow
+          , subq_1.ds__extract_doy AS ds__extract_doy
+          , subq_1.ds_partitioned__day AS ds_partitioned__day
+          , subq_1.ds_partitioned__week AS ds_partitioned__week
+          , subq_1.ds_partitioned__month AS ds_partitioned__month
+          , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+          , subq_1.ds_partitioned__year AS ds_partitioned__year
+          , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+          , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+          , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+          , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+          , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+          , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+          , subq_1.paid_at__day AS paid_at__day
+          , subq_1.paid_at__week AS paid_at__week
+          , subq_1.paid_at__month AS paid_at__month
+          , subq_1.paid_at__quarter AS paid_at__quarter
+          , subq_1.paid_at__year AS paid_at__year
+          , subq_1.paid_at__extract_year AS paid_at__extract_year
+          , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+          , subq_1.paid_at__extract_month AS paid_at__extract_month
+          , subq_1.paid_at__extract_day AS paid_at__extract_day
+          , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+          , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+          , subq_1.booking__ds__day AS booking__ds__day
+          , subq_1.booking__ds__week AS booking__ds__week
+          , subq_1.booking__ds__month AS booking__ds__month
+          , subq_1.booking__ds__quarter AS booking__ds__quarter
+          , subq_1.booking__ds__year AS booking__ds__year
+          , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+          , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+          , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+          , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+          , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+          , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+          , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+          , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+          , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+          , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+          , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+          , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+          , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+          , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+          , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+          , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+          , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+          , subq_1.booking__paid_at__day AS booking__paid_at__day
+          , subq_1.booking__paid_at__week AS booking__paid_at__week
+          , subq_1.booking__paid_at__month AS booking__paid_at__month
+          , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+          , subq_1.booking__paid_at__year AS booking__paid_at__year
+          , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+          , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+          , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+          , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+          , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+          , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+          , subq_1.listing AS listing
+          , subq_1.guest AS guest
+          , subq_1.host AS host
+          , subq_1.booking__listing AS booking__listing
+          , subq_1.booking__guest AS booking__guest
+          , subq_1.booking__host AS booking__host
+          , subq_1.is_instant AS is_instant
+          , subq_1.booking__is_instant AS booking__is_instant
+          , subq_1.bookings AS bookings
+          , subq_1.instant_bookings AS instant_bookings
+          , subq_1.booking_value AS booking_value
+          , subq_1.max_booking_value AS max_booking_value
+          , subq_1.min_booking_value AS min_booking_value
+          , subq_1.bookers AS bookers
+          , subq_1.average_booking_value AS average_booking_value
+          , subq_1.referred_bookings AS referred_bookings
+          , subq_1.median_booking_value AS median_booking_value
+          , subq_1.booking_value_p99 AS booking_value_p99
+          , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+          , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+          , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+        FROM (
+          -- Date Spine
+          SELECT
+            subq_3.ds AS metric_time__day
+          FROM ***************************.mf_time_spine subq_3
+          WHERE subq_3.ds BETWEEN '2019-12-19' AND '2020-01-02'
+        ) subq_2
+        INNER JOIN (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+        ON
+          DATEADD(day, -5, subq_2.metric_time__day) = subq_1.metric_time__day
+      ) subq_4
+    ) subq_5
+    GROUP BY
+      subq_5.metric_time__day
+  ) subq_6
+) subq_7

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_time_offset_metric_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,33 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , bookings_5_days_ago AS bookings_5_day_lag
+FROM (
+  -- Join to Time Spine Dataset
+  -- Pass Only Elements:
+  --   ['bookings', 'metric_time__day']
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
+  SELECT
+    subq_10.metric_time__day AS metric_time__day
+    , SUM(subq_9.bookings) AS bookings_5_days_ago
+  FROM (
+    -- Date Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_11
+    WHERE ds BETWEEN '2019-12-19' AND '2020-01-02'
+  ) subq_10
+  INNER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_10001
+  ) subq_9
+  ON
+    DATEADD(day, -5, subq_10.metric_time__day) = subq_9.metric_time__day
+  GROUP BY
+    subq_10.metric_time__day
+) subq_15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "PyYAML~=6.0",
   "click>=7.1.2",
   "dbt-core~=1.7.0",
-  "dbt-semantic-interfaces~=0.4.0",
+  "dbt-semantic-interfaces==0.4.2.dev0",
   "graphviz>=0.18.2, <0.21",
   "halo~=0.0.31",
   "more-itertools>=8.10.0, <10.2.0",


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves SL-1357
Resolves #925

### Description
Fixes time constraint issues with time offset metrics. The time constraint was being applied in several places:
1. In the time spine subquery
2. In the input metric subquery
3. After joining the two subqueries
4. In the outer query for the outer derived metric

This PR removes 2 and 4. 
2 is incorrect because the input metric subquery has not had the time offset applied yet, so the constrained values will be incorrect. Plus, one the input metric subquery is joined to the time spine subquery, the time constraint will effectively be applied since the queries use `INNER JOIN` on the time constraint column.
3 is not incorrect, it's just redundant.
4 may appear redundant for cases when all input metrics have offsets, but in the case when one input metric is offset and another is not, it is necessary.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  6. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  7. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
