### PR TITLE
Remove Default Time Constraint for Queries with Cumulative Metrics

### DIFF
--- a/.changes/unreleased/Fixes-20231207-170704.yaml
+++ b/.changes/unreleased/Fixes-20231207-170704.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove default time constraint for queries with cumulative metrics.
+time: 2023-12-07T17:07:04.040509-08:00
+custom:
+  Author: plypaul
+  Issue: "917"

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -427,6 +427,8 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                     else None
                 ),
                 limit=mf_query_request.limit,
+                time_constraint_start=mf_query_request.time_constraint_start,
+                time_constraint_end=mf_query_request.time_constraint_end,
                 order_by_names=mf_query_request.order_by_names,
                 order_by_parameters=mf_query_request.order_by,
             )

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -58,7 +58,6 @@ from metricflow.specs.specs import InstanceSpecSet, MetricFlowQuerySpec
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from metricflow.telemetry.models import TelemetryLevel
 from metricflow.telemetry.reporter import TelemetryReporter, log_call
-from metricflow.time.time_granularity import TimeGranularity
 from metricflow.time.time_source import TimeSource
 
 logger = logging.getLogger(__name__)
@@ -320,7 +319,6 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         sql_client: SqlClient,
         time_source: TimeSource = ServerTimeSource(),
         column_association_resolver: Optional[ColumnAssociationResolver] = None,
-        enable_default_time_constraint: bool = True,
     ) -> None:
         """Initializer for MetricFlowEngine.
 
@@ -328,11 +326,6 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         - time_source
         - column_association_resolver
         - time_spine_source
-        - enable_default_time_constraint: In cases where the time constraint is not specified for cumulative
-        metrics, the time constraint is adjusted to reduce the number of rows produced as cumulative metrics can
-        produce rows for all time values in the time spine. This was added to avoid adding time constraints
-        automatically for tests. This could be removed if automatic adjustment is removed, or when the tests are
-        updated.
 
         These parameters are mainly there to be overridden during tests.
         """
@@ -343,7 +336,6 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         )
         self._time_source = time_source
         self._time_spine_source = semantic_manifest_lookup.time_spine_source
-        self._enable_default_time_constraint = enable_default_time_constraint
         self._source_data_sets: List[SemanticModelDataSet] = []
         converter = SemanticModelToDataSetConverter(column_association_resolver=self._column_association_resolver)
         for semantic_model in sorted(
@@ -452,51 +444,6 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 order_by=mf_query_request.order_by,
             )
         logger.info(f"Query spec is:\n{pformat_big_objects(query_spec)}")
-
-        if (
-            self._semantic_manifest_lookup.metric_lookup.contains_cumulative_or_time_offset_metric(
-                tuple(metric_spec.reference for metric_spec in query_spec.metric_specs)
-            )
-            and self._enable_default_time_constraint
-        ):
-            if self._time_spine_source.time_column_granularity != TimeGranularity.DAY:
-                raise RuntimeError(
-                    f"A time spine source with a granularity {self._time_spine_source.time_column_granularity} is not "
-                    f"yet supported."
-                )
-            logger.warning(
-                f"Query spec requires a time spine dataset conforming to the following spec: {self._time_spine_source}. "
-            )
-            time_constraint_updated = False
-
-            if mf_query_request.time_constraint_start is None:
-                time_constraint_start = self._time_source.get_time() - datetime.timedelta(days=365)
-                logger.warning(
-                    "A start time has not be supplied while querying for cumulative metrics. To avoid an excessive "
-                    f"number of rows, the start time will be changed to {time_constraint_start.isoformat()}"
-                )
-                time_constraint_updated = True
-            else:
-                time_constraint_start = mf_query_request.time_constraint_start
-
-            if not mf_query_request.time_constraint_end:
-                time_constraint_end = self._time_source.get_time()
-                logger.warning(
-                    "A end time has not be supplied while querying for cumulative metrics. To avoid an excessive "
-                    f"number of rows, the end time will be changed to {time_constraint_end.isoformat()}"
-                )
-                time_constraint_updated = True
-            else:
-                time_constraint_end = mf_query_request.time_constraint_end
-
-            if time_constraint_updated:
-                query_spec = query_spec.with_time_range_constraint(
-                    TimeRangeConstraint(
-                        start_time=time_constraint_start,
-                        end_time=time_constraint_end,
-                    )
-                )
-                logger.warning(f"Query spec updated to:\n{pformat_big_objects(query_spec)}")
 
         output_table: Optional[SqlTable] = None
         if mf_query_request.output_table is not None:

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -188,6 +188,8 @@ class MetricFlowQueryParser:
         saved_query_parameter: SavedQueryParameter,
         where_filter: Optional[WhereFilter],
         limit: Optional[int],
+        time_constraint_start: Optional[datetime.datetime],
+        time_constraint_end: Optional[datetime.datetime],
         order_by_names: Optional[Sequence[str]],
         order_by_parameters: Optional[Sequence[OrderByQueryParameter]],
     ) -> MetricFlowQuerySpec:
@@ -211,6 +213,8 @@ class MetricFlowQueryParser:
                 for group_by_item_name in saved_query.query_params.group_by
             ),
             where_constraint=merge_to_single_where_filter(PydanticWhereFilterIntersection(where_filters=where_filters)),
+            time_constraint_start=time_constraint_start,
+            time_constraint_end=time_constraint_end,
             limit=limit,
             order_by_names=order_by_names,
             order_by=order_by_parameters,

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -271,7 +271,17 @@ def test_saved_query_with_cumulative_metric(  # noqa: D
     sql_client: SqlClient,
 ) -> None:
     resp = cli_runner.run(
-        query, args=["--saved-query", "saved_query_with_cumulative_metric", "--order", "metric_time__day"]
+        query,
+        args=[
+            "--saved-query",
+            "saved_query_with_cumulative_metric",
+            "--order",
+            "metric_time__day",
+            "--start-time",
+            "2020-01-01",
+            "--end-time",
+            "2020-01-01",
+        ],
     )
 
     assert_object_snapshot_equal(

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -252,7 +252,6 @@ def test_case(
         sql_client=sql_client,
         column_association_resolver=DunderColumnAssociationResolver(semantic_manifest_lookup),
         time_source=ConfigurableTimeSource(as_datetime("2021-01-04")),
-        enable_default_time_constraint=False,
     )
 
     check_query_helpers = CheckQueryHelpers(sql_client)


### PR DESCRIPTION
Resolves #917

### Description

A previous change (https://github.com/dbt-labs/metricflow/pull/918) updated the logic to apply a default time constraint for queries with cumulative metrics if one was not supplied. However, the fix revealed that the feature was not working for some time, possibly since the public release. I also realized that the original logic (and also the fix) is not correct with derived metrics that use cumulative metrics. There is future work to better handle time constraints / predicate push down, so removing this for now.

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
