### PR TITLE
Allow Partial Entity Paths in Group-By-Items

### DIFF
--- a/metricflow/query/issues/group_by_item_resolver/multiple_join_paths.py
+++ b/metricflow/query/issues/group_by_item_resolver/multiple_join_paths.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import Sequence
 
 from typing_extensions import override
 
@@ -18,47 +18,52 @@ from metricflow.query.resolver_inputs.base_resolver_inputs import MetricFlowQuer
 
 
 @dataclass(frozen=True)
-class AmbiguousGroupByItemIssue(MetricFlowQueryResolutionIssue):
-    """Describes an issue with the query where the input is ambiguous and it can't be resolved."""
+class MultipleMatchIssue(MetricFlowQueryResolutionIssue):
+    """Describes an issue during group-by-item resolution the input pattern matches multiple specs."""
 
     candidate_set: GroupByItemCandidateSet
 
     @staticmethod
     def from_parameters(  # noqa: D
-        candidate_set: GroupByItemCandidateSet,
         query_resolution_path: MetricFlowQueryResolutionPath,
-    ) -> AmbiguousGroupByItemIssue:
-        return AmbiguousGroupByItemIssue(
+        candidate_set: GroupByItemCandidateSet,
+        parent_issues: Sequence[MetricFlowQueryResolutionIssue],
+    ) -> MultipleMatchIssue:
+        return MultipleMatchIssue(
             issue_type=MetricFlowQueryIssueType.ERROR,
-            parent_issues=(),
-            candidate_set=candidate_set,
             query_resolution_path=query_resolution_path,
+            candidate_set=candidate_set,
+            parent_issues=tuple(parent_issues),
         )
 
     @override
     def ui_description(self, associated_input: MetricFlowQueryResolverInput) -> str:
-        if associated_input.input_pattern_description is not None:
-            naming_scheme = associated_input.input_pattern_description.naming_scheme
-        else:
-            naming_scheme = ObjectBuilderNamingScheme()
-        candidates_str: List[str] = []
+        last_path_item = self.query_resolution_path.last_item
+        naming_scheme = (
+            associated_input.input_pattern_description.naming_scheme
+            if associated_input.input_pattern_description is not None
+            else ObjectBuilderNamingScheme()
+        )
 
+        specs_as_strs = []
         for spec in self.candidate_set.specs:
             input_str = naming_scheme.input_str(spec)
             if input_str is not None:
-                candidates_str.append(input_str)
+                specs_as_strs.append(input_str)
             else:
-                candidates_str.append(str(spec))
+                specs_as_strs.append(f"<{repr(spec)}>")
+
         return (
-            f"The given input is ambiguous and can't be resolved. The input could match:\n\n"
-            f"{indent(mf_pformat(sorted(candidates_str)))}"
+            f"The given input matches multiple group-by-items for {last_path_item.ui_description}:\n\n"
+            f"{indent(mf_pformat(specs_as_strs))}\n\n"
+            f"Please use a more specific input to resolve the ambiguity."
         )
 
     @override
