### PR TITLE
Fix Optimizer to Dedupe Cases Where a Metric Is Used More Than Once

### DIFF
--- a/.changes/unreleased/Fixes-20231215-141744.yaml
+++ b/.changes/unreleased/Fixes-20231215-141744.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Optimizer Does Not Deduplicate Common Metrics
+time: 2023-12-15T14:17:44.7035-08:00
+custom:
+  Author: plypaul
+  Issue: "941"

--- a/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
+++ b/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
@@ -27,6 +27,7 @@ from metricflow.dataflow.dataflow_plan import (
     WriteToResultTableNode,
 )
 from metricflow.dataflow.optimizer.source_scan.matching_linkable_specs import MatchingLinkableSpecsTransform
+from metricflow.specs.specs import MetricSpec
 
 logger = logging.getLogger(__name__)
 
@@ -283,9 +284,17 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         assert len(combined_parent_nodes) == 1
         combined_parent_node = combined_parent_nodes[0]
         assert combined_parent_node is not None
+
+        # Dedupe (preserving order for output consistency) as it's possible for multiple derived metrics to use the same
+        # metric.
+        unique_metric_specs: List[MetricSpec] = []
+        for metric_spec in self._current_left_node.metric_specs + current_right_node.metric_specs:
+            if metric_spec not in unique_metric_specs:
+                unique_metric_specs.append(metric_spec)
+
         combined_node = ComputeMetricsNode(
             parent_node=combined_parent_node,
-            metric_specs=self._current_left_node.metric_specs + current_right_node.metric_specs,
+            metric_specs=unique_metric_specs,
         )
         self._log_combine_success(
             left_node=self._current_left_node,

--- a/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
@@ -350,3 +350,26 @@ def test_2_ratio_metrics_from_1_semantic_model(  # noqa: D
         expected_num_sources_in_unoptimized=4,
         expected_num_sources_in_optimized=1,
     )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_duplicate_measures(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+) -> None:
+    """Tests a case where derived metrics in a query use the same measure (in the same form e.g. filters)."""
+    check_optimization(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=MetricFlowQuerySpec(
+            metric_specs=(
+                MetricSpec(element_name="derived_bookings_0"),
+                MetricSpec(element_name="derived_bookings_1"),
+            ),
+            dimension_specs=(DataSet.metric_time_dimension_spec(TimeGranularity.DAY),),
+        ),
+        expected_num_sources_in_unoptimized=2,
+        expected_num_sources_in_optimized=1,
+    )

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/metrics.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/metrics.yaml
@@ -662,3 +662,21 @@ metric:
         offset_to_grain: month
         alias: booking_fees_start_of_month
       - name: booking_fees
+---
+metric:
+  name: "derived_bookings_0"
+  description: Derived metric for testing optimizations for duplicate measures in a query.
+  type: derived
+  type_params:
+    expr: bookings
+    metrics:
+      - name: bookings
+---
+metric:
+  name: "derived_bookings_1"
+  description: Derived metric for testing optimizations for duplicate measures in a query.
+  type: derived
+  type_params:
+    expr: bookings
+    metrics:
+      - name: bookings

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfpo_0.xml
@@ -36,13 +36,6 @@
                 <!--    'alias': None,              -->
                 <!--    'offset_window': None,      -->
                 <!--    'offset_to_grain': None}    -->
