### PR TITLE
Enable querying cumulative metrics with agg_time_dimension

### DIFF
--- a/.changes/unreleased/Features-20240125-220047.yaml
+++ b/.changes/unreleased/Features-20240125-220047.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Enable querying cumulative metrics with their agg_time_dimension.
+time: 2024-01-25T22:00:47.648696-08:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1000"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1297,12 +1297,26 @@ class DataflowPlanBuilder:
                 f"Recipe not found for measure spec: {measure_spec} and linkable specs: {required_linkable_specs}"
             )
 
-        # If a cumulative metric is queried with metric_time, join over time range.
+        queried_agg_time_dimension_specs = list(queried_linkable_specs.metric_time_specs)
+        if not queried_agg_time_dimension_specs:
+            valid_agg_time_dimensions = self._semantic_model_lookup.get_agg_time_dimension_specs_for_measure(
+                measure_spec.reference
+            )
+            queried_agg_time_dimension_specs = list(
+                set(queried_linkable_specs.time_dimension_specs).intersection(set(valid_agg_time_dimensions))
+            )
+
+        # If a cumulative metric is queried with agg_time_dimension, join over time range.
         # Otherwise, the measure will be aggregated over all time.
         time_range_node: Optional[JoinOverTimeRangeNode] = None
-        if cumulative and queried_linkable_specs.contains_metric_time:
+        if cumulative and queried_agg_time_dimension_specs:
+            # Use the time dimension spec with the smallest granularity.
+            agg_time_dimension_spec_for_join = sorted(
+                queried_agg_time_dimension_specs, key=lambda spec: spec.time_granularity.to_int()
+            )[0]
             time_range_node = JoinOverTimeRangeNode(
                 parent_node=measure_recipe.source_node,
+                time_dimension_spec_for_join=agg_time_dimension_spec_for_join,
                 window=cumulative_window,
                 grain_to_date=cumulative_grain_to_date,
                 time_range_constraint=time_range_constraint
@@ -1356,11 +1370,13 @@ class DataflowPlanBuilder:
         else:
             unaggregated_measure_node = filtered_measure_source_node
 
+        # If time constraint was previously adjusted for cumulative window or grain, apply original time constraint
+        # here. Can skip if metric is being aggregated over all time.
         cumulative_metric_constrained_node: Optional[ConstrainTimeRangeNode] = None
         if (
             cumulative_metric_adjusted_time_constraint is not None
             and time_range_constraint is not None
-            and queried_linkable_specs.contains_metric_time
+            and queried_agg_time_dimension_specs
         ):
             cumulative_metric_constrained_node = ConstrainTimeRangeNode(
                 unaggregated_measure_node, time_range_constraint

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1373,11 +1373,10 @@ class DataflowPlanBuilder:
         # If time constraint was previously adjusted for cumulative window or grain, apply original time constraint
         # here. Can skip if metric is being aggregated over all time.
         cumulative_metric_constrained_node: Optional[ConstrainTimeRangeNode] = None
-        if (
-            cumulative_metric_adjusted_time_constraint is not None
-            and time_range_constraint is not None
-            and queried_agg_time_dimension_specs
-        ):
+        if cumulative_metric_adjusted_time_constraint is not None and time_range_constraint is not None:
+            assert (
+                queried_linkable_specs.contains_metric_time
+            ), "Using time constraints currently requires querying with metric_time."
             cumulative_metric_constrained_node = ConstrainTimeRangeNode(
                 unaggregated_measure_node, time_range_constraint
             )

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -376,6 +376,7 @@ class JoinOverTimeRangeNode(BaseOutput):
     def __init__(
         self,
         parent_node: BaseOutput,
+        time_dimension_spec_for_join: TimeDimensionSpec,
         window: Optional[MetricTimeWindow],
         grain_to_date: Optional[TimeGranularity],
         node_id: Optional[NodeId] = None,
@@ -390,6 +391,7 @@ class JoinOverTimeRangeNode(BaseOutput):
             (eg month to day)
             node_id: Override the node ID with this value
             time_range_constraint: time range to aggregate over
+            time_dimension_spec_for_join: time dimension spec to use when joining to time spine
         """
         if window and grain_to_date:
             raise RuntimeError(
@@ -400,6 +402,7 @@ class JoinOverTimeRangeNode(BaseOutput):
         self._grain_to_date = grain_to_date
         self._window = window
         self.time_range_constraint = time_range_constraint
+        self.time_dimension_spec_for_join = time_dimension_spec_for_join
 
         # Doing a list comprehension throws a type error, so doing it this way.
         parent_nodes: List[DataflowPlanNode] = [self._parent_node]
@@ -447,6 +450,7 @@ class JoinOverTimeRangeNode(BaseOutput):
             window=self.window,
             grain_to_date=self.grain_to_date,
             time_range_constraint=self.time_range_constraint,
+            time_dimension_spec_for_join=self.time_dimension_spec_for_join,
         )
 
 

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -175,8 +175,8 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
 
     def _make_time_spine_data_set(
         self,
-        metric_time_dimension_instance: TimeDimensionInstance,
-        metric_time_dimension_column_name: str,
+        agg_time_dimension_instance: TimeDimensionInstance,
+        agg_time_dimension_column_name: str,
         time_spine_source: TimeSpineSource,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
     ) -> SqlDataSet:
@@ -187,21 +187,21 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         """
         time_spine_instance = (
             TimeDimensionInstance(
-                defined_from=metric_time_dimension_instance.defined_from,
+                defined_from=agg_time_dimension_instance.defined_from,
                 associated_columns=(
                     ColumnAssociation(
-                        column_name=metric_time_dimension_column_name,
+                        column_name=agg_time_dimension_column_name,
                         single_column_correlation_key=SingleColumnCorrelationKey(),
                     ),
                 ),
-                spec=metric_time_dimension_instance.spec,
+                spec=agg_time_dimension_instance.spec,
             ),
         )
         time_spine_instance_set = InstanceSet(time_dimension_instances=time_spine_instance)
         time_spine_table_alias = self._next_unique_table_alias()
 
         # If the requested granularity is the same as the granularity of the spine, do a direct select.
-        if metric_time_dimension_instance.spec.time_granularity == time_spine_source.time_column_granularity:
+        if agg_time_dimension_instance.spec.time_granularity == time_spine_source.time_column_granularity:
             return SqlDataSet(
                 instance_set=time_spine_instance_set,
                 sql_select_node=SqlSelectStatementNode(
@@ -214,7 +214,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                                     column_name=time_spine_source.time_column_name,
                                 ),
                             ),
-                            column_alias=metric_time_dimension_column_name,
+                            column_alias=agg_time_dimension_column_name,
                         ),
                     ),
                     from_source=SqlTableFromClauseNode(sql_table=time_spine_source.spine_table),
@@ -236,7 +236,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             select_columns = (
                 SqlSelectColumn(
                     expr=SqlDateTruncExpression(
-                        time_granularity=metric_time_dimension_instance.spec.time_granularity,
+                        time_granularity=agg_time_dimension_instance.spec.time_granularity,
                         arg=SqlColumnReferenceExpression(
                             SqlColumnReference(
                                 table_alias=time_spine_table_alias,
@@ -244,7 +244,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                             ),
                         ),
                     ),
-                    column_alias=metric_time_dimension_column_name,
+                    column_alias=agg_time_dimension_column_name,
                 ),
             )
             return SqlDataSet(
@@ -281,27 +281,26 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         input_data_set = node.parent_node.accept(self)
         input_data_set_alias = self._next_unique_table_alias()
 
-        metric_time_dimension_spec: Optional[TimeDimensionSpec] = None
-        metric_time_dimension_instance: Optional[TimeDimensionInstance] = None
+        agg_time_dimension_instance: Optional[TimeDimensionInstance] = None
         for instance in input_data_set.instance_set.time_dimension_instances:
             if instance.spec == node.time_dimension_spec_for_join:
-                metric_time_dimension_instance = instance
-                metric_time_dimension_spec = instance.spec
+                agg_time_dimension_instance = instance
                 break
+        assert (
+            agg_time_dimension_instance
+        ), "Specified metric time spec not found in parent data set. This should have been caught by validations."
 
-        assert metric_time_dimension_spec
         time_spine_data_set_alias = self._next_unique_table_alias()
 
-        metric_time_dimension_column_name = self.column_association_resolver.resolve_spec(
-            metric_time_dimension_spec
+        agg_time_dimension_column_name = self.column_association_resolver.resolve_spec(
+            agg_time_dimension_instance.spec
         ).column_name
 
         # Assemble time_spine dataset with metric_time_dimension to join.
         # Granularity of time_spine column should match granularity of metric_time column from parent dataset.
-        assert metric_time_dimension_instance
         time_spine_data_set = self._make_time_spine_data_set(
-            metric_time_dimension_instance=metric_time_dimension_instance,
-            metric_time_dimension_column_name=metric_time_dimension_column_name,
+            agg_time_dimension_instance=agg_time_dimension_instance,
+            agg_time_dimension_column_name=agg_time_dimension_column_name,
             time_spine_source=self._time_spine_source,
             time_range_constraint=node.time_range_constraint,
         )
@@ -309,12 +308,12 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
 
         # Figure out which columns correspond to the time dimension that we want to join on.
         input_data_set_metric_time_column_association = input_data_set.column_association_for_time_dimension(
-            metric_time_dimension_spec
+            agg_time_dimension_instance.spec
         )
         input_data_set_metric_time_col = input_data_set_metric_time_column_association.column_name
 
         time_spine_data_set_column_associations = time_spine_data_set.column_association_for_time_dimension(
-            metric_time_dimension_spec
+            agg_time_dimension_instance.spec
         )
         time_spine_data_set_time_dimension_col = time_spine_data_set_column_associations.column_name
 
@@ -342,7 +341,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                 [
                     time_dimension_instance
                     for time_dimension_instance in input_data_set.instance_set.time_dimension_instances
-                    if time_dimension_instance.spec != metric_time_dimension_spec
+                    if time_dimension_instance != agg_time_dimension_instance
                 ]
             ),
         )
@@ -1256,8 +1255,8 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         ).column_name
         time_spine_alias = self._next_unique_table_alias()
         time_spine_dataset = self._make_time_spine_data_set(
-            metric_time_dimension_instance=metric_time_dimension_instance,
-            metric_time_dimension_column_name=metric_time_dimension_column_name,
+            agg_time_dimension_instance=metric_time_dimension_instance,
+            agg_time_dimension_column_name=metric_time_dimension_column_name,
             time_spine_source=self._time_spine_source,
             time_range_constraint=node.time_range_constraint,
         )

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -283,8 +283,8 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
 
         metric_time_dimension_spec: Optional[TimeDimensionSpec] = None
         metric_time_dimension_instance: Optional[TimeDimensionInstance] = None
