### PR TITLE
Remove MarkupSafe dependency

### DIFF
--- a/.changes/unreleased/Dependencies-20231219-170616.yaml
+++ b/.changes/unreleased/Dependencies-20231219-170616.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Remove unnecessary MarkupSafe dependency
+time: 2023-12-19T17:06:16.61921-08:00
+custom:
+  Author: tlento
+  PR: "950"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 dependencies = [
   "Jinja2>=2.11.3",
-  "MarkupSafe==2.0.1", # pandas implicitly requires this version
   "PyYAML~=6.0",
   "click>=7.1.2",
   "dbt-core~=1.7.0",


### PR DESCRIPTION
Resolves #927

We do not use MarkupSafe directly. Historically, we've needed this
because sometime, somewhere, something was causing runtime problems
with the way Pandas was importing and loading MarkupSafe.

Whatever that was appears to have been fixed - clean installs still
load MarkupSafe (since it's a transitive dependency) and everything
appears to be working as normal.