-    def with_path_prefix(self, path_prefix: MetricFlowQueryResolutionPath) -> AmbiguousGroupByItemIssue:
-        return AmbiguousGroupByItemIssue(
+    def with_path_prefix(self, path_prefix: MetricFlowQueryResolutionPath) -> MultipleMatchIssue:
+        return MultipleMatchIssue(
             issue_type=self.issue_type,
             parent_issues=tuple(issue.with_path_prefix(path_prefix) for issue in self.parent_issues),
             query_resolution_path=self.query_resolution_path.with_path_prefix(path_prefix),
-            candidate_set=self.candidate_set,
+            candidate_set=self.candidate_set.with_path_prefix(path_prefix),
         )

--- a/metricflow/test/fixtures/model_fixtures.py
+++ b/metricflow/test/fixtures/model_fixtures.py
@@ -303,3 +303,17 @@ def ambiguous_resolution_manifest_lookup(  # noqa: D
     ambiguous_resolution_manifest: PydanticSemanticManifest,
 ) -> SemanticManifestLookup:
     return SemanticManifestLookup(ambiguous_resolution_manifest)
+
+
+@pytest.fixture(scope="session")
+def simple_multi_hop_join_manifest(template_mapping: Dict[str, str]) -> PydanticSemanticManifest:  # noqa: D
+    build_result = load_semantic_manifest("simple_multi_hop_join_manifest", template_mapping)
+    return build_result.semantic_manifest
+
+
+@pytest.fixture(scope="session")
+def simple_multi_hop_join_manifest_lookup(  # noqa: D
+    simple_multi_hop_join_manifest: PydanticSemanticManifest,
+) -> SemanticManifestLookup:
+    """Manifest used to test ambiguous resolution of group-by-items."""
+    return SemanticManifestLookup(simple_multi_hop_join_manifest)

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/all_entity_measure_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/all_entity_measure_source.yaml
@@ -1,0 +1,33 @@
+---
+semantic_model:
+  name: all_entity_measure_source
+  description: A measure source associated with ["entity_0", "entity_1", "entity_2"]
+
+  node_relation:
+    schema_name: $source_schema
+    alias: all_entity_measure_table
+
+  defaults:
+    agg_time_dimension: ds
+
+  measures:
+    - name: all_entity_measure
+      agg: sum
+      expr: "1"
+
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        time_granularity: day
+
+  entities:
+    - name: all_entity_composite
+      type: primary
+      expr: entity_0 || entity_1 || entity_2
+    - name: entity_0
+      type: foreign
+    - name: entity_1
+      type: foreign
+    - name: entity_2
+      type: foreign

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_0_dimension_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_0_dimension_source.yaml
@@ -1,0 +1,16 @@
+---
+semantic_model:
+  name: entity_0_dimension_source
+  description: Contains dimensions for "entity_0"
+
+  node_relation:
+    schema_name: $source_schema
+    alias: entity_0_dimension_table
+
+  dimensions:
+    - name: country
+      type: categorical
+
+  entities:
+    - name: entity_0
+      type: primary

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_0_measure_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_0_measure_source.yaml
@@ -22,4 +22,4 @@ semantic_model:
 
   entities:
     - name: entity_0
-      type: foreign
+      type: primary

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_0_measure_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_0_measure_source.yaml
@@ -1,0 +1,25 @@
+---
+semantic_model:
+  name: entity_0_measure_source
+  description: A measure source associated with "entity_0".
+
+  node_relation:
+    schema_name: $source_schema
+    alias: entity_0_measure_table
+
+  defaults:
+    agg_time_dimension: ds
+
+  measures:
+    - name: entity_0_measure
+      agg: sum
+
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        time_granularity: day
+
+  entities:
+    - name: entity_0
+      type: foreign

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_1_and_entity_2_measure_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_1_and_entity_2_measure_source.yaml
@@ -1,0 +1,31 @@
+---
+semantic_model:
+  name: entity_1_and_entity_2_measure_source
+  description: A measure source associated with "entity_1" and "entity_2".
+
+  node_relation:
+    schema_name: $source_schema
+    alias: entity_1_and_entity_2_measure_table
+
+  defaults:
+    agg_time_dimension: ds
+
+  measures:
+    - name: entity_1_and_entity_2_measure
+      agg: sum
+      expr: "1"
+
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        time_granularity: day
+
+  entities:
+    - name: composite_entity
+      type: primary
+      expr: entity_1 || entity_2
+    - name: entity_1
+      type: foreign
+    - name: entity_2
+      type: foreign

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_1_dimension_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_1_dimension_source.yaml
@@ -1,0 +1,16 @@
+---
+semantic_model:
+  name: entity_1_dimension_source
+  description: Contains dimensions for "entity_1"
+
+  node_relation:
+    schema_name: $source_schema
+    alias: entity_1_dimension_table
+
+  dimensions:
+    - name: country
+      type: categorical
+
+  entities:
+    - name: entity_1
+      type: primary

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_1_measure_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_1_measure_source.yaml
@@ -1,0 +1,25 @@
+---
+semantic_model:
+  name: entity_1_measure_source
+  description: A measure source associated with "entity_1".
+
+  node_relation:
+    schema_name: $source_schema
+    alias: entity_1_measure_table
+
+  defaults:
+    agg_time_dimension: ds
+
+  measures:
+    - name: entity_1_measure
+      agg: sum
+
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        time_granularity: day
+
+  entities:
+    - name: entity_1
+      type: primary

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_1_to_entity_0_mapping_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_1_to_entity_0_mapping_source.yaml
@@ -1,0 +1,14 @@
+---
+semantic_model:
+  name: entity_1_to_entity_0_mapping_source
+  description: Maps "entity_1" to "entity_0"
+
+  node_relation:
+    schema_name: $source_schema
+    alias: entity_1_to_entity_0_mapping_table
+
+  entities:
+    - name: entity_1
+      type: primary
+    - name: entity_0
+      type: foreign

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_2_to_entity_0_mapping_source.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/entity_2_to_entity_0_mapping_source.yaml
@@ -1,0 +1,14 @@
+---
+semantic_model:
+  name: entity_2_to_entity_0_mapping_source
+  description: Maps "entity_2" to "entity_0"
+
+  node_relation:
+    schema_name: $source_schema
+    alias: entity_2_to_entity_0_mapping_table
+
+  entities:
+    - name: entity_2
+      type: primary
+    - name: entity_0
+      type: foreign

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/metrics.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/metrics.yaml
@@ -1,0 +1,14 @@
+---
+metric:
+  name: entity_1_metric
+  description: Metric based on a measure defined with "entity_1"
+  type: simple
+  type_params:
+    measure: entity_1_measure
+---
+metric:
+  name: entity_1_and_entity_2_metric
+  description: Metric based on a measure defined with "entity_1" and "entity_2"
+  type: simple
+  type_params:
+    measure: entity_1_and_entity_2_measure

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/metrics.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/metrics.yaml
@@ -1,5 +1,12 @@
 ---
 metric:
+  name: entity_0_metric
+  description: Metric based on a measure defined with "entity_0".
+  type: simple
+  type_params:
+    measure: entity_0_measure
+---
+metric:
   name: entity_1_metric
   description: Metric based on a measure defined with "entity_1"
   type: simple
@@ -12,3 +19,10 @@ metric:
   type: simple
   type_params:
     measure: entity_1_and_entity_2_measure
+---
+metric:
+  name: all_entity_metric
+  description: Metric based on a defined with ["entity_0", "entity_1", "entity_2"].
+  type: simple
+  type_params:
+    measure: all_entity_measure

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/project_configuration.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_multi_hop_join_manifest/project_configuration.yaml
@@ -1,0 +1,1 @@
+../shared/project_configuration.yaml

--- a/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/all_entity_measure_table.yaml
+++ b/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/all_entity_measure_table.yaml
@@ -1,0 +1,14 @@
+---
+table_snapshot:
+  table_name: all_entity_measure_table
+  column_definitions:
+    - name: entity_0
+      type: STRING
+    - name: entity_1
+      type: STRING
+    - name: entity_2
+      type: STRING
+    - name: ds
+      type: TIME
+  rows:
+    - ["E0_0", "E1_1", "E1_2", "2020-01-01"]

--- a/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_0_dimension_table.yaml
+++ b/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_0_dimension_table.yaml
@@ -1,0 +1,11 @@
+---
+table_snapshot:
+  table_name: entity_0_dimension_source
+  column_definitions:
+    - name: entity_0
+      type: STRING
+    - name: country
+      type: STRING
+  rows:
+    - ["E0_0", "us"]
+    - ["E0_1", "ca"]

--- a/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_0_measure_table.yaml
+++ b/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_0_measure_table.yaml
@@ -1,0 +1,12 @@
+---
+table_snapshot:
+  table_name: entity_0_measure_table
+  column_definitions:
+    - name: entity_0_measure
+      type: INT
+    - name: entity_0
+      type: STRING
+    - name: ds
+      type: TIME
+  rows:
+    - ["0", "E0_0", "2020-01-01"]

--- a/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_1_and_entity_2_measure_table.yaml
+++ b/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_1_and_entity_2_measure_table.yaml
@@ -1,0 +1,12 @@
+---
+table_snapshot:
+  table_name: entity_1_and_entity_2_measure_table
+  column_definitions:
+    - name: entity_1
+      type: STRING
+    - name: entity_2
+      type: STRING
+    - name: ds
+      type: TIME
+  rows:
+    - ["E1_0", "E2_0", "2020-01-01"]

--- a/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_1_dimension_table.yaml
+++ b/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_1_dimension_table.yaml
@@ -1,0 +1,11 @@
+---
+table_snapshot:
+  table_name: entity_1_dimension_source
+  column_definitions:
+    - name: entity_1
+      type: STRING
+    - name: country
+      type: STRING
+  rows:
+    - ["E0_2", "us"]
+    - ["E0_3", "ca"]

--- a/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_1_measure_table.yaml
+++ b/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_1_measure_table.yaml
@@ -1,0 +1,12 @@
+---
+table_snapshot:
+  table_name: entity_1_measure_table
+  column_definitions:
+    - name: entity_1_measure
+      type: INT
+    - name: entity_1
+      type: STRING
+    - name: ds
+      type: TIME
+  rows:
+    - ["1", "E1_0", "2020-01-01"]

--- a/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_1_to_entity_0_mapping_table.yaml
+++ b/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_1_to_entity_0_mapping_table.yaml
@@ -1,0 +1,10 @@
+---
+table_snapshot:
+  table_name: entity_1_to_entity_0_table
+  column_definitions:
+    - name: entity_1
+      type: STRING
+    - name: entity_0
+      type: STRING
+  rows:
+    - ["E1_0", "E0_0"]

--- a/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_2_measure_table.yaml
+++ b/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_2_measure_table.yaml
@@ -1,0 +1,10 @@
+---
+table_snapshot:
+  table_name: entity_2_measure_table
+  column_definitions:
+    - name: entity_2
+      type: STRING
+    - name: ds
+      type: TIME
+  rows:
+    - ["E2_0", "2020-01-01"]

--- a/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_2_to_entity_0_mapping_table.yaml
+++ b/metricflow/test/fixtures/source_table_snapshots/simple_multi_hop_join_manifest/entity_2_to_entity_0_mapping_table.yaml
@@ -1,0 +1,10 @@
+---
+table_snapshot:
+  table_name: entity_2_to_entity_0_mapping_table
+  column_definitions:
+    - name: entity_2
+      type: STRING
+    - name: entity_0
+      type: STRING
+  rows:
+    - ["E2_0", "E0_1"]

--- a/metricflow/test/query/test_ambiguous_entity_path.py
+++ b/metricflow/test/query/test_ambiguous_entity_path.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+
+from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow.query.group_by_item.filter_spec_resolution.filter_pattern_factory import (
+    DefaultWhereFilterPatternFactory,
+)
+from metricflow.query.query_exceptions import InvalidQueryException
+from metricflow.query.query_parser import MetricFlowQueryParser
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.snapshot_utils import assert_object_snapshot_equal
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def multi_hop_query_parser(  # noqa: D
+    simple_multi_hop_join_manifest_lookup: SemanticManifestLookup,
+) -> MetricFlowQueryParser:
+    return MetricFlowQueryParser(
+        semantic_manifest_lookup=simple_multi_hop_join_manifest_lookup,
+        where_filter_pattern_factory=DefaultWhereFilterPatternFactory(),
+    )
+
+
+def test_resolvable_ambiguous_entity_path(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    multi_hop_query_parser: MetricFlowQueryParser,
+) -> None:
+    query_spec = multi_hop_query_parser.parse_and_validate_query(
+        metric_names=["entity_1_metric"],
+        group_by_names=["entity_0__country"],
+    )
+
+    assert_object_snapshot_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        obj_id="result_0",
+        obj=query_spec,
+    )
+
+
+def test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches(
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    multi_hop_query_parser: MetricFlowQueryParser,
+) -> None:
+    """Tests an input with an ambiguous entity-path that can't be resolved due to multiple matches.
+
+    'entity_0__country' matches ['entity_1__entity_0__country', 'entity_2__entity_0__country']
+    """
+    with pytest.raises(InvalidQueryException) as e:
+        multi_hop_query_parser.parse_and_validate_query(
+            metric_names=["entity_1_and_entity_2_metric"],
+            group_by_names=["entity_0__country"],
+        )
+
+    assert_object_snapshot_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        obj_id="result_0",
+        obj=str(e.value),
+    )