-        for instance in input_data_set.metric_time_dimension_instances:
-            if len(instance.spec.entity_links) == 0:
+        for instance in input_data_set.instance_set.time_dimension_instances:
+            if instance.spec == node.time_dimension_spec_for_join:
                 metric_time_dimension_instance = instance
                 metric_time_dimension_spec = instance.spec
                 break

--- a/metricflow/query/issues/parsing/cumulative_metric_requires_metric_time.py
+++ b/metricflow/query/issues/parsing/cumulative_metric_requires_metric_time.py
@@ -24,7 +24,8 @@ class CumulativeMetricRequiresMetricTimeIssue(MetricFlowQueryResolutionIssue):
     def ui_description(self, associated_input: MetricFlowQueryResolverInput) -> str:
         return (
             f"The query includes a cumulative metric {repr(self.metric_reference.element_name)} that does not "
-            f"accumulate over all-time, but the group-by items do not include {repr(METRIC_TIME_ELEMENT_NAME)}"
+            f"accumulate over all-time, but the group-by items do not include {repr(METRIC_TIME_ELEMENT_NAME)} "
+            "or the metric's agg_time_dimension."
         )
 
     @override

--- a/metricflow/query/validation_rules/metric_time_requirements.py
+++ b/metricflow/query/validation_rules/metric_time_requirements.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from typing import List, Sequence
+from typing import Sequence
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
 from dbt_semantic_interfaces.protocols import WhereFilterIntersection
-from dbt_semantic_interfaces.references import MetricReference
-from dbt_semantic_interfaces.type_enums import MetricType, TimeGranularity
-from dbt_semantic_interfaces.type_enums.date_part import DatePart
+from dbt_semantic_interfaces.references import MetricReference, TimeDimensionReference
+from dbt_semantic_interfaces.type_enums import MetricType
 from typing_extensions import override
 
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
@@ -34,33 +33,27 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
     def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
         super().__init__(manifest_lookup=manifest_lookup)
 
-        metric_time_specs: List[TimeDimensionSpec] = []
-
-        for time_granularity in TimeGranularity:
-            metric_time_specs.append(
-                TimeDimensionSpec(
-                    element_name=METRIC_TIME_ELEMENT_NAME,
-                    entity_links=(),
-                    time_granularity=time_granularity,
-                    date_part=None,
-                )
+        self._metric_time_specs = tuple(
+            TimeDimensionSpec.generate_possible_specs_for_time_dimension(
+                time_dimension_reference=TimeDimensionReference(element_name=METRIC_TIME_ELEMENT_NAME), entity_links=()
             )
-        for date_part in DatePart:
-            for time_granularity in date_part.compatible_granularities:
-                metric_time_specs.append(
-                    TimeDimensionSpec(
-                        element_name=METRIC_TIME_ELEMENT_NAME,
-                        entity_links=(),
-                        time_granularity=time_granularity,
-                        date_part=date_part,
-                    )
-                )
-
-        self._metric_time_specs = tuple(metric_time_specs)
+        )
 
     def _group_by_items_include_metric_time(self, query_resolver_input: ResolverInputForQuery) -> bool:
         for group_by_item_input in query_resolver_input.group_by_item_inputs:
             if group_by_item_input.spec_pattern.matches_any(self._metric_time_specs):
+                return True
+
+        return False
+
+    def _group_by_items_include_agg_time_dimension(
+        self, query_resolver_input: ResolverInputForQuery, metric_reference: MetricReference
+    ) -> bool:
+        valid_agg_time_dimension_specs = self._manifest_lookup.metric_lookup.get_valid_agg_time_dimensions_for_metric(
+            metric_reference
+        )
+        for group_by_item_input in query_resolver_input.group_by_item_inputs:
+            if group_by_item_input.spec_pattern.matches_any(valid_agg_time_dimension_specs):
                 return True
 
         return False
@@ -74,6 +67,12 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
     ) -> MetricFlowQueryResolutionIssueSet:
         metric = self._get_metric(metric_reference)
         query_includes_metric_time = self._group_by_items_include_metric_time(resolver_input_for_query)
