### PR TITLE
Expose `label` on MFEngine Metric

### DIFF
--- a/.changes/unreleased/Features-20240102-163031.yaml
+++ b/.changes/unreleased/Features-20240102-163031.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Expose label on Metric & Dimension for use in APIs.
+time: 2024-01-02T16:30:31.302535-08:00
+custom:
+  Author: courtneyholcomb
+  Issue: "956"

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -81,6 +81,7 @@ class Dimension:
     metadata: Optional[Metadata]
     is_partition: bool = False
     expr: Optional[str] = None
+    label: Optional[str] = None
 
     @classmethod
     def from_pydantic(cls, pydantic_dimension: SemanticManifestDimension, path_key: ElementPathKey) -> Dimension:
@@ -104,6 +105,7 @@ class Dimension:
             metadata=pydantic_dimension.metadata,
             is_partition=pydantic_dimension.is_partition,
             expr=pydantic_dimension.expr,
+            label=pydantic_dimension.label,
         )
 
     @property

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -43,6 +43,7 @@ class Metric:
     filter: Optional[WhereFilterIntersection]
     metadata: Optional[Metadata]
     dimensions: List[Dimension]
+    label: Optional[str]
 
     @classmethod
     def from_pydantic(cls, pydantic_metric: SemanticManifestMetric, dimensions: List[Dimension]) -> Metric:
@@ -55,6 +56,7 @@ class Metric:
             filter=pydantic_metric.filter,
             metadata=pydantic_metric.metadata,
             dimensions=dimensions,
+            label=pydantic_metric.label,
         )
 
     @property


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves #SL-1485


### Description
Expose `label` attribute for `Metrics` & `Dimensions` on `MFEngine`. Needed in APIs - will be used for partners to build integrations.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