--- a/metricflow/test/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_ambiguous_entity_path_resolves_to_shortest_entity_path_item__result_0.txt
+++ b/metricflow/test/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_ambiguous_entity_path_resolves_to_shortest_entity_path_item__result_0.txt
@@ -1,0 +1,7 @@
+MetricFlowQuerySpec(
+  metric_specs=(MetricSpec(element_name='all_entity_metric'),),
+  dimension_specs=(DimensionSpec(element_name='country', entity_links=(EntityReference(element_name='entity_1'),)),),
+  filter_intersection=PydanticWhereFilterIntersection(),
+  filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
+  min_max_only=False,
+)

--- a/metricflow/test/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_resolvable_ambiguous_entity_path__result_0.txt
+++ b/metricflow/test/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_resolvable_ambiguous_entity_path__result_0.txt
@@ -1,0 +1,12 @@
+MetricFlowQuerySpec(
+  metric_specs=(MetricSpec(element_name='entity_1_metric'),),
+  dimension_specs=(
+    DimensionSpec(
+      element_name='country',
+      entity_links=(EntityReference(element_name='entity_1'), EntityReference(element_name='entity_0')),
+    ),
+  ),
+  filter_intersection=PydanticWhereFilterIntersection(),
+  filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
+  min_max_only=False,
+)