+        query_includes_metric_time_or_agg_time_dimension = (
+            query_includes_metric_time
+            or self._group_by_items_include_agg_time_dimension(
+                query_resolver_input=resolver_input_for_query, metric_reference=metric_reference
+            )
+        )
 
         if metric.type is MetricType.SIMPLE or metric.type is MetricType.CONVERSION:
             return MetricFlowQueryResolutionIssueSet.empty_instance()
@@ -81,7 +80,7 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
             if (
                 metric.type_params is not None
                 and (metric.type_params.window is not None or metric.type_params.grain_to_date is not None)
-                and not query_includes_metric_time
+                and not query_includes_metric_time_or_agg_time_dimension
             ):
                 return MetricFlowQueryResolutionIssueSet.from_issue(
                     CumulativeMetricRequiresMetricTimeIssue.from_parameters(

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -174,6 +174,7 @@ def test_saved_query(  # noqa: D
     resp = cli_runner.run(
         query, args=["--saved-query", "p0_booking", "--order", "metric_time__day,listing__capacity_latest"]
     )
+    print(resp.output)
 
     assert resp.exit_code == 0
 
@@ -291,5 +292,5 @@ def test_saved_query_with_cumulative_metric(  # noqa: D
         snapshot_str=resp.output,
         sql_engine=sql_client.sql_engine_type,
     )
-
+    print(resp.output)
     assert resp.exit_code == 0

--- a/metricflow/test/integration/test_cases/itest_cumulative_metric.yaml
+++ b/metricflow/test/integration/test_cases/itest_cumulative_metric.yaml
@@ -384,3 +384,31 @@ integration_test:
     GROUP BY
       subq_3.metric_time__month
     ORDER BY subq_3.metric_time__month
+---
+integration_test:
+  name: cumulative_metric_with_agg_time_dimension
+  description: Query a cumulative metric with its agg_time_dimension and a time constraint.
+  model: SIMPLE_MODEL
+  metrics: ["trailing_2_months_revenue"]
+  group_bys: ["revenue_instance__ds__day"]
+  order_bys: ["revenue_instance__ds__day"]
+  where_filter: '{{ render_time_constraint("revenue_instance__ds__day", "2020-03-05", "2021-01-04") }}'
+  check_query: |
+    SELECT
+      SUM(b.txn_revenue) as trailing_2_months_revenue
+      , a.ds AS revenue_instance__ds__day
+    FROM (
+      SELECT ds
+      FROM {{ mf_time_spine_source }}
+      WHERE {{ render_time_constraint("ds", "2020-01-05", "2021-01-04") }}
+    ) a
+    INNER JOIN (
+      SELECT
+        revenue as txn_revenue
+        , created_at AS ds
+      FROM {{ source_schema }}.fct_revenue
+    ) b
+    ON b.ds <= a.ds AND b.ds > {{ render_date_sub("a", "ds", 2, TimeGranularity.MONTH) }}
+    WHERE {{ render_time_constraint("a.ds", "2020-03-05", "2021-01-04") }}
+    GROUP BY a.ds
+    ORDER BY a.ds

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -460,16 +460,7 @@ def test_cumulative_metric_wrong_time_dimension_validation() -> None:
 
 
 def test_cumulative_metric_agg_time_dimension_name_validation() -> None:
-    """Test that queries for cumulative metrics fail if the agg_time_dimension is selected by name.
-
-    Currently, cumulative metrics only return correct results if the query includes the `metric_time` virtual
-    dimension. In many cases the underlying agg_time_dimension is a single column and users will use it
-    directly instead of requesting metric_time. While shis should be fine, we cannot allow it until we fix
-    the query rendering issues that prevent this from working correctly.
-
-    This is a test of validation enforcement to ensure users don't get incorrect results due to current
-    limitations, and should be deleted or updated when this restriction is lifted.
-    """
+    """Test that queries for cumulative metrics succeed if the agg_time_dimension is selected by name."""
     bookings_yaml_file = YamlConfigFile(filepath="inline_for_test_1", contents=BOOKINGS_YAML)
     metrics_yaml_file = YamlConfigFile(filepath="inline_for_test_1", contents=METRICS_YAML)
     revenue_yaml_file = YamlConfigFile(filepath="inline_for_test_1", contents=REVENUE_YAML)
@@ -477,11 +468,7 @@ def test_cumulative_metric_agg_time_dimension_name_validation() -> None:
         [EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, bookings_yaml_file, revenue_yaml_file, metrics_yaml_file]
     )
 
-    with pytest.raises(InvalidQueryException, match="do not include 'metric_time'"):
-        query_parser.parse_and_validate_query(
-            metric_names=["revenue_cumulative"],
-            group_by_names=["company__ds"],
-        )
+    query_parser.parse_and_validate_query(metric_names=["revenue_cumulative"], group_by_names=["company__ds"])
 
 
 def test_derived_metric_query_parsing() -> None:

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -103,7 +103,7 @@ REVENUE_YAML = textwrap.dedent(
           type: categorical
           expr: country
 
-      primary_entity: company
+      primary_entity: revenue_instance
 
       entities:
         - name: user
@@ -455,7 +455,7 @@ def test_cumulative_metric_wrong_time_dimension_validation() -> None:
     with pytest.raises(InvalidQueryException, match="do not include 'metric_time'"):
         query_parser.parse_and_validate_query(
             metric_names=["revenue_cumulative"],
-            group_by_names=["company__loaded_at"],
+            group_by_names=["revenue_instance__loaded_at"],
         )
 
 
@@ -468,7 +468,7 @@ def test_cumulative_metric_agg_time_dimension_name_validation() -> None:
         [EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, bookings_yaml_file, revenue_yaml_file, metrics_yaml_file]
     )
 
-    query_parser.parse_and_validate_query(metric_names=["revenue_cumulative"], group_by_names=["company__ds"])
+    query_parser.parse_and_validate_query(metric_names=["revenue_cumulative"], group_by_names=["revenue_instance__ds"])
 
 
 def test_derived_metric_query_parsing() -> None:
@@ -518,7 +518,7 @@ def test_derived_metric_with_offset_parsing() -> None:
     with pytest.raises(InvalidQueryException, match="do not include 'metric_time'"):
         query_parser.parse_and_validate_query(
             metric_names=["revenue_growth_2_weeks"],
-            group_by_names=["company__country"],
+            group_by_names=["revenue_instance__country"],
         )
 
     # Query with time dimension

--- a/metricflow/test/query_rendering/test_cumulative_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_cumulative_metric_rendering.py
@@ -208,13 +208,7 @@ def test_cumulative_metric_no_window_with_time_constraint(
         MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="revenue_all_time"),),
             dimension_specs=(),
-            time_dimension_specs=(
-                TimeDimensionSpec(
-                    element_name="ds",
-                    entity_links=(),
-                    time_granularity=TimeGranularity.MONTH,
-                ),
-            ),
+            time_dimension_specs=(MTD_SPEC_MONTH,),
             time_range_constraint=TimeRangeConstraint(
                 start_time=as_datetime("2020-01-01"), end_time=as_datetime("2020-01-01")
             ),

--- a/metricflow/test/query_rendering/test_cumulative_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_cumulative_metric_rendering.py
@@ -15,11 +15,7 @@ from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanCon
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.specs.column_assoc import ColumnAssociationResolver
-from metricflow.specs.specs import (
-    MetricFlowQuerySpec,
-    MetricSpec,
-    TimeDimensionSpec,
-)
+from metricflow.specs.specs import EntityReference, MetricFlowQuerySpec, MetricSpec, TimeDimensionSpec
 from metricflow.test.fixtures.model_fixtures import ConsistentIdObjectRepository
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.query_rendering.compare_rendered_query import convert_and_check
@@ -292,6 +288,35 @@ def test_cumulative_metric_month(
         request=request,
         mf_test_session_state=mf_test_session_state,
         dataflow_to_sql_converter=extended_date_dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_cumulative_metric_with_agg_time_dimension(
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    consistent_id_object_repository: ConsistentIdObjectRepository,
+    sql_client: SqlClient,
+) -> None:
+    """Tests rendering a query for a cumulative metric queried with agg time dimension."""
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="trailing_2_months_revenue"),),
+            dimension_specs=(),
+            time_dimension_specs=(
+                TimeDimensionSpec(element_name="ds", entity_links=(EntityReference("revenue_instance"),)),
+            ),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
     )

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,129 +1,187 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS revenue_all_time
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.revenue_instance__ds__day
-        , subq_1.revenue_instance__ds__week
-        , subq_1.revenue_instance__ds__month
-        , subq_1.revenue_instance__ds__quarter
-        , subq_1.revenue_instance__ds__year
-        , subq_1.revenue_instance__ds__extract_year
-        , subq_1.revenue_instance__ds__extract_quarter
-        , subq_1.revenue_instance__ds__extract_month
-        , subq_1.revenue_instance__ds__extract_day
-        , subq_1.revenue_instance__ds__extract_dow
-        , subq_1.revenue_instance__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.revenue_instance__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.revenue_instance__ds__day
-          , subq_0.revenue_instance__ds__week
-          , subq_0.revenue_instance__ds__month
-          , subq_0.revenue_instance__ds__quarter
-          , subq_0.revenue_instance__ds__year
-          , subq_0.revenue_instance__ds__extract_year
-          , subq_0.revenue_instance__ds__extract_quarter
-          , subq_0.revenue_instance__ds__extract_month
-          , subq_0.revenue_instance__ds__extract_day
-          , subq_0.revenue_instance__ds__extract_dow
-          , subq_0.revenue_instance__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.revenue_instance__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Time Spine
           SELECT
