### PR TITLE
Update dbt-metricflow version to 0.5.0

### DIFF
--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dbt-metricflow"
-version = "0.4.0"
+version = "0.5.0"
 description = "Execute commands against the MetricFlow semantic layer with dbt."
 readme = "README.md"
 requires-python = ">=3.8,<3.12"
@@ -24,8 +24,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "dbt-core~=1.7.0",
-  "metricflow~=0.203.0"
+  "dbt-core~=1.7.4",
+  "metricflow~=0.204.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
With the release of MetricFlow 0.204.0 we can now release
dbt-metricflow 0.5.0 to complement it.

Note MetricFlow nominally depends on dbt-core 1.7.x, but installs
with that specific version will not be able to use conversion
metrics. That's a boundary case we should probably fix with a patch
release for MetricFlow.

In the meantime, we  ensure the installation helper dbt-metricflow
will force an update to the proper minimum version of dbt-core.