-                <!-- metric_spec =                   -->
-                <!--   {'class': 'MetricSpec',       -->
-                <!--    'element_name': 'bookings',  -->
-                <!--    'filter_specs': (),          -->
-                <!--    'alias': None,               -->
-                <!--    'offset_window': None,       -->
-                <!--    'offset_to_grain': None}     -->
                 <!-- metric_spec =                        -->
                 <!--   {'class': 'MetricSpec',            -->
                 <!--    'element_name': 'booking_value',  -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfp_0.xml
@@ -1,0 +1,124 @@
+<DataflowPlan>
+    <WriteToResultDataframeNode>
+        <!-- description = Write to Dataframe -->
+        <!-- node_id = wrd_0 -->
+        <CombineAggregatedOutputsNode>
+            <!-- description = Combine Aggregated Outputs -->
+            <!-- node_id = cao_0 -->
+            <ComputeMetricsNode>
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = cm_1 -->
+                <!-- metric_spec =                             -->
+                <!--   {'class': 'MetricSpec',                 -->
+                <!--    'element_name': 'derived_bookings_0',  -->
+                <!--    'constraint': None,                    -->
+                <!--    'alias': None,                         -->
+                <!--    'offset_window': None,                 -->
+                <!--    'offset_to_grain': None}               -->
+                <ComputeMetricsNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = cm_0 -->
+                    <!-- metric_spec =                   -->
+                    <!--   {'class': 'MetricSpec',       -->
+                    <!--    'element_name': 'bookings',  -->
+                    <!--    'constraint': None,          -->
+                    <!--    'alias': None,               -->
+                    <!--    'offset_window': None,       -->
+                    <!--    'offset_to_grain': None}     -->
+                    <AggregateMeasuresNode>
+                        <!-- description = Aggregate Measures -->
+                        <!-- node_id = am_0 -->
+                        <FilterElementsNode>
+                            <!-- description =                         -->
+                            <!--   Pass Only Elements:                 -->
+                            <!--     ['bookings', 'metric_time__day']  -->
+                            <!-- node_id = pfe_0 -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'bookings',           -->
+                            <!--    'non_additive_dimension_spec': None,  -->
+                            <!--    'fill_nulls_with': None}              -->
+                            <!-- include_spec =                               -->
+                            <!--   {'class': 'TimeDimensionSpec',             -->
+                            <!--    'element_name': 'metric_time',            -->
+                            <!--    'entity_links': (),                       -->
+                            <!--    'time_granularity': TimeGranularity.DAY,  -->
+                            <!--    'date_part': None,                        -->
+                            <!--    'aggregation_state': None}                -->
+                            <!-- distinct = False -->
+                            <MetricTimeDimensionTransformNode>
+                                <!-- description = Metric Time Dimension 'ds' -->
+                                <!-- node_id = sma_10001 -->
+                                <!-- aggregation_time_dimension = ds -->
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                                    -->
+                                    <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                    <!-- node_id = rss_10011 -->
+                                    <!-- data_set =                                                                             -->
+                                    <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                </ReadSqlSourceNode>
+                            </MetricTimeDimensionTransformNode>
+                        </FilterElementsNode>
+                    </AggregateMeasuresNode>
+                </ComputeMetricsNode>
+            </ComputeMetricsNode>
+            <ComputeMetricsNode>
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = cm_3 -->
+                <!-- metric_spec =                             -->
+                <!--   {'class': 'MetricSpec',                 -->
+                <!--    'element_name': 'derived_bookings_1',  -->
+                <!--    'constraint': None,                    -->
+                <!--    'alias': None,                         -->
+                <!--    'offset_window': None,                 -->
+                <!--    'offset_to_grain': None}               -->
+                <ComputeMetricsNode>
+                    <!-- description = Compute Metrics via Expressions -->
+                    <!-- node_id = cm_2 -->
+                    <!-- metric_spec =                   -->
+                    <!--   {'class': 'MetricSpec',       -->
+                    <!--    'element_name': 'bookings',  -->
+                    <!--    'constraint': None,          -->
+                    <!--    'alias': None,               -->
+                    <!--    'offset_window': None,       -->
+                    <!--    'offset_to_grain': None}     -->
+                    <AggregateMeasuresNode>
+                        <!-- description = Aggregate Measures -->
+                        <!-- node_id = am_1 -->
+                        <FilterElementsNode>
+                            <!-- description =                         -->
+                            <!--   Pass Only Elements:                 -->
+                            <!--     ['bookings', 'metric_time__day']  -->
+                            <!-- node_id = pfe_1 -->
+                            <!-- include_spec =                           -->
+                            <!--   {'class': 'MeasureSpec',               -->
+                            <!--    'element_name': 'bookings',           -->
+                            <!--    'non_additive_dimension_spec': None,  -->
+                            <!--    'fill_nulls_with': None}              -->
+                            <!-- include_spec =                               -->
+                            <!--   {'class': 'TimeDimensionSpec',             -->
+                            <!--    'element_name': 'metric_time',            -->
+                            <!--    'entity_links': (),                       -->
+                            <!--    'time_granularity': TimeGranularity.DAY,  -->
+                            <!--    'date_part': None,                        -->
+                            <!--    'aggregation_state': None}                -->
+                            <!-- distinct = False -->
+                            <MetricTimeDimensionTransformNode>
+                                <!-- description = Metric Time Dimension 'ds' -->
+                                <!-- node_id = sma_10001 -->
+                                <!-- aggregation_time_dimension = ds -->
+                                <ReadSqlSourceNode>
+                                    <!-- description =                                                                                    -->
+                                    <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                    <!-- node_id = rss_10011 -->
+                                    <!-- data_set =                                                                             -->
+                                    <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                </ReadSqlSourceNode>
+                            </MetricTimeDimensionTransformNode>
+                        </FilterElementsNode>
+                    </AggregateMeasuresNode>
+                </ComputeMetricsNode>
+            </ComputeMetricsNode>
+        </CombineAggregatedOutputsNode>
+    </WriteToResultDataframeNode>
+</DataflowPlan>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfp_0.xml
@@ -11,7 +11,7 @@
                 <!-- metric_spec =                             -->
                 <!--   {'class': 'MetricSpec',                 -->
                 <!--    'element_name': 'derived_bookings_0',  -->
-                <!--    'constraint': None,                    -->
+                <!--    'filter_specs': (),                    -->
                 <!--    'alias': None,                         -->
                 <!--    'offset_window': None,                 -->
                 <!--    'offset_to_grain': None}               -->