--- a/metricflow/test/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_mismatch__result_0.txt
+++ b/metricflow/test/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_mismatch__result_0.txt
@@ -1,0 +1,27 @@
+('Got errors while resolving the query.\n'
+ '\n'
+ 'Error #1:\n'
+ '  Message:\n'
+ '\n'
+ "    Query(['entity_0_metric', 'entity_1_metric']) is built from:\n"
+ '\n'
+ "      Metric('entity_0_metric'), Metric('entity_1_metric').\n"
+ '    However, the given input does not match to a common item that is available to those parents:\n'
+ '\n'
+ '      {\n'
+ '        "Matching items for: Metric(\'entity_0_metric\')": [\'entity_0__country\',],\n'
+ '        "Matching items for: Metric(\'entity_1_metric\')": [\n'
+ "          'entity_1__entity_0__country',\n"
+ '        ],\n'
+ '      }\n'
+ '\n'
+ '    For time dimension inputs, please specify a time grain as ambiguous resolution only allows resolution when the '
+ 'parents have the same defined time gain.\n'
+ '\n'
+ '  Query Input:\n'
+ '\n'
+ '    entity_0__country\n'
+ '\n'
+ '  Issue Location:\n'
+ '\n'
+ "    [Resolve Query(['entity_0_metric', 'entity_1_metric'])]")

--- a/metricflow/test/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches__result_0.txt
+++ b/metricflow/test/snapshots/test_ambiguous_entity_path.py/str/test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches__result_0.txt
@@ -1,0 +1,16 @@
+('Got errors while resolving the query.\n'
+ '\n'
+ 'Error #1:\n'
+ '  Message:\n'
+ '\n'
+ "    The given input is ambiguous and can't be resolved. The input could match:\n"
+ '\n'
+ "      ['entity_1__entity_0__country', 'entity_2__entity_0__country']\n"
+ '\n'
+ '  Query Input:\n'
+ '\n'
+ '    entity_0__country\n'
+ '\n'
+ '  Issue Location:\n'
+ '\n'
+ "    [Resolve Query(['entity_1_and_entity_2_metric'])]")


### PR DESCRIPTION
### Description

This PR allows for partial entity paths to be specified for group-by-items. e.g. `user__country` instead of `listing__user__country` if there is a unique shortest path available.


<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
