### PR TITLE
Potential bug fix: Don't use `defaultdict` for `SemanticModelLookup` indexes

### DIFF
--- a/metricflow/model/semantics/semantic_model_lookup.py
+++ b/metricflow/model/semantics/semantic_model_lookup.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
 from copy import deepcopy
 from typing import Dict, List, Optional, Sequence, Set
 
@@ -59,7 +58,7 @@ class SemanticModelLookup(SemanticModelAccessor):
         self._measure_agg_time_dimension: Dict[MeasureReference, TimeDimensionReference] = {}
         self._measure_non_additive_dimension_specs: Dict[MeasureReference, NonAdditiveDimensionSpec] = {}
         self._dimension_index: Dict[DimensionReference, List[SemanticModel]] = {}
-        self._linkable_reference_index: Dict[LinkableElementReference, List[SemanticModel]] = defaultdict(list)
+        self._linkable_reference_index: Dict[LinkableElementReference, List[SemanticModel]] = {}
         self._entity_index: Dict[EntityReference, List[SemanticModel]] = {}
         self._semantic_model_names: Set[str] = set()
 
@@ -245,11 +244,10 @@ class SemanticModelLookup(SemanticModelAccessor):
                 )
                 self._measure_non_additive_dimension_specs[measure.reference] = non_additive_dimension_spec
         for dim in semantic_model.dimensions:
-            self._linkable_reference_index[dim.reference].append(semantic_model)
-
             semantic_models_for_dimension = self._dimension_index.get(dim.reference, [])
             semantic_models_for_dimension.append(semantic_model)
             self._dimension_index[dim.reference] = semantic_models_for_dimension
+            self._linkable_reference_index[dim.reference] = semantic_models_for_dimension
 
             self._dimension_ref_to_spec[dim.time_dimension_reference or dim.reference] = (
                 TimeDimensionSpec.from_name(dim.name)
@@ -261,8 +259,8 @@ class SemanticModelLookup(SemanticModelAccessor):
             semantic_models_for_entity = self._entity_index.get(entity.reference, [])
             semantic_models_for_entity.append(semantic_model)
             self._entity_index[entity.reference] = semantic_models_for_entity
+            self._linkable_reference_index[entity.reference] = semantic_models_for_entity
 
-            self._linkable_reference_index[entity.reference].append(semantic_model)
             self._entity_ref_to_spec[entity.reference] = EntitySpec.from_name(entity.name)
 
         self._semantic_model_reference_to_semantic_model[semantic_model.reference] = semantic_model

--- a/metricflow/model/semantics/semantic_model_lookup.py
+++ b/metricflow/model/semantics/semantic_model_lookup.py
@@ -192,11 +192,7 @@ class SemanticModelLookup(SemanticModelAccessor):
 
         for measure in semantic_model.measures:
             self._measure_aggs[measure.reference] = measure.agg
-
-            semantic_models_for_measure = self._measure_index.get(measure.reference, [])
-            semantic_models_for_measure.append(semantic_model)
-            self._measure_index[measure.reference] = semantic_models_for_measure
-
+            self._measure_index[measure.reference] = self._measure_index.get(measure.reference, []) + [semantic_model]
             agg_time_dimension_reference = semantic_model.checked_agg_time_dimension_for_measure(measure.reference)
 
             matching_dimensions = tuple(
@@ -244,8 +240,7 @@ class SemanticModelLookup(SemanticModelAccessor):
                 )
                 self._measure_non_additive_dimension_specs[measure.reference] = non_additive_dimension_spec
         for dim in semantic_model.dimensions:
-            semantic_models_for_dimension = self._dimension_index.get(dim.reference, [])
-            semantic_models_for_dimension.append(semantic_model)
+            semantic_models_for_dimension = self._dimension_index.get(dim.reference, []) + [semantic_model]
             self._dimension_index[dim.reference] = semantic_models_for_dimension
             self._linkable_reference_index[dim.reference] = semantic_models_for_dimension
 
@@ -256,8 +251,7 @@ class SemanticModelLookup(SemanticModelAccessor):
             )
 
         for entity in semantic_model.entities:
-            semantic_models_for_entity = self._entity_index.get(entity.reference, [])
-            semantic_models_for_entity.append(semantic_model)
+            semantic_models_for_entity = self._entity_index.get(entity.reference, []) + [semantic_model]
             self._entity_index[entity.reference] = semantic_models_for_entity
             self._linkable_reference_index[entity.reference] = semantic_models_for_entity
 


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
`SemanticModelLookup` keeps track of all the valid measures, dimensions, and entities for a given semantic manifest using dictionaries `_measure_index`, `_dimension_index`, `_entity_index`, and `_linkable_reference_index`. These are used for various purposes, one of which is to check if a given measure/dimension/entity name is valid (i.e., if someone queries a dimension name that's not in the index, we will raise an error telling them the dimension doesn't exist).

Previously, these were created as `defaultdicts`. This simplifies the code, but creates a potential bug. If someone queries `get_dimension()` with a dimension that doesn't exist, we will raise the appropriate error, but with an unintended side effect. When you index into a `defaultdict` using a key that doesn't exist yet, that key gets automatically added to the dict. Therefore, when calling `get_dimension()` with a dimension that doesn't exist, that non-existent dimension will be added to `_dimension_index`. This becomes a problem when you call `get_dimension_references()`, which returns a list of all keys in `_dimension_index`; you would end up with a non-existent dimension in the list of what should be all valid dimensions.

This PR converts all those `defaultdicts` into normal dicts to avoid that potential bug.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
