### PR TITLE
Add a Validation Rule for Duplicate Metrics in a Query

### DIFF
--- a/.changes/unreleased/Features-20231218-121506.yaml
+++ b/.changes/unreleased/Features-20231218-121506.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add a Query Validation Rule for Repeated Metrics in a Query
+time: 2023-12-18T12:15:06.224541-08:00
+custom:
+  Author: plypaul
+  Issue: "943"

--- a/metricflow/query/issues/parsing/duplicate_metric.py
+++ b/metricflow/query/issues/parsing/duplicate_metric.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
+from dbt_semantic_interfaces.references import MetricReference
+from typing_extensions import override
+
+from metricflow.query.group_by_item.resolution_dag.resolution_nodes.base_node import GroupByItemResolutionNode
+from metricflow.query.group_by_item.resolution_path import MetricFlowQueryResolutionPath
+from metricflow.query.issues.issues_base import (
+    MetricFlowQueryIssueType,
+    MetricFlowQueryResolutionIssue,
+)
+from metricflow.query.resolver_inputs.base_resolver_inputs import MetricFlowQueryResolverInput
+
+
+@dataclass(frozen=True)
+class DuplicateMetricIssue(MetricFlowQueryResolutionIssue):
+    """Describes when there are duplicate metrics in a query."""
+
+    duplicate_metric_references: Tuple[MetricReference, ...]
+
+    @staticmethod
+    def from_parameters(  # noqa: D
+        duplicate_metric_references: Sequence[MetricReference],
+        query_resolution_path: MetricFlowQueryResolutionPath,
+    ) -> DuplicateMetricIssue:
+        return DuplicateMetricIssue(
+            issue_type=MetricFlowQueryIssueType.ERROR,
+            parent_issues=(),
+            duplicate_metric_references=tuple(duplicate_metric_references),
+            query_resolution_path=query_resolution_path,
+        )
+
+    @override
+    def ui_description(self, associated_input: MetricFlowQueryResolverInput) -> str:
+        return (
+            f"Query contains duplicate metrics: "
+            f"{[metric_reference.element_name for metric_reference in self.duplicate_metric_references]}"
+        )
+
+    @override
+    def with_path_prefix(self, path_prefix_node: GroupByItemResolutionNode) -> DuplicateMetricIssue:
+        return DuplicateMetricIssue(
+            issue_type=self.issue_type,
+            parent_issues=tuple(issue.with_path_prefix(path_prefix_node) for issue in self.parent_issues),
+            query_resolution_path=self.query_resolution_path.with_path_prefix(path_prefix_node),
+            duplicate_metric_references=self.duplicate_metric_references,
+        )

--- a/metricflow/query/validation_rules/base_validation_rule.py
+++ b/metricflow/query/validation_rules/base_validation_rule.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Sequence
 
-from dbt_semantic_interfaces.protocols import Metric
+from dbt_semantic_interfaces.protocols import Metric, WhereFilterIntersection
 from dbt_semantic_interfaces.references import MetricReference
 
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
@@ -12,12 +13,7 @@ from metricflow.query.resolver_inputs.query_resolver_inputs import ResolverInput
 
 
 class PostResolutionQueryValidationRule(ABC):
-    """A validation rule that runs after all query inputs have been resolved to specs.
-
-    In a previous implementation, there were more validation rules, but many of those validation rules were rolled into
-    checks in the GroupByItemResolver. Consequently, there is only one validation rule, and it is TBD whether this
-    abstraction is necessary.
-    """
+    """A validation rule that runs after all query inputs have been resolved to specs."""
 
     def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
         self._manifest_lookup = manifest_lookup