-            revenue_src_10007.revenue AS txn_revenue
-            , DATE_TRUNC(revenue_src_10007.created_at, day) AS ds__day
-            , DATE_TRUNC(revenue_src_10007.created_at, isoweek) AS ds__week
-            , DATE_TRUNC(revenue_src_10007.created_at, month) AS ds__month
-            , DATE_TRUNC(revenue_src_10007.created_at, quarter) AS ds__quarter
-            , DATE_TRUNC(revenue_src_10007.created_at, year) AS ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
-            , IF(EXTRACT(dayofweek FROM revenue_src_10007.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_10007.created_at) - 1) AS ds__extract_dow
-            , EXTRACT(dayofyear FROM revenue_src_10007.created_at) AS ds__extract_doy
-            , DATE_TRUNC(revenue_src_10007.created_at, day) AS revenue_instance__ds__day
-            , DATE_TRUNC(revenue_src_10007.created_at, isoweek) AS revenue_instance__ds__week
-            , DATE_TRUNC(revenue_src_10007.created_at, month) AS revenue_instance__ds__month
-            , DATE_TRUNC(revenue_src_10007.created_at, quarter) AS revenue_instance__ds__quarter
-            , DATE_TRUNC(revenue_src_10007.created_at, year) AS revenue_instance__ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
-            , IF(EXTRACT(dayofweek FROM revenue_src_10007.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_10007.created_at) - 1) AS revenue_instance__ds__extract_dow
-            , EXTRACT(dayofyear FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
-            , revenue_src_10007.user_id AS user
-            , revenue_src_10007.user_id AS revenue_instance__user
-          FROM ***************************.fct_revenue revenue_src_10007
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            DATE_TRUNC(subq_4.ds, month) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+          GROUP BY
+            metric_time__month
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10007.revenue AS txn_revenue
+                , DATE_TRUNC(revenue_src_10007.created_at, day) AS ds__day
+                , DATE_TRUNC(revenue_src_10007.created_at, isoweek) AS ds__week
+                , DATE_TRUNC(revenue_src_10007.created_at, month) AS ds__month
+                , DATE_TRUNC(revenue_src_10007.created_at, quarter) AS ds__quarter
+                , DATE_TRUNC(revenue_src_10007.created_at, year) AS ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM revenue_src_10007.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_10007.created_at) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM revenue_src_10007.created_at) AS ds__extract_doy
+                , DATE_TRUNC(revenue_src_10007.created_at, day) AS revenue_instance__ds__day
+                , DATE_TRUNC(revenue_src_10007.created_at, isoweek) AS revenue_instance__ds__week
+                , DATE_TRUNC(revenue_src_10007.created_at, month) AS revenue_instance__ds__month
+                , DATE_TRUNC(revenue_src_10007.created_at, quarter) AS revenue_instance__ds__quarter
+                , DATE_TRUNC(revenue_src_10007.created_at, year) AS revenue_instance__ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM revenue_src_10007.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_10007.created_at) - 1) AS revenue_instance__ds__extract_dow
+                , EXTRACT(dayofyear FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+                , revenue_src_10007.user_id AS user
+                , revenue_src_10007.user_id AS revenue_instance__user
+              FROM ***************************.fct_revenue revenue_src_10007
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (subq_2.metric_time__month <= subq_3.metric_time__month)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    ds__month
-) subq_4
+    metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,13 +1,32 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
--- Pass Only Elements: ['txn_revenue', 'ds__month']
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC(created_at, month) AS ds__month
-  , SUM(revenue) AS revenue_all_time
-FROM ***************************.fct_revenue revenue_src_10007
-WHERE DATE_TRUNC(created_at, day) BETWEEN '2000-01-01' AND '2020-01-01'
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC(ds, month) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  GROUP BY
+    metric_time__month
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC(created_at, month) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10007
+  WHERE DATE_TRUNC(created_at, day) BETWEEN '2000-01-01' AND '2020-01-01'
+) subq_11
+ON
+  (subq_11.metric_time__month <= subq_12.metric_time__month)
+WHERE subq_12.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  ds__month
+  metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+        FROM ***************************.mf_time_spine subq_3
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_10007.revenue AS txn_revenue
+            , DATE_TRUNC(revenue_src_10007.created_at, day) AS ds__day
+            , DATE_TRUNC(revenue_src_10007.created_at, isoweek) AS ds__week
+            , DATE_TRUNC(revenue_src_10007.created_at, month) AS ds__month
+            , DATE_TRUNC(revenue_src_10007.created_at, quarter) AS ds__quarter
+            , DATE_TRUNC(revenue_src_10007.created_at, year) AS ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+            , IF(EXTRACT(dayofweek FROM revenue_src_10007.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_10007.created_at) - 1) AS ds__extract_dow
+            , EXTRACT(dayofyear FROM revenue_src_10007.created_at) AS ds__extract_doy
+            , DATE_TRUNC(revenue_src_10007.created_at, day) AS revenue_instance__ds__day
+            , DATE_TRUNC(revenue_src_10007.created_at, isoweek) AS revenue_instance__ds__week
+            , DATE_TRUNC(revenue_src_10007.created_at, month) AS revenue_instance__ds__month
+            , DATE_TRUNC(revenue_src_10007.created_at, quarter) AS revenue_instance__ds__quarter
+            , DATE_TRUNC(revenue_src_10007.created_at, year) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+            , IF(EXTRACT(dayofweek FROM revenue_src_10007.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_10007.created_at) - 1) AS revenue_instance__ds__extract_dow
+            , EXTRACT(dayofyear FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_10007.user_id AS user
+            , revenue_src_10007.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_10007
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > DATE_SUB(CAST(subq_2.revenue_instance__ds__day AS DATETIME), INTERVAL 2 month)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    revenue_instance__ds__day
+) subq_6

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
@@ -1,0 +1,18 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.ds AS revenue_instance__ds__day
+  , SUM(revenue_src_10007.revenue) AS trailing_2_months_revenue
+FROM ***************************.mf_time_spine subq_10
+INNER JOIN
+  ***************************.fct_revenue revenue_src_10007
+ON
+  (
+    DATE_TRUNC(revenue_src_10007.created_at, day) <= subq_10.ds
+  ) AND (
+    DATE_TRUNC(revenue_src_10007.created_at, day) > DATE_SUB(CAST(subq_10.ds AS DATETIME), INTERVAL 2 month)
+  )
+GROUP BY
+  revenue_instance__ds__day

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,129 +1,187 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS revenue_all_time
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.revenue_instance__ds__day
-        , subq_1.revenue_instance__ds__week
-        , subq_1.revenue_instance__ds__month
-        , subq_1.revenue_instance__ds__quarter
-        , subq_1.revenue_instance__ds__year
-        , subq_1.revenue_instance__ds__extract_year
-        , subq_1.revenue_instance__ds__extract_quarter
-        , subq_1.revenue_instance__ds__extract_month
-        , subq_1.revenue_instance__ds__extract_day
-        , subq_1.revenue_instance__ds__extract_dow
-        , subq_1.revenue_instance__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.revenue_instance__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.revenue_instance__ds__day
-          , subq_0.revenue_instance__ds__week
-          , subq_0.revenue_instance__ds__month
-          , subq_0.revenue_instance__ds__quarter
-          , subq_0.revenue_instance__ds__year
-          , subq_0.revenue_instance__ds__extract_year
-          , subq_0.revenue_instance__ds__extract_quarter
-          , subq_0.revenue_instance__ds__extract_month
-          , subq_0.revenue_instance__ds__extract_day
-          , subq_0.revenue_instance__ds__extract_dow
-          , subq_0.revenue_instance__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.revenue_instance__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Time Spine
           SELECT