@@ -21,7 +21,7 @@
                     <!-- metric_spec =                   -->
                     <!--   {'class': 'MetricSpec',       -->
                     <!--    'element_name': 'bookings',  -->
-                    <!--    'constraint': None,          -->
+                    <!--    'filter_specs': (),          -->
                     <!--    'alias': None,               -->
                     <!--    'offset_window': None,       -->
                     <!--    'offset_to_grain': None}     -->
@@ -53,7 +53,7 @@
                                 <ReadSqlSourceNode>
                                     <!-- description =                                                                                    -->
                                     <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
-                                    <!-- node_id = rss_10011 -->
+                                    <!-- node_id = rss_10013 -->
                                     <!-- data_set =                                                                             -->
                                     <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
                                 </ReadSqlSourceNode>
@@ -68,7 +68,7 @@
                 <!-- metric_spec =                             -->
                 <!--   {'class': 'MetricSpec',                 -->
                 <!--    'element_name': 'derived_bookings_1',  -->
-                <!--    'constraint': None,                    -->
+                <!--    'filter_specs': (),                    -->
                 <!--    'alias': None,                         -->
                 <!--    'offset_window': None,                 -->
                 <!--    'offset_to_grain': None}               -->
@@ -78,7 +78,7 @@
                     <!-- metric_spec =                   -->
                     <!--   {'class': 'MetricSpec',       -->
                     <!--    'element_name': 'bookings',  -->
-                    <!--    'constraint': None,          -->
+                    <!--    'filter_specs': (),          -->
                     <!--    'alias': None,               -->
                     <!--    'offset_window': None,       -->
                     <!--    'offset_to_grain': None}     -->
@@ -110,7 +110,7 @@
                                 <ReadSqlSourceNode>
                                     <!-- description =                                                                                    -->
                                     <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
-                                    <!-- node_id = rss_10011 -->
+                                    <!-- node_id = rss_10013 -->
                                     <!-- data_set =                                                                             -->
                                     <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
                                 </ReadSqlSourceNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfpo_0.xml
