### PR TITLE
Fix duplicate input measures error

### DIFF
--- a/.changes/unreleased/Fixes-20240110-140727.yaml
+++ b/.changes/unreleased/Fixes-20240110-140727.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Duplicate input measures after combiner optimizer
+time: 2024-01-10T14:07:27.027242-05:00
+custom:
+  Author: WilliamDee
+  Issue: "969"

--- a/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
+++ b/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
@@ -240,8 +240,10 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         combined_parent_node = combined_parent_nodes[0]
         assert combined_parent_node is not None
 
-        combined_metric_input_measure_specs = (
-            self._current_left_node.metric_input_measure_specs + current_right_node.metric_input_measure_specs
+        combined_metric_input_measure_specs = tuple(
+            dict.fromkeys(
+                self._current_left_node.metric_input_measure_specs + current_right_node.metric_input_measure_specs
+            ).keys()
         )
 
         for spec in combined_metric_input_measure_specs:

--- a/metricflow/model/dbt_manifest_parser.py
+++ b/metricflow/model/dbt_manifest_parser.py
@@ -16,6 +16,8 @@ from dbt_semantic_interfaces.transformations.semantic_manifest_transformer impor
     PydanticSemanticManifestTransformer,
 )
 
+from metricflow.model.transformations.dedupe_metric_input_measures import DedupeMetricInputMeasuresRule
+
 
 def parse_manifest_from_dbt_generated_manifest(manifest_json_string: str) -> PydanticSemanticManifest:
     """Parse a PydanticSemanticManifest given the generated semantic_manifest json from dbt."""
@@ -32,7 +34,7 @@ def parse_manifest_from_dbt_generated_manifest(manifest_json_string: str) -> Pyd
             BooleanMeasureAggregationRule(),
             ConvertCountToSumRule(),
             ConvertMedianToPercentileRule(),
-            # AddInputMetricMeasuresRule(), Fixed by dbt-core=1.6.0b8
+            DedupeMetricInputMeasuresRule(),  # Remove once fix is in core
         ),
     )
     model = PydanticSemanticManifestTransformer.transform(raw_model, rules)

--- a/metricflow/model/transformations/dedupe_metric_input_measures.py
+++ b/metricflow/model/transformations/dedupe_metric_input_measures.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
+from dbt_semantic_interfaces.protocols import ProtocolHint
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
+from typing_extensions import override
+
+
+class DedupeMetricInputMeasuresRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
+    """Dedupe the input measures within a metric.
+
+    This can be removed once the fix is in the dbt-core transformation.
+    """
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
+
+    @staticmethod
+    def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
+        for metric in semantic_manifest.metrics:
+            metric.type_params.input_measures = list(dict.fromkeys(metric.input_measures).keys())
+        return semantic_manifest


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves #969 

### Description
Currently, when running through the branch combiner, in an instance where you have 2 derived metrics that contains the same input measure, it would get combined and it doesn't get deduped. Example,
```yaml
metric:
  name: "derived1"
  description: Test child derived metric 1
  type: derived
  type_params:
    expr: "booking_value + bookings"
    metrics:
      - name: booking_value
      - name: bookings
---
metric:
  name: "derived2"
  description: Test child derived metric 2
  type: derived
  type_params:
    expr: "bookings + instant_bookings"
    metrics:
      - name: instant_bookings
      - name: bookings
---
metric:
  name: "derived_parent"
  description: Test parent derived metric
  type: derived
  type_params:
    expr: "derived1 + derived2"
    metrics:
      - name: derived1
      - name: derived2
 ```
This leads to hitting an error during the dataflow rendering where we matched 2 duplicate input measures when expecting only 1 ([here](https://github.com/dbt-labs/metricflow/blob/main/metricflow/plan_conversion/instance_converters.py#L608)). Additionally, the parser in dbt-core utilizes it's own rewritten set of transformation rules and it currently isn't doing any deduping, this is a bug and should be fixed within dbt-core, tho it isn't affecting this issue.

**NOTE:** this error only occurs from manifests parsed by dbt-core, which is why the error never popped up in MF as MF uses the transformation rules in DSI.

1. Dedupe the combined input measure specs
2. Dedupe metric input measures in transformation rule (to remove after change is in core)

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  4. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  5. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
