### PR TITLE
Fix conditional execution on populate schema action

### DIFF
--- a/.github/workflows/cd-sql-engine-populate-persistent-source-schema.yaml
+++ b/.github/workflows/cd-sql-engine-populate-persistent-source-schema.yaml
@@ -20,9 +20,7 @@ env:
 jobs:
   snowflake-populate:
     environment: DW_INTEGRATION_TESTS
-    if: >
-      github.event.action == 'workflow_dispatch'
-      || (github.event.action == 'labeled' && github.event.label.name == 'Reload Test Data in SQL Engines')
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Reload Test Data in SQL Engines' }}
     name: Snowflake
     runs-on: ubuntu-latest
     steps:
@@ -41,9 +39,7 @@ jobs:
   redshift-populate:
     environment: DW_INTEGRATION_TESTS
     name: Redshift
-    if: >
-      github.event.action == 'workflow_dispatch'
-      || (github.event.action == 'labeled' && github.event.label.name == 'Reload Test Data in SQL Engines')
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Reload Test Data in SQL Engines' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
@@ -61,9 +57,7 @@ jobs:
   bigquery-populate:
     environment: DW_INTEGRATION_TESTS
     name: BigQuery
-    if: >
-      github.event.action == 'workflow_dispatch'
-      || (github.event.action == 'labeled' && github.event.label.name == 'Reload Test Data in SQL Engines')
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Reload Test Data in SQL Engines' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
@@ -81,9 +75,7 @@ jobs:
   databricks-populate:
     environment: DW_INTEGRATION_TESTS
     name: Databricks SQL Warehouse
-    if: >
-      github.event.action == 'workflow_dispatch'
-      || (github.event.action == 'labeled' && github.event.label.name == 'Reload Test Data in SQL Engines')
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'Reload Test Data in SQL Engines' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo

--- a/.github/workflows/cd-sql-engine-populate-persistent-source-schema.yaml
+++ b/.github/workflows/cd-sql-engine-populate-persistent-source-schema.yaml
@@ -16,6 +16,7 @@ on:
 env:
   # Unclear on how to make 'Reload Test Data in SQL Engines' a constant here as it does not work here.
   PYTHON_VERSION: "3.8"
+  ADDITIONAL_PYTEST_OPTIONS: "--log-cli-level info"
 
 jobs:
   snowflake-populate:
@@ -34,6 +35,7 @@ jobs:
           mf_sql_engine_url: ${{ secrets.MF_SNOWFLAKE_URL }}
           mf_sql_engine_password: ${{ secrets.MF_SNOWFLAKE_PWD }}
           parallelism: 1
+          additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
           make-target: "populate-persistent-source-schema-snowflake"
 
   redshift-populate:
@@ -52,6 +54,7 @@ jobs:
           mf_sql_engine_url: ${{ secrets.MF_REDSHIFT_URL }}
           mf_sql_engine_password: ${{ secrets.MF_REDSHIFT_PWD }}
           parallelism: 1
+          additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
           make-target: "populate-persistent-source-schema-redshift"
 
   bigquery-populate:
@@ -70,6 +73,7 @@ jobs:
           MF_SQL_ENGINE_URL: ${{ secrets.MF_BIGQUERY_URL }}
           MF_SQL_ENGINE_PASSWORD: ${{ secrets.MF_BIGQUERY_PWD }}
           parallelism: 1
+          additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
           make-target: "populate-persistent-source-schema-bigquery"
 
   databricks-populate:
@@ -88,6 +92,7 @@ jobs:
           mf_sql_engine_url: ${{ secrets.MF_DATABRICKS_URL }}
           mf_sql_engine_password: ${{ secrets.MF_DATABRICKS_PWD }}
           parallelism: 1
+          additional-pytest-options: ${{ env.ADDITIONAL_PYTEST_OPTIONS }}
           make-target: "populate-persistent-source-schema-databricks"
 
   remove-label:

--- a/metricflow/test/populate_persistent_source_schemas.py
+++ b/metricflow/test/populate_persistent_source_schemas.py
@@ -35,7 +35,7 @@ def populate_schemas(test_configuration: MetricFlowTestConfiguration) -> None:  
         os.environ["MF_TEST_ADAPTER_TYPE"] = engine_name
         hatch_env = f"{engine_name}-env"
         run_command(
-            f"hatch -v run {hatch_env}:pytest -vv --use-persistent-source-schema "
+            f"hatch -v run {hatch_env}:pytest -vv --log-cli-level info --use-persistent-source-schema "
             "metricflow/test/source_schema_tools.py::populate_source_schema"
         )
     else:


### PR DESCRIPTION
The populate persistent source schema GitHub action has a
workflow_dispatch trigger, but when you attempt to use it all
actions are immediately skipped.

This makes the changes necessary to enable the workflow_dispatch
trigger to execute the tasks in this workflow.