@@ -1,0 +1,77 @@
+<DataflowPlan>
+    <WriteToResultDataframeNode>
+        <!-- description = Write to Dataframe -->
+        <!-- node_id = wrd_1 -->
+        <ComputeMetricsNode>
+            <!-- description = Compute Metrics via Expressions -->
+            <!-- node_id = cm_9 -->
+            <!-- metric_spec =                             -->
+            <!--   {'class': 'MetricSpec',                 -->
+            <!--    'element_name': 'derived_bookings_0',  -->
+            <!--    'constraint': None,                    -->
+            <!--    'alias': None,                         -->
+            <!--    'offset_window': None,                 -->
+            <!--    'offset_to_grain': None}               -->
+            <!-- metric_spec =                             -->
+            <!--   {'class': 'MetricSpec',                 -->
+            <!--    'element_name': 'derived_bookings_1',  -->
+            <!--    'constraint': None,                    -->
+            <!--    'alias': None,                         -->
+            <!--    'offset_window': None,                 -->
+            <!--    'offset_to_grain': None}               -->
+            <ComputeMetricsNode>
+                <!-- description = Compute Metrics via Expressions -->
+                <!-- node_id = cm_8 -->
+                <!-- metric_spec =                   -->
+                <!--   {'class': 'MetricSpec',       -->
+                <!--    'element_name': 'bookings',  -->
+                <!--    'constraint': None,          -->
+                <!--    'alias': None,               -->
+                <!--    'offset_window': None,       -->
+                <!--    'offset_to_grain': None}     -->
+                <!-- metric_spec =                   -->
+                <!--   {'class': 'MetricSpec',       -->
+                <!--    'element_name': 'bookings',  -->
+                <!--    'constraint': None,          -->
+                <!--    'alias': None,               -->
+                <!--    'offset_window': None,       -->
+                <!--    'offset_to_grain': None}     -->
+                <AggregateMeasuresNode>
+                    <!-- description = Aggregate Measures -->
+                    <!-- node_id = am_4 -->
+                    <FilterElementsNode>
+                        <!-- description =                         -->
+                        <!--   Pass Only Elements:                 -->
+                        <!--     ['bookings', 'metric_time__day']  -->
+                        <!-- node_id = pfe_4 -->
+                        <!-- include_spec =                           -->
+                        <!--   {'class': 'MeasureSpec',               -->
+                        <!--    'element_name': 'bookings',           -->
+                        <!--    'non_additive_dimension_spec': None,  -->
+                        <!--    'fill_nulls_with': None}              -->
+                        <!-- include_spec =                               -->
+                        <!--   {'class': 'TimeDimensionSpec',             -->
+                        <!--    'element_name': 'metric_time',            -->
+                        <!--    'entity_links': (),                       -->
+                        <!--    'time_granularity': TimeGranularity.DAY,  -->
+                        <!--    'date_part': None,                        -->
+                        <!--    'aggregation_state': None}                -->
+                        <!-- distinct = False -->
+                        <MetricTimeDimensionTransformNode>
+                            <!-- description = Metric Time Dimension 'ds' -->
+                            <!-- node_id = sma_2 -->
+                            <!-- aggregation_time_dimension = ds -->
+                            <ReadSqlSourceNode>
+                                <!-- description =                                                                                    -->
+                                <!--   Read From SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                                <!-- node_id = rss_2 -->
+                                <!-- data_set =                                                                             -->
+                                <!--   SemanticModelDataSet(SemanticModelReference(semantic_model_name='bookings_source'))  -->
+                            </ReadSqlSourceNode>
+                        </MetricTimeDimensionTransformNode>
+                    </FilterElementsNode>
+                </AggregateMeasuresNode>
+            </ComputeMetricsNode>
+        </ComputeMetricsNode>
+    </WriteToResultDataframeNode>
+</DataflowPlan>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfpo_0.xml
@@ -8,14 +8,14 @@
             <!-- metric_spec =                             -->
             <!--   {'class': 'MetricSpec',                 -->
             <!--    'element_name': 'derived_bookings_0',  -->
-            <!--    'constraint': None,                    -->
+            <!--    'filter_specs': (),                    -->
             <!--    'alias': None,                         -->
             <!--    'offset_window': None,                 -->
             <!--    'offset_to_grain': None}               -->
             <!-- metric_spec =                             -->
             <!--   {'class': 'MetricSpec',                 -->
             <!--    'element_name': 'derived_bookings_1',  -->
-            <!--    'constraint': None,                    -->
+            <!--    'filter_specs': (),                    -->
             <!--    'alias': None,                         -->
             <!--    'offset_window': None,                 -->
             <!--    'offset_to_grain': None}               -->
@@ -25,14 +25,7 @@
                 <!-- metric_spec =                   -->
                 <!--   {'class': 'MetricSpec',       -->
                 <!--    'element_name': 'bookings',  -->
-                <!--    'constraint': None,          -->
-                <!--    'alias': None,               -->
-                <!--    'offset_window': None,       -->
-                <!--    'offset_to_grain': None}     -->
-                <!-- metric_spec =                   -->
-                <!--   {'class': 'MetricSpec',       -->
-                <!--    'element_name': 'bookings',  -->
-                <!--    'constraint': None,          -->
+                <!--    'filter_specs': (),          -->
                 <!--    'alias': None,               -->
                 <!--    'offset_window': None,       -->
                 <!--    'offset_to_grain': None}     -->


### PR DESCRIPTION
# Resolves #


### Description

If there are multiple derived metrics in a query that use the same metric, it's
possible that the same metric is used multiple times. In such cases, the metric
should be deduped so that we don't get a collision in the colum name.