-            revenue_src_10007.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_10007.created_at) AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
-            , revenue_src_10007.user_id AS user
-            , revenue_src_10007.user_id AS revenue_instance__user
-          FROM ***************************.fct_revenue revenue_src_10007
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+          GROUP BY
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10007.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_10007.created_at) AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+                , revenue_src_10007.user_id AS user
+                , revenue_src_10007.user_id AS revenue_instance__user
+              FROM ***************************.fct_revenue revenue_src_10007
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (subq_2.metric_time__month <= subq_3.metric_time__month)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,13 +1,32 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
--- Pass Only Elements: ['txn_revenue', 'ds__month']
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS revenue_all_time
-FROM ***************************.fct_revenue revenue_src_10007
-WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10007
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
+) subq_11
+ON
+  (subq_11.metric_time__month <= subq_12.metric_time__month)
+WHERE subq_12.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_12.metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+        FROM ***************************.mf_time_spine subq_3
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_10007.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_10007.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_10007.user_id AS user
+            , revenue_src_10007.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_10007
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > DATEADD(month, -2, subq_2.revenue_instance__ds__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+) subq_6

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
@@ -1,0 +1,18 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.ds AS revenue_instance__ds__day
+  , SUM(revenue_src_10007.revenue) AS trailing_2_months_revenue
+FROM ***************************.mf_time_spine subq_10
+INNER JOIN
+  ***************************.fct_revenue revenue_src_10007
+ON
+  (
+    DATE_TRUNC('day', revenue_src_10007.created_at) <= subq_10.ds
+  ) AND (
+    DATE_TRUNC('day', revenue_src_10007.created_at) > DATEADD(month, -2, subq_10.ds)
+  )
+GROUP BY
+  subq_10.ds

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,129 +1,187 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS revenue_all_time
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.revenue_instance__ds__day
-        , subq_1.revenue_instance__ds__week
-        , subq_1.revenue_instance__ds__month
-        , subq_1.revenue_instance__ds__quarter
-        , subq_1.revenue_instance__ds__year
-        , subq_1.revenue_instance__ds__extract_year
-        , subq_1.revenue_instance__ds__extract_quarter
-        , subq_1.revenue_instance__ds__extract_month
-        , subq_1.revenue_instance__ds__extract_day
-        , subq_1.revenue_instance__ds__extract_dow
-        , subq_1.revenue_instance__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.revenue_instance__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.revenue_instance__ds__day
-          , subq_0.revenue_instance__ds__week
-          , subq_0.revenue_instance__ds__month
-          , subq_0.revenue_instance__ds__quarter
-          , subq_0.revenue_instance__ds__year
-          , subq_0.revenue_instance__ds__extract_year
-          , subq_0.revenue_instance__ds__extract_quarter
-          , subq_0.revenue_instance__ds__extract_month
-          , subq_0.revenue_instance__ds__extract_day
-          , subq_0.revenue_instance__ds__extract_dow
-          , subq_0.revenue_instance__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.revenue_instance__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Time Spine
           SELECT
-            revenue_src_10007.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
-            , EXTRACT(isodow FROM revenue_src_10007.created_at) AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
-            , EXTRACT(isodow FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
-            , revenue_src_10007.user_id AS user
-            , revenue_src_10007.user_id AS revenue_instance__user
-          FROM ***************************.fct_revenue revenue_src_10007
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+          GROUP BY
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10007.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+                , EXTRACT(isodow FROM revenue_src_10007.created_at) AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+                , EXTRACT(isodow FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+                , revenue_src_10007.user_id AS user
+                , revenue_src_10007.user_id AS revenue_instance__user
+              FROM ***************************.fct_revenue revenue_src_10007
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (subq_2.metric_time__month <= subq_3.metric_time__month)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,13 +1,32 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
--- Pass Only Elements: ['txn_revenue', 'ds__month']
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS revenue_all_time
-FROM ***************************.fct_revenue revenue_src_10007
-WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10007
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
+) subq_11
+ON
+  (subq_11.metric_time__month <= subq_12.metric_time__month)
+WHERE subq_12.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_12.metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+        FROM ***************************.mf_time_spine subq_3
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_10007.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_10007.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_10007.user_id AS user
+            , revenue_src_10007.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_10007
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > subq_2.revenue_instance__ds__day - INTERVAL 2 month
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+) subq_6

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
@@ -1,0 +1,18 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.ds AS revenue_instance__ds__day
+  , SUM(revenue_src_10007.revenue) AS trailing_2_months_revenue
+FROM ***************************.mf_time_spine subq_10
+INNER JOIN
+  ***************************.fct_revenue revenue_src_10007
+ON
+  (
+    DATE_TRUNC('day', revenue_src_10007.created_at) <= subq_10.ds
+  ) AND (
+    DATE_TRUNC('day', revenue_src_10007.created_at) > subq_10.ds - INTERVAL 2 month
+  )
+GROUP BY
+  subq_10.ds

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,129 +1,187 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS revenue_all_time
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.revenue_instance__ds__day
-        , subq_1.revenue_instance__ds__week
-        , subq_1.revenue_instance__ds__month
-        , subq_1.revenue_instance__ds__quarter
-        , subq_1.revenue_instance__ds__year
-        , subq_1.revenue_instance__ds__extract_year
-        , subq_1.revenue_instance__ds__extract_quarter
-        , subq_1.revenue_instance__ds__extract_month
-        , subq_1.revenue_instance__ds__extract_day
-        , subq_1.revenue_instance__ds__extract_dow
-        , subq_1.revenue_instance__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.revenue_instance__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.revenue_instance__ds__day
-          , subq_0.revenue_instance__ds__week
-          , subq_0.revenue_instance__ds__month
-          , subq_0.revenue_instance__ds__quarter
-          , subq_0.revenue_instance__ds__year
-          , subq_0.revenue_instance__ds__extract_year
-          , subq_0.revenue_instance__ds__extract_quarter
-          , subq_0.revenue_instance__ds__extract_month
-          , subq_0.revenue_instance__ds__extract_day
-          , subq_0.revenue_instance__ds__extract_dow
-          , subq_0.revenue_instance__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.revenue_instance__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Time Spine
           SELECT
