### PR TITLE
Add a make target to run Trino warehouse locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ lint:
 postgresql postgres:
 	make -C local-data-warehouses postgresql
 
+.PHONY: trino
+trino:
+	docker run --name trino -d -p 8080:8080 trinodb/trino
+
 # Re-generate test snapshots using all supported SQL engines.
 .PHONY: regenerate-test-snapshots
 regenerate-test-snapshots:

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ postgresql postgres:
 
 .PHONY: trino
 trino:
-	docker run --name trino -d -p 8080:8080 trinodb/trino
+	make -C local-data-warehouses trino
 
 # Re-generate test snapshots using all supported SQL engines.
 .PHONY: regenerate-test-snapshots

--- a/local-data-warehouses/Makefile
+++ b/local-data-warehouses/Makefile
@@ -5,3 +5,7 @@
 .PHONY: postgresql
 postgresql:
 	docker-compose -f postgresql/docker-compose.yaml up
+
+.PHONY: trino
+trino:
+	docker-compose -f trino/docker-compose.yaml up

--- a/local-data-warehouses/trino/docker-compose.yaml
+++ b/local-data-warehouses/trino/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: "3.7"
+
+services:
+  trino:
+    container_name: trino
+    image: "trinodb/trino"
+    expose:
+      - "8080"
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->



### Description
Quick dev improvement. Adds a make target to run a Trino warehouse locally. This makes it so you can run `make trino` instead of needing to remember the docker command to run it.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
