### PR TITLE
Methods to look up `agg_time_dimensions`

### DIFF
--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -26,7 +26,6 @@ from metricflow.errors.errors import UnknownMetricLinkingError
 from metricflow.mf_logging.pretty_print import mf_pformat
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.semantic_model_join_evaluator import SemanticModelJoinEvaluator
-from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow.protocols.semantics import SemanticModelAccessor
 from metricflow.specs.specs import (
     DEFAULT_TIME_GRANULARITY,
@@ -524,9 +523,7 @@ class ValidLinkableSpecResolver:
         linkable_element_sets_to_merge: List[LinkableElementSet] = []
 
         for semantic_model in semantic_manifest.semantic_models:
-            linkable_element_sets_to_merge.append(
-                ValidLinkableSpecResolver._get_elements_in_semantic_model(semantic_model)
-            )
+            linkable_element_sets_to_merge.append(self._get_elements_in_semantic_model(semantic_model))
 
         metric_time_elements_for_no_metrics = self._get_metric_time_elements(measure_reference=None)
         self._no_metric_linkable_element_set = LinkableElementSet.merge_by_path_key(
@@ -550,8 +547,7 @@ class ValidLinkableSpecResolver:
             )
         return semantic_models_where_measure_was_found[0]
 
-    @staticmethod
-    def _get_elements_in_semantic_model(semantic_model: SemanticModel) -> LinkableElementSet:
+    def _get_elements_in_semantic_model(self, semantic_model: SemanticModel) -> LinkableElementSet:
         """Gets the elements in the semantic model, without requiring any joins.
 
         Elements related to metric_time are handled separately in _get_metric_time_elements().
@@ -568,7 +564,7 @@ class ValidLinkableSpecResolver:
                     properties=frozenset({LinkableElementProperties.LOCAL, LinkableElementProperties.ENTITY}),
                 )
             )
-            for entity_link in SemanticModelLookup.entity_links_for_local_elements(semantic_model):
+            for entity_link in self._semantic_model_lookup.entity_links_for_local_elements(semantic_model):
                 linkable_entities.append(
                     LinkableEntity(
                         semantic_model_origin=semantic_model.reference,
@@ -579,7 +575,7 @@ class ValidLinkableSpecResolver:
                     )
                 )
 
-        for entity_link in SemanticModelLookup.entity_links_for_local_elements(semantic_model):
+        for entity_link in self._semantic_model_lookup.entity_links_for_local_elements(semantic_model):
             dimension_properties = frozenset({LinkableElementProperties.LOCAL})
             for dimension in semantic_model.dimensions:
                 dimension_type = dimension.type

--- a/metricflow/model/semantics/semantic_model_lookup.py
+++ b/metricflow/model/semantics/semantic_model_lookup.py
@@ -25,6 +25,7 @@ from typing_extensions import override
 from metricflow.errors.errors import InvalidSemanticModelError
 from metricflow.mf_logging.pretty_print import mf_pformat
 from metricflow.model.semantics.element_group import ElementGrouper
+from metricflow.model.semantics.linkable_spec_resolver import ElementPathKey
 from metricflow.model.spec_converters import MeasureConverter
 from metricflow.protocols.semantics import SemanticModelAccessor
 from metricflow.specs.specs import (
@@ -214,7 +215,7 @@ class SemanticModelLookup(SemanticModelAccessor):
                     f"Aggregation time dimension does not have a time granularity set: {agg_time_dimension}"
                 )
 
-            primary_entity = SemanticModelLookup._resolved_primary_entity(semantic_model)
+            primary_entity = SemanticModelLookup.resolved_primary_entity(semantic_model)
 
             if primary_entity is None:
                 raise RuntimeError(
@@ -291,7 +292,7 @@ class SemanticModelLookup(SemanticModelAccessor):
         )
 
     @staticmethod
-    def _resolved_primary_entity(semantic_model: SemanticModel) -> Optional[EntityReference]:
+    def resolved_primary_entity(semantic_model: SemanticModel) -> Optional[EntityReference]:
         """Return the primary entity for dimensions in the model."""
         primary_entity_reference = semantic_model.primary_entity_reference
 
@@ -300,14 +301,12 @@ class SemanticModelLookup(SemanticModelAccessor):
         )
 
         # This should be caught by the validation, but adding a sanity check.
-        assert len(entities_with_type_primary) <= 1, f"Found >1 primary entity in {semantic_model}"
+        assert len(entities_with_type_primary) <= 1, f"Found > 1 primary entity in {semantic_model}"
         if primary_entity_reference is not None:
             assert len(entities_with_type_primary) == 0, (
                 f"The primary_entity field was set to {primary_entity_reference}, but there are non-zero entities with "
                 f"type {EntityType.PRIMARY} in {semantic_model}"
             )
-
-        if primary_entity_reference is not None:
             return primary_entity_reference
 
         if len(entities_with_type_primary) > 0:
@@ -339,3 +338,37 @@ class SemanticModelLookup(SemanticModelAccessor):
             return self._entity_ref_to_spec[EntityReference(element_name=element_name)]
         else:
             raise ValueError(f"Unable to find linkable element {element_name} in manifest")
+
+    def get_agg_time_dimension_path_key_for_measure(self, measure_reference: MeasureReference) -> ElementPathKey:
+        """Get the agg time dimension associated with the measure."""
+        agg_time_dimension = self.get_agg_time_dimension_for_measure(measure_reference)
+
+        # A measure's agg_time_dimension is required to be in the same semantic model as the measure,
+        # so we can assume the same semantic model for both measure and dimension.
+        semantic_models = self.get_semantic_models_for_measure(measure_reference)
+        assert (
+            len(semantic_models) == 1
+        ), f"Expected exactly one semantic model for measure {measure_reference}, but found semantic models {semantic_models}."
+        semantic_model = semantic_models[0]
+
+        entity_link = self.resolved_primary_entity(semantic_model)
+        assert (
+            entity_link is not None
+        ), f"Expected semantic model {semantic_model} to have a primary entity since is contains dimensions, but found none."
+
+        return ElementPathKey(
+            element_name=agg_time_dimension.element_name,
+            entity_links=(entity_link,),
+            time_granularity=None,
+            date_part=None,
+        )
+
+    def get_agg_time_dimension_specs_for_measure(
+        self, measure_reference: MeasureReference
+    ) -> Sequence[TimeDimensionSpec]:
+        """Get the agg time dimension specs that can be used in place of metric time for this measure."""
+        path_key = self.get_agg_time_dimension_path_key_for_measure(measure_reference)
+        return TimeDimensionSpec.generate_possible_specs_for_time_dimension(
+            time_dimension_reference=TimeDimensionReference(element_name=path_key.element_name),
+            entity_links=path_key.entity_links,
+        )

--- a/metricflow/model/semantics/semantic_model_lookup.py
+++ b/metricflow/model/semantics/semantic_model_lookup.py
@@ -352,9 +352,10 @@ class SemanticModelLookup(SemanticModelAccessor):
         semantic_model = semantic_models[0]
 
         entity_link = self.resolved_primary_entity(semantic_model)
-        assert (
-            entity_link is not None
-        ), f"Expected semantic model {semantic_model} to have a primary entity since is contains dimensions, but found none."
+        assert entity_link is not None, (
+            f"Expected semantic model {semantic_model} to have a primary entity since it has a "
+            "measure requiring an agg_time_dimension, but found none.",
+        )
 
         return ElementPathKey(
             element_name=agg_time_dimension.element_name,

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -157,3 +157,32 @@ def test_linkable_set_for_common_dimensions_in_different_models(
             ),
         ),
     )
+
+
+def test_get_valid_agg_time_dimensions_for_metric(  # noqa: D
+    metric_lookup: MetricLookup, semantic_model_lookup: SemanticModelLookup
+) -> None:
+    for metric_name in ["views", "listings", "bookings_per_view"]:
+        metric_reference = MetricReference(metric_name)
+        metric = metric_lookup.get_metric(metric_reference)
+        metric_agg_time_dims = metric_lookup.get_valid_agg_time_dimensions_for_metric(metric_reference)
+        measure_agg_time_dims = list(
+            {
+                semantic_model_lookup.get_agg_time_dimension_for_measure(measure.measure_reference)
+                for measure in metric.input_measures
+            }
+        )
+        if len(measure_agg_time_dims) == 1:
+            for metric_agg_time_dim in metric_agg_time_dims:
+                assert metric_agg_time_dim.reference == measure_agg_time_dims[0]
+        else:
+            assert len(metric_agg_time_dims) == 0
+
+
+def test_get_agg_time_dimension_specs_for_measure(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D
+    for measure_name in ["bookings", "views", "listings"]:
+        measure_reference = MeasureReference(measure_name)
+        agg_time_dim_specs = semantic_model_lookup.get_agg_time_dimension_specs_for_measure(measure_reference)
+        agg_time_dim_reference = semantic_model_lookup.get_agg_time_dimension_for_measure(measure_reference)
+        for spec in agg_time_dim_specs:
+            assert spec.reference == agg_time_dim_reference


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Adds some methods that will be used to enable querying with `agg_time_dimension` instead of `metric_time`.
`MetricLookup.get_valid_agg_time_dimensions_for_metric()` will be used in validations, while `SemanticModelLookup.get_agg_time_dimension_specs_for_measure()` will be used in query building.

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