-            revenue_src_10007.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
-            , EXTRACT(isodow FROM revenue_src_10007.created_at) AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
-            , EXTRACT(isodow FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
-            , revenue_src_10007.user_id AS user
-            , revenue_src_10007.user_id AS revenue_instance__user
-          FROM ***************************.fct_revenue revenue_src_10007
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+          GROUP BY
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10007.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+                , EXTRACT(isodow FROM revenue_src_10007.created_at) AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+                , EXTRACT(isodow FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+                , revenue_src_10007.user_id AS user
+                , revenue_src_10007.user_id AS revenue_instance__user
+              FROM ***************************.fct_revenue revenue_src_10007
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (subq_2.metric_time__month <= subq_3.metric_time__month)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,13 +1,32 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
--- Pass Only Elements: ['txn_revenue', 'ds__month']
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS revenue_all_time
-FROM ***************************.fct_revenue revenue_src_10007
-WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10007
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
+) subq_11
+ON
+  (subq_11.metric_time__month <= subq_12.metric_time__month)
+WHERE subq_12.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_12.metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+        FROM ***************************.mf_time_spine subq_3
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_10007.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_10007.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_10007.user_id AS user
+            , revenue_src_10007.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_10007
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > subq_2.revenue_instance__ds__day - MAKE_INTERVAL(months => 2)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+) subq_6

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
@@ -1,0 +1,18 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.ds AS revenue_instance__ds__day
+  , SUM(revenue_src_10007.revenue) AS trailing_2_months_revenue
+FROM ***************************.mf_time_spine subq_10
+INNER JOIN
+  ***************************.fct_revenue revenue_src_10007
+ON
+  (
+    DATE_TRUNC('day', revenue_src_10007.created_at) <= subq_10.ds
+  ) AND (
+    DATE_TRUNC('day', revenue_src_10007.created_at) > subq_10.ds - MAKE_INTERVAL(months => 2)
+  )
+GROUP BY
+  subq_10.ds

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,129 +1,187 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS revenue_all_time
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.revenue_instance__ds__day
-        , subq_1.revenue_instance__ds__week
-        , subq_1.revenue_instance__ds__month
-        , subq_1.revenue_instance__ds__quarter
-        , subq_1.revenue_instance__ds__year
-        , subq_1.revenue_instance__ds__extract_year
-        , subq_1.revenue_instance__ds__extract_quarter
-        , subq_1.revenue_instance__ds__extract_month
-        , subq_1.revenue_instance__ds__extract_day
-        , subq_1.revenue_instance__ds__extract_dow
-        , subq_1.revenue_instance__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.revenue_instance__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.revenue_instance__ds__day
-          , subq_0.revenue_instance__ds__week
-          , subq_0.revenue_instance__ds__month
-          , subq_0.revenue_instance__ds__quarter
-          , subq_0.revenue_instance__ds__year
-          , subq_0.revenue_instance__ds__extract_year
-          , subq_0.revenue_instance__ds__extract_quarter
-          , subq_0.revenue_instance__ds__extract_month
-          , subq_0.revenue_instance__ds__extract_day
-          , subq_0.revenue_instance__ds__extract_dow
-          , subq_0.revenue_instance__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.revenue_instance__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Time Spine
           SELECT
-            revenue_src_10007.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
-            , CASE WHEN EXTRACT(dow FROM revenue_src_10007.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_10007.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_10007.created_at) END AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
-            , CASE WHEN EXTRACT(dow FROM revenue_src_10007.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_10007.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_10007.created_at) END AS revenue_instance__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
-            , revenue_src_10007.user_id AS user
-            , revenue_src_10007.user_id AS revenue_instance__user
-          FROM ***************************.fct_revenue revenue_src_10007
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+          GROUP BY
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10007.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM revenue_src_10007.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_10007.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_10007.created_at) END AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM revenue_src_10007.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_10007.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_10007.created_at) END AS revenue_instance__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+                , revenue_src_10007.user_id AS user
+                , revenue_src_10007.user_id AS revenue_instance__user
+              FROM ***************************.fct_revenue revenue_src_10007
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (subq_2.metric_time__month <= subq_3.metric_time__month)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,13 +1,32 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
--- Pass Only Elements: ['txn_revenue', 'ds__month']
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS revenue_all_time
-FROM ***************************.fct_revenue revenue_src_10007
-WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10007
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
+) subq_11
+ON
+  (subq_11.metric_time__month <= subq_12.metric_time__month)
+WHERE subq_12.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_12.metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+        FROM ***************************.mf_time_spine subq_3
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_10007.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM revenue_src_10007.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_10007.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_10007.created_at) END AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM revenue_src_10007.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_10007.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_10007.created_at) END AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_10007.user_id AS user
+            , revenue_src_10007.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_10007
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > DATEADD(month, -2, subq_2.revenue_instance__ds__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+) subq_6

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
@@ -1,0 +1,18 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.ds AS revenue_instance__ds__day
+  , SUM(revenue_src_10007.revenue) AS trailing_2_months_revenue
+FROM ***************************.mf_time_spine subq_10
+INNER JOIN
+  ***************************.fct_revenue revenue_src_10007
+ON
+  (
+    DATE_TRUNC('day', revenue_src_10007.created_at) <= subq_10.ds
+  ) AND (
+    DATE_TRUNC('day', revenue_src_10007.created_at) > DATEADD(month, -2, subq_10.ds)
+  )
+GROUP BY
+  subq_10.ds

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,129 +1,187 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS revenue_all_time
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.revenue_instance__ds__day
-        , subq_1.revenue_instance__ds__week
-        , subq_1.revenue_instance__ds__month
-        , subq_1.revenue_instance__ds__quarter
-        , subq_1.revenue_instance__ds__year
-        , subq_1.revenue_instance__ds__extract_year
-        , subq_1.revenue_instance__ds__extract_quarter
-        , subq_1.revenue_instance__ds__extract_month
-        , subq_1.revenue_instance__ds__extract_day
-        , subq_1.revenue_instance__ds__extract_dow
-        , subq_1.revenue_instance__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.revenue_instance__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.revenue_instance__ds__day
-          , subq_0.revenue_instance__ds__week
-          , subq_0.revenue_instance__ds__month
-          , subq_0.revenue_instance__ds__quarter
-          , subq_0.revenue_instance__ds__year
-          , subq_0.revenue_instance__ds__extract_year
-          , subq_0.revenue_instance__ds__extract_quarter
-          , subq_0.revenue_instance__ds__extract_month
-          , subq_0.revenue_instance__ds__extract_day
-          , subq_0.revenue_instance__ds__extract_dow
-          , subq_0.revenue_instance__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.revenue_instance__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Time Spine
           SELECT
