### PR TITLE
Remove unused numpy dependency

### DIFF
--- a/.changes/unreleased/Dependencies-20240119-174213.yaml
+++ b/.changes/unreleased/Dependencies-20240119-174213.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Remove unused numpy dependency
+time: 2024-01-19T17:42:13.46617-08:00
+custom:
+  Author: tlento
+  PR: "984"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
   "graphviz>=0.18.2, <0.21",
   "halo~=0.0.31",
   "more-itertools>=8.10.0, <10.2.0",
-  "numpy>=1.22.2",
   "pandas~=1.5.0",
   "pydantic~=1.10.0",
   "python-dateutil~=2.8.2",


### PR DESCRIPTION
Licensing analysis tripped a potential issue with numpy. The
thing is we don't use numpy for anything - this dependency is
only here because some past transitive dependency caused issues
with M1 macs and pinning a minimum version for numpy ensured
that particular problem would not come up. Even the initial
addition was to pin past some security patch. Wild.

Anyway, rather than try to figure out if the new licensing
issue is a false positive, I'm simply removing the package from
our linked dependency set.
