### PR TITLE
Return exit code 1 for failed validations

### DIFF
--- a/.changes/unreleased/Fixes-20231215-154356.yaml
+++ b/.changes/unreleased/Fixes-20231215-154356.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Return exit code 1 for failed validations
+time: 2023-12-15T15:43:56.503346-05:00
+custom:
+  Author: WilliamDee
+  Issue: "867"

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -639,7 +639,7 @@ def validate_configs(
         parsing_spinner.succeed("🎉 Successfully parsed manifest from dbt project")
     except Exception as e:
         parsing_spinner.fail(f"Exception found when parsing manifest from dbt project ({str(e)})")
-        return
+        exit(1)
 
     # Semantic validation
     semantic_spinner = Halo(text="Validating semantics of built manifest", spinner="dots")
@@ -655,7 +655,7 @@ def validate_configs(
             f"Breaking issues found when checking semantics of built manifest ({model_issues.summary()})"
         )
         _print_issues(model_issues, show_non_blocking=show_all, verbose=verbose_issues)
-        return
+        exit(1)
 
     dw_results = SemanticManifestValidationResults()
     if not skip_dw:
@@ -667,6 +667,8 @@ def validate_configs(
 
     merged_results = SemanticManifestValidationResults.merge([model_issues, dw_results])
     _print_issues(merged_results, show_non_blocking=show_all, verbose=verbose_issues)
+    if merged_results.has_blocking_issues:
+        exit(1)
 
 
 if __name__ == "__main__":

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -126,7 +126,7 @@ def test_validate_configs(cli_context: CLIContext) -> None:
             resp = cli_runner.run(validate_configs)
 
         assert "ERROR" in resp.output
-        assert resp.exit_code == 0
+        assert resp.exit_code == 1
 
     finally:
         dummy_project.unlink()


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves #867 


### Description
When an exception happens in validate-configs on the CLI, return exit code 1.

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