-            revenue_src_10007.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
-            , EXTRACT(dayofweekiso FROM revenue_src_10007.created_at) AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
-            , EXTRACT(dayofweekiso FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
-            , revenue_src_10007.user_id AS user
-            , revenue_src_10007.user_id AS revenue_instance__user
-          FROM ***************************.fct_revenue revenue_src_10007
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
-    ) subq_2
-  ) subq_3
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN '2020-01-01' AND '2020-01-01'
+          GROUP BY
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10007.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM revenue_src_10007.created_at) AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+                , EXTRACT(dayofweekiso FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+                , revenue_src_10007.user_id AS user
+                , revenue_src_10007.user_id AS revenue_instance__user
+              FROM ***************************.fct_revenue revenue_src_10007
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
+        ) subq_2
+        ON
+          (subq_2.metric_time__month <= subq_3.metric_time__month)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,13 +1,32 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
--- Pass Only Elements: ['txn_revenue', 'ds__month']
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS revenue_all_time
-FROM ***************************.fct_revenue revenue_src_10007
-WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10007
+  WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
+) subq_11
+ON
+  (subq_11.metric_time__month <= subq_12.metric_time__month)
+WHERE subq_12.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_12.metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+        FROM ***************************.mf_time_spine subq_3
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_10007.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+            , EXTRACT(dayofweekiso FROM revenue_src_10007.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(dayofweekiso FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_10007.user_id AS user
+            , revenue_src_10007.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_10007
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > DATEADD(month, -2, subq_2.revenue_instance__ds__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+) subq_6

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
@@ -1,0 +1,18 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.ds AS revenue_instance__ds__day
+  , SUM(revenue_src_10007.revenue) AS trailing_2_months_revenue
+FROM ***************************.mf_time_spine subq_10
+INNER JOIN
+  ***************************.fct_revenue revenue_src_10007
+ON
+  (
+    DATE_TRUNC('day', revenue_src_10007.created_at) <= subq_10.ds
+  ) AND (
+    DATE_TRUNC('day', revenue_src_10007.created_at) > DATEADD(month, -2, subq_10.ds)
+  )
+GROUP BY
+  subq_10.ds

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,129 +1,187 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_4.ds__month
-  , subq_4.txn_revenue AS revenue_all_time
+  subq_8.metric_time__month
+  , subq_8.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_3.ds__month
-    , SUM(subq_3.txn_revenue) AS txn_revenue
+    subq_7.metric_time__month
+    , SUM(subq_7.txn_revenue) AS txn_revenue
   FROM (
-    -- Pass Only Elements: ['txn_revenue', 'ds__month']
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_2.ds__month
-      , subq_2.txn_revenue
+      subq_6.metric_time__month
+      , subq_6.txn_revenue
     FROM (
-      -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
       SELECT
-        subq_1.ds__day
-        , subq_1.ds__week
-        , subq_1.ds__month
-        , subq_1.ds__quarter
-        , subq_1.ds__year
-        , subq_1.ds__extract_year
-        , subq_1.ds__extract_quarter
-        , subq_1.ds__extract_month
-        , subq_1.ds__extract_day
-        , subq_1.ds__extract_dow
-        , subq_1.ds__extract_doy
-        , subq_1.revenue_instance__ds__day
-        , subq_1.revenue_instance__ds__week
-        , subq_1.revenue_instance__ds__month
-        , subq_1.revenue_instance__ds__quarter
-        , subq_1.revenue_instance__ds__year
-        , subq_1.revenue_instance__ds__extract_year
-        , subq_1.revenue_instance__ds__extract_quarter
-        , subq_1.revenue_instance__ds__extract_month
-        , subq_1.revenue_instance__ds__extract_day
-        , subq_1.revenue_instance__ds__extract_dow
-        , subq_1.revenue_instance__ds__extract_doy
-        , subq_1.metric_time__day
-        , subq_1.metric_time__week
-        , subq_1.metric_time__month
-        , subq_1.metric_time__quarter
-        , subq_1.metric_time__year
-        , subq_1.metric_time__extract_year
-        , subq_1.metric_time__extract_quarter
-        , subq_1.metric_time__extract_month
-        , subq_1.metric_time__extract_day
-        , subq_1.metric_time__extract_dow
-        , subq_1.metric_time__extract_doy
-        , subq_1.user
-        , subq_1.revenue_instance__user
-        , subq_1.txn_revenue
+        subq_5.metric_time__month
+        , subq_5.txn_revenue
       FROM (
-        -- Metric Time Dimension 'ds'
+        -- Join Self Over Time Range
         SELECT
-          subq_0.ds__day
-          , subq_0.ds__week
-          , subq_0.ds__month
-          , subq_0.ds__quarter
-          , subq_0.ds__year
-          , subq_0.ds__extract_year
-          , subq_0.ds__extract_quarter
-          , subq_0.ds__extract_month
-          , subq_0.ds__extract_day
-          , subq_0.ds__extract_dow
-          , subq_0.ds__extract_doy
-          , subq_0.revenue_instance__ds__day
-          , subq_0.revenue_instance__ds__week
-          , subq_0.revenue_instance__ds__month
-          , subq_0.revenue_instance__ds__quarter
-          , subq_0.revenue_instance__ds__year
-          , subq_0.revenue_instance__ds__extract_year
-          , subq_0.revenue_instance__ds__extract_quarter
-          , subq_0.revenue_instance__ds__extract_month
-          , subq_0.revenue_instance__ds__extract_day
-          , subq_0.revenue_instance__ds__extract_dow
-          , subq_0.revenue_instance__ds__extract_doy
-          , subq_0.ds__day AS metric_time__day
-          , subq_0.ds__week AS metric_time__week
-          , subq_0.ds__month AS metric_time__month
-          , subq_0.ds__quarter AS metric_time__quarter
-          , subq_0.ds__year AS metric_time__year
-          , subq_0.ds__extract_year AS metric_time__extract_year
-          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-          , subq_0.ds__extract_month AS metric_time__extract_month
-          , subq_0.ds__extract_day AS metric_time__extract_day
-          , subq_0.ds__extract_dow AS metric_time__extract_dow
-          , subq_0.ds__extract_doy AS metric_time__extract_doy
-          , subq_0.user
-          , subq_0.revenue_instance__user
-          , subq_0.txn_revenue
+          subq_3.metric_time__month AS metric_time__month
+          , subq_2.ds__day AS ds__day
+          , subq_2.ds__week AS ds__week
+          , subq_2.ds__month AS ds__month
+          , subq_2.ds__quarter AS ds__quarter
+          , subq_2.ds__year AS ds__year
+          , subq_2.ds__extract_year AS ds__extract_year
+          , subq_2.ds__extract_quarter AS ds__extract_quarter
+          , subq_2.ds__extract_month AS ds__extract_month
+          , subq_2.ds__extract_day AS ds__extract_day
+          , subq_2.ds__extract_dow AS ds__extract_dow
+          , subq_2.ds__extract_doy AS ds__extract_doy
+          , subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+          , subq_2.revenue_instance__ds__week AS revenue_instance__ds__week
+          , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+          , subq_2.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+          , subq_2.revenue_instance__ds__year AS revenue_instance__ds__year
+          , subq_2.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+          , subq_2.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+          , subq_2.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+          , subq_2.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+          , subq_2.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+          , subq_2.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+          , subq_2.metric_time__day AS metric_time__day
+          , subq_2.metric_time__week AS metric_time__week
+          , subq_2.metric_time__quarter AS metric_time__quarter
+          , subq_2.metric_time__year AS metric_time__year
+          , subq_2.metric_time__extract_year AS metric_time__extract_year
+          , subq_2.metric_time__extract_quarter AS metric_time__extract_quarter
+          , subq_2.metric_time__extract_month AS metric_time__extract_month
+          , subq_2.metric_time__extract_day AS metric_time__extract_day
+          , subq_2.metric_time__extract_dow AS metric_time__extract_dow
+          , subq_2.metric_time__extract_doy AS metric_time__extract_doy
+          , subq_2.user AS user
+          , subq_2.revenue_instance__user AS revenue_instance__user
+          , subq_2.txn_revenue AS txn_revenue
         FROM (
-          -- Read Elements From Semantic Model 'revenue'
+          -- Time Spine
           SELECT
-            revenue_src_10007.revenue AS txn_revenue
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM revenue_src_10007.created_at) AS ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
-            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
-            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
-            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
-            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
-            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
-            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
-            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
-            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
-            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
-            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
-            , revenue_src_10007.user_id AS user
-            , revenue_src_10007.user_id AS revenue_instance__user
-          FROM ***************************.fct_revenue revenue_src_10007
-        ) subq_0
-      ) subq_1
-      WHERE subq_1.metric_time__day BETWEEN timestamp '2000-01-01' AND timestamp '2020-01-01'
-    ) subq_2
-  ) subq_3
+            DATE_TRUNC('month', subq_4.ds) AS metric_time__month
+          FROM ***************************.mf_time_spine subq_4
+          WHERE subq_4.ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+          GROUP BY
+            DATE_TRUNC('month', subq_4.ds)
+        ) subq_3
+        INNER JOIN (
+          -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+          SELECT
+            subq_1.ds__day
+            , subq_1.ds__week
+            , subq_1.ds__month
+            , subq_1.ds__quarter
+            , subq_1.ds__year
+            , subq_1.ds__extract_year
+            , subq_1.ds__extract_quarter
+            , subq_1.ds__extract_month
+            , subq_1.ds__extract_day
+            , subq_1.ds__extract_dow
+            , subq_1.ds__extract_doy
+            , subq_1.revenue_instance__ds__day
+            , subq_1.revenue_instance__ds__week
+            , subq_1.revenue_instance__ds__month
+            , subq_1.revenue_instance__ds__quarter
+            , subq_1.revenue_instance__ds__year
+            , subq_1.revenue_instance__ds__extract_year
+            , subq_1.revenue_instance__ds__extract_quarter
+            , subq_1.revenue_instance__ds__extract_month
+            , subq_1.revenue_instance__ds__extract_day
+            , subq_1.revenue_instance__ds__extract_dow
+            , subq_1.revenue_instance__ds__extract_doy
+            , subq_1.metric_time__day
+            , subq_1.metric_time__week
+            , subq_1.metric_time__month
+            , subq_1.metric_time__quarter
+            , subq_1.metric_time__year
+            , subq_1.metric_time__extract_year
+            , subq_1.metric_time__extract_quarter
+            , subq_1.metric_time__extract_month
+            , subq_1.metric_time__extract_day
+            , subq_1.metric_time__extract_dow
+            , subq_1.metric_time__extract_doy
+            , subq_1.user
+            , subq_1.revenue_instance__user
+            , subq_1.txn_revenue
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.revenue_instance__ds__day
+              , subq_0.revenue_instance__ds__week
+              , subq_0.revenue_instance__ds__month
+              , subq_0.revenue_instance__ds__quarter
+              , subq_0.revenue_instance__ds__year
+              , subq_0.revenue_instance__ds__extract_year
+              , subq_0.revenue_instance__ds__extract_quarter
+              , subq_0.revenue_instance__ds__extract_month
+              , subq_0.revenue_instance__ds__extract_day
+              , subq_0.revenue_instance__ds__extract_dow
+              , subq_0.revenue_instance__ds__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.user
+              , subq_0.revenue_instance__user
+              , subq_0.txn_revenue
+            FROM (
+              -- Read Elements From Semantic Model 'revenue'
+              SELECT
+                revenue_src_10007.revenue AS txn_revenue
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM revenue_src_10007.created_at) AS ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+                , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+                , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+                , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+                , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+                , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+                , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+                , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+                , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+                , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
+                , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+                , revenue_src_10007.user_id AS user
+                , revenue_src_10007.user_id AS revenue_instance__user
+              FROM ***************************.fct_revenue revenue_src_10007
+            ) subq_0
+          ) subq_1
+          WHERE subq_1.metric_time__day BETWEEN timestamp '2000-01-01' AND timestamp '2020-01-01'
+        ) subq_2
+        ON
+          (subq_2.metric_time__month <= subq_3.metric_time__month)
+      ) subq_5
+    ) subq_6
+    WHERE subq_6.metric_time__month BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+  ) subq_7
   GROUP BY
