### PR TITLE
Bug fix: always use candidate join type when evaluating nodes to join

### DIFF
--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -339,7 +339,6 @@ class NodeEvaluatorForLinkableInstances:
     def _update_candidates_that_can_satisfy_linkable_specs(
         candidates_for_join: List[JoinLinkableInstancesRecipe],
         already_satisfisfied_linkable_specs: List[LinkableInstanceSpec],
-        join_type: SqlJoinType,
     ) -> List[JoinLinkableInstancesRecipe]:
         """Update / filter candidates_for_join based on linkable instance specs that we have already satisfied.
 
@@ -363,7 +362,7 @@ class NodeEvaluatorForLinkableInstances:
                         join_on_partition_dimensions=candidate_for_join.join_on_partition_dimensions,
                         join_on_partition_time_dimensions=candidate_for_join.join_on_partition_time_dimensions,
                         validity_window=candidate_for_join.validity_window,
-                        join_type=join_type,
+                        join_type=candidate_for_join.join_type,
                     )
                 )
         return sorted(
@@ -454,7 +453,6 @@ class NodeEvaluatorForLinkableInstances:
             candidates_for_join = self._update_candidates_that_can_satisfy_linkable_specs(
                 candidates_for_join=candidates_for_join,
                 already_satisfisfied_linkable_specs=next_candidate.satisfiable_linkable_specs,
-                join_type=default_join_type,
             )
 
             # The once possibly joinable specs are definitely joinable and no longer need to be searched for.


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Resolves [a bug](https://dbtlabsmt.datadoghq.com/logs?query=service%3Ametricflow-server%20status%3A%28error%20OR%20info%20OR%20warn%29%20cross%20join%20&cols=host%2Cservice&event=AgAAAY1CURh7OqhiHgAAAAAAAAAYAAAAAEFZMUNVU1BaQUFCbDVWMXY5LWllSUFBMQAAACQAAAAAMDE4ZDQyNTEtMjQ0ZC00ZGNhLTg1YTUtMGM2ZDBiMjI0OTll&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1706210388237&to_ts=1706213988237&live=true) found during Tableau complaint storm. We should be using the join type specified for the join candidate here instead of the default join type. This caused an error when joining to the time spine table, since the default join type for distinct values queries is `FULL OUTER JOIN` but time spine joins require `CROSS JOIN`.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