@@ -35,5 +31,19 @@ class PostResolutionQueryValidationRule(ABC):
         """Given a metric that exists in a resolution DAG, check that the query is valid.
 
         This is called for each metric as the resolution DAG is traversed.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def validate_query_in_resolution_dag(
+        self,
+        metrics_in_query: Sequence[MetricReference],
+        where_filter_intersection: WhereFilterIntersection,
+        resolver_input_for_query: ResolverInputForQuery,
+        resolution_path: MetricFlowQueryResolutionPath,
+    ) -> MetricFlowQueryResolutionIssueSet:
+        """Validate the parameters to the query are valid.
+
+        This will be call once at the query node in the resolution DAG.
         """
         raise NotImplementedError

--- a/metricflow/query/validation_rules/duplicate_metric.py
+++ b/metricflow/query/validation_rules/duplicate_metric.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+from dbt_semantic_interfaces.protocols import WhereFilterIntersection
+from dbt_semantic_interfaces.references import MetricReference
+from typing_extensions import override
+
+from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow.query.group_by_item.resolution_path import MetricFlowQueryResolutionPath
+from metricflow.query.issues.issues_base import MetricFlowQueryResolutionIssueSet
+from metricflow.query.issues.parsing.duplicate_metric import DuplicateMetricIssue
+from metricflow.query.resolver_inputs.query_resolver_inputs import ResolverInputForQuery
+from metricflow.query.validation_rules.base_validation_rule import PostResolutionQueryValidationRule
+
+logger = logging.getLogger(__name__)
+
+
+class DuplicateMetricValidationRule(PostResolutionQueryValidationRule):
+    """Validates that a query does not include the same metric multiple times."""
+
+    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
+        super().__init__(manifest_lookup=manifest_lookup)
+
+    @override
+    def validate_metric_in_resolution_dag(
+        self,
+        metric_reference: MetricReference,
+        resolver_input_for_query: ResolverInputForQuery,
+        resolution_path: MetricFlowQueryResolutionPath,
+    ) -> MetricFlowQueryResolutionIssueSet:
+        return MetricFlowQueryResolutionIssueSet.empty_instance()
+
+    @override
+    def validate_query_in_resolution_dag(
+        self,
+        metrics_in_query: Sequence[MetricReference],
+        where_filter_intersection: WhereFilterIntersection,
+        resolver_input_for_query: ResolverInputForQuery,
+        resolution_path: MetricFlowQueryResolutionPath,
+    ) -> MetricFlowQueryResolutionIssueSet:
+        duplicate_metric_references = tuple(
+            sorted(
+                metric_reference
+                for metric_reference in set(metrics_in_query)
+                if metrics_in_query.count(metric_reference) > 1
+            )
+        )
+
+        if len(duplicate_metric_references) > 0:
+            return MetricFlowQueryResolutionIssueSet.from_issue(
+                DuplicateMetricIssue.from_parameters(
+                    query_resolution_path=resolution_path, duplicate_metric_references=duplicate_metric_references
+                )
+            )
+
+        return MetricFlowQueryResolutionIssueSet.empty_instance()

--- a/metricflow/query/validation_rules/metric_time_requirements.py
+++ b/metricflow/query/validation_rules/metric_time_requirements.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Sequence
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
+from dbt_semantic_interfaces.protocols import WhereFilterIntersection
 from dbt_semantic_interfaces.references import MetricReference
 from dbt_semantic_interfaces.type_enums import MetricType, TimeGranularity
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
@@ -107,3 +108,13 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
             return MetricFlowQueryResolutionIssueSet.empty_instance()
         else:
             assert_values_exhausted(metric.type)
+
+    @override
+    def validate_query_in_resolution_dag(
+        self,
+        metrics_in_query: Sequence[MetricReference],
+        where_filter_intersection: WhereFilterIntersection,
+        resolver_input_for_query: ResolverInputForQuery,
+        resolution_path: MetricFlowQueryResolutionPath,
+    ) -> MetricFlowQueryResolutionIssueSet:
+        return MetricFlowQueryResolutionIssueSet.empty_instance()

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -584,3 +584,11 @@ def test_date_part_parsing() -> None:
         metric_names=["revenue"],
         group_by=(TimeDimensionParameter(name="metric_time", date_part=DatePart.MONTH),),
     )
+
+
+def test_duplicate_metric_query(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
+    with pytest.raises(InvalidQueryException, match="duplicate metrics"):
+        bookings_query_parser.parse_and_validate_query(
+            metric_names=["bookings", "bookings"],
+            group_by_names=[MTD],
+        )


### PR DESCRIPTION
Resolves #943 

### Description

This PR add a validation to check that queries do not contain the same metric more than once, as that would result in a duplicate column in the generated SQL.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