-    subq_3.ds__month
-) subq_4
+    subq_7.metric_time__month
+) subq_8

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,13 +1,32 @@
--- Read Elements From Semantic Model 'revenue'
--- Metric Time Dimension 'ds'
--- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
--- Pass Only Elements: ['txn_revenue', 'ds__month']
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', created_at) AS ds__month
-  , SUM(revenue) AS revenue_all_time
-FROM ***************************.fct_revenue revenue_src_10007
-WHERE DATE_TRUNC('day', created_at) BETWEEN timestamp '2000-01-01' AND timestamp '2020-01-01'
+  subq_12.metric_time__month AS metric_time__month
+  , SUM(subq_11.txn_revenue) AS revenue_all_time
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_13
+  WHERE ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+  GROUP BY
+    DATE_TRUNC('month', ds)
+) subq_12
+INNER JOIN (
+  -- Read Elements From Semantic Model 'revenue'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
+  SELECT
+    DATE_TRUNC('month', created_at) AS metric_time__month
+    , revenue AS txn_revenue
+  FROM ***************************.fct_revenue revenue_src_10007
+  WHERE DATE_TRUNC('day', created_at) BETWEEN timestamp '2000-01-01' AND timestamp '2020-01-01'
+) subq_11
+ON
+  (subq_11.metric_time__month <= subq_12.metric_time__month)
+WHERE subq_12.metric_time__month BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
 GROUP BY
-  DATE_TRUNC('month', created_at)
+  subq_12.metric_time__month

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_dimension__plan0.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_dimension__plan0.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+        FROM ***************************.mf_time_spine subq_3
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_10007.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM revenue_src_10007.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_10007.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_10007.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_10007.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_10007.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_10007.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_10007.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_10007.user_id AS user
+            , revenue_src_10007.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_10007
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > DATE_ADD('month', -2, subq_2.revenue_instance__ds__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+) subq_6

--- a/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_dimension__plan0_optimized.sql
@@ -1,0 +1,18 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.ds AS revenue_instance__ds__day
+  , SUM(revenue_src_10007.revenue) AS trailing_2_months_revenue
+FROM ***************************.mf_time_spine subq_10
+INNER JOIN
+  ***************************.fct_revenue revenue_src_10007
+ON
+  (
+    DATE_TRUNC('day', revenue_src_10007.created_at) <= subq_10.ds
+  ) AND (
+    DATE_TRUNC('day', revenue_src_10007.created_at) > DATE_ADD('month', -2, subq_10.ds)
+  )
+GROUP BY
+  subq_10.ds


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves #1000


### Description
Enable querying cumulative metrics with their `agg_time_dimension`. Should have the same behavior as when queried with `metric_time`.
 <!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
