### PR TITLE
Stop triggering SQL Engine Tests on push to main

### DIFF
--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -4,9 +4,6 @@ name: MetricFlow SQL Engine Tests
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
   pull_request:
     types: [labeled]
 


### PR DESCRIPTION
This GitHub Action requires manual approval to run in order to
protect the various warehouse credentials included in it.

However, we trigger it on every push to main, and those nearly
always go without approval. In practice, these tests are only
run manually, either via a PR label or the occasional "I want
to run these on trunk so I'll approve the last one of these that
triggered off a push to main".

We can do the latter via workflow_dispatch anyway, so let's just
get rid of the nearly-universally-ignored action trigger.
