### PR TITLE
Enable querying time offset metrics with `agg_time_dimension`

### DIFF
--- a/.changes/unreleased/Features-20240126-132734.yaml
+++ b/.changes/unreleased/Features-20240126-132734.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Enable offset metrics to be queried with agg_time_dimension.
+time: 2024-01-26T13:27:34.200253-08:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1006"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -515,7 +515,7 @@ class DataflowPlanBuilder:
                 )
             assert (
                 queried_agg_time_dimension_specs
-            ), "Joining to time spine requires querying with metric_timeor the appropriate agg_time_dimension."
+            ), "Joining to time spine requires querying with metric_time or the appropriate agg_time_dimension."
             output_node = JoinToTimeSpineNode(
                 parent_node=output_node,
                 requested_agg_time_dimension_specs=queried_agg_time_dimension_specs,

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -505,14 +505,9 @@ class DataflowPlanBuilder:
 
         # For nested ratio / derived metrics with time offset, apply offset & where constraint after metric computation.
         if metric_spec.has_time_offset:
-            queried_agg_time_dimension_specs = list(queried_linkable_specs.metric_time_specs)
-            if not queried_agg_time_dimension_specs:
-                valid_agg_time_dimensions = self._metric_lookup.get_valid_agg_time_dimensions_for_metric(
-                    metric_spec.reference
-                )
-                queried_agg_time_dimension_specs = list(
-                    set(queried_linkable_specs.time_dimension_specs).intersection(set(valid_agg_time_dimensions))
-                )
+            queried_agg_time_dimension_specs = queried_linkable_specs.included_agg_time_dimension_specs_for_metric(
+                metric_reference=metric_spec.reference, metric_lookup=self._metric_lookup
+            )
             assert (
                 queried_agg_time_dimension_specs
             ), "Joining to time spine requires querying with metric_time or the appropriate agg_time_dimension."
@@ -1296,14 +1291,9 @@ class DataflowPlanBuilder:
                 f"Recipe not found for measure spec: {measure_spec} and linkable specs: {required_linkable_specs}"
             )
 
-        queried_agg_time_dimension_specs = list(queried_linkable_specs.metric_time_specs)
-        if not queried_agg_time_dimension_specs:
-            valid_agg_time_dimensions = self._semantic_model_lookup.get_agg_time_dimension_specs_for_measure(
-                measure_spec.reference
-            )
-            queried_agg_time_dimension_specs = list(
-                set(queried_linkable_specs.time_dimension_specs).intersection(set(valid_agg_time_dimensions))
-            )
+        queried_agg_time_dimension_specs = queried_linkable_specs.included_agg_time_dimension_specs_for_measure(
+            measure_reference=measure_spec.reference, semantic_model_lookup=self._semantic_model_lookup
+        )
 
         # If a cumulative metric is queried with metric_time, join over time range.
         # Otherwise, the measure will be aggregated over all time.

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -514,6 +514,7 @@ class DataflowPlanBuilder:
             output_node = JoinToTimeSpineNode(
                 parent_node=output_node,
                 requested_agg_time_dimension_specs=queried_agg_time_dimension_specs,
+                query_includes_metric_time=queried_linkable_specs.contains_metric_time,
                 time_range_constraint=time_range_constraint,
                 offset_window=metric_spec.offset_window,
                 offset_to_grain=metric_spec.offset_to_grain,
@@ -1327,6 +1328,7 @@ class DataflowPlanBuilder:
             join_to_time_spine_node = JoinToTimeSpineNode(
                 parent_node=time_range_node or measure_recipe.source_node,
                 requested_agg_time_dimension_specs=queried_agg_time_dimension_specs,
+                query_includes_metric_time=queried_linkable_specs.contains_metric_time,
                 time_range_constraint=time_range_constraint,
                 offset_window=before_aggregation_time_spine_join_description.offset_window,
                 offset_to_grain=before_aggregation_time_spine_join_description.offset_to_grain,
@@ -1431,6 +1433,7 @@ class DataflowPlanBuilder:
             return JoinToTimeSpineNode(
                 parent_node=aggregate_measures_node,
                 requested_agg_time_dimension_specs=list(queried_linkable_specs.metric_time_specs),
+                query_includes_metric_time=queried_linkable_specs.contains_metric_time,
                 join_type=after_aggregation_time_spine_join_description.join_type,
                 time_range_constraint=time_range_constraint,
                 offset_window=after_aggregation_time_spine_join_description.offset_window,

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -510,7 +510,7 @@ class DataflowPlanBuilder:
             ), "Joining to time spine requires querying with metric_time."
             output_node = JoinToTimeSpineNode(
                 parent_node=output_node,
-                requested_metric_time_dimension_specs=list(queried_linkable_specs.metric_time_specs),
+                requested_agg_time_dimension_specs=list(queried_linkable_specs.metric_time_specs),
                 time_range_constraint=time_range_constraint,
                 offset_window=metric_spec.offset_window,
                 offset_to_grain=metric_spec.offset_to_grain,
@@ -1315,7 +1315,7 @@ class DataflowPlanBuilder:
             )
             join_to_time_spine_node = JoinToTimeSpineNode(
                 parent_node=time_range_node or measure_recipe.source_node,
-                requested_metric_time_dimension_specs=list(queried_linkable_specs.metric_time_specs),
+                requested_agg_time_dimension_specs=list(queried_linkable_specs.metric_time_specs),
                 time_range_constraint=time_range_constraint,
                 offset_window=before_aggregation_time_spine_join_description.offset_window,
                 offset_to_grain=before_aggregation_time_spine_join_description.offset_to_grain,
@@ -1418,7 +1418,7 @@ class DataflowPlanBuilder:
             )
             return JoinToTimeSpineNode(
                 parent_node=aggregate_measures_node,
-                requested_metric_time_dimension_specs=list(queried_linkable_specs.metric_time_specs),
+                requested_agg_time_dimension_specs=list(queried_linkable_specs.metric_time_specs),
                 join_type=after_aggregation_time_spine_join_description.join_type,
                 time_range_constraint=time_range_constraint,
                 offset_window=after_aggregation_time_spine_join_description.offset_window,

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -673,6 +673,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         self,
         parent_node: BaseOutput,
         requested_agg_time_dimension_specs: List[TimeDimensionSpec],
+        query_includes_metric_time: bool,
         join_type: SqlJoinType,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
         offset_window: Optional[MetricTimeWindow] = None,
@@ -683,6 +684,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         Args:
             parent_node: Node that returns desired dataset to join to time spine.
             requested_agg_time_dimension_specs: Time dimensions requested in query.
+            query_includes_metric_time: Indicates if metric time was queried.
             time_range_constraint: Time range to constrain the time spine to.
             offset_window: Time window to offset the parent dataset by when joining to time spine.
             offset_to_grain: Granularity period to offset the parent dataset to when joining to time spine.
@@ -698,6 +700,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
 
         self._parent_node = parent_node
         self._requested_agg_time_dimension_specs = requested_agg_time_dimension_specs
+        self._query_includes_metric_time = query_includes_metric_time
         self._offset_window = offset_window
         self._offset_to_grain = offset_to_grain
         self._time_range_constraint = time_range_constraint
@@ -713,6 +716,11 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
     def requested_agg_time_dimension_specs(self) -> List[TimeDimensionSpec]:
         """Time dimension specs to use when creating time spine table."""
         return self._requested_agg_time_dimension_specs
+
+    @property
+    def query_includes_metric_time(self) -> bool:
+        """Whether or not metric_time was included in the query."""
+        return self._query_includes_metric_time
 
     @property
     def time_range_constraint(self) -> Optional[TimeRangeConstraint]:
@@ -745,6 +753,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
     def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
         return super().displayed_properties + [
             DisplayedProperty("requested_agg_time_dimension_specs", self._requested_agg_time_dimension_specs),
+            DisplayedProperty("query_includes_metric_time", self._query_includes_metric_time),
             DisplayedProperty("time_range_constraint", self._time_range_constraint),
             DisplayedProperty("offset_window", self._offset_window),
             DisplayedProperty("offset_to_grain", self._offset_to_grain),
@@ -762,6 +771,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
             and other_node.offset_window == self.offset_window
             and other_node.offset_to_grain == self.offset_to_grain
             and other_node.requested_agg_time_dimension_specs == self.requested_agg_time_dimension_specs
+            and other_node.query_includes_metric_time == self.query_includes_metric_time
             and other_node.join_type == self.join_type
         )
 
@@ -770,6 +780,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         return JoinToTimeSpineNode(
             parent_node=new_parent_nodes[0],
             requested_agg_time_dimension_specs=self.requested_agg_time_dimension_specs,
+            query_includes_metric_time=self.query_includes_metric_time,
             time_range_constraint=self.time_range_constraint,
             offset_window=self.offset_window,
             offset_to_grain=self.offset_to_grain,

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -692,6 +692,10 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         assert not (
             offset_window and offset_to_grain
         ), "Can't set both offset_window and offset_to_grain when joining to time spine. Choose one or the other."
+        assert (
+            len(requested_agg_time_dimension_specs) > 0
+        ), "Must have at least one value in requested_agg_time_dimension_specs for JoinToTimeSpineNode."
+
         self._parent_node = parent_node
         self._requested_agg_time_dimension_specs = requested_agg_time_dimension_specs
         self._offset_window = offset_window

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -668,7 +668,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
     def __init__(
         self,
         parent_node: BaseOutput,
-        requested_metric_time_dimension_specs: List[TimeDimensionSpec],
+        requested_agg_time_dimension_specs: List[TimeDimensionSpec],
         join_type: SqlJoinType,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
         offset_window: Optional[MetricTimeWindow] = None,
@@ -678,7 +678,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
 
         Args:
             parent_node: Node that returns desired dataset to join to time spine.
-            requested_metric_time_dimension_specs: Time dimensions requested in query. Used to determine granularities.
+            requested_agg_time_dimension_specs: Time dimensions requested in query.
             time_range_constraint: Time range to constrain the time spine to.
             offset_window: Time window to offset the parent dataset by when joining to time spine.
             offset_to_grain: Granularity period to offset the parent dataset to when joining to time spine.
@@ -689,7 +689,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
             offset_window and offset_to_grain
         ), "Can't set both offset_window and offset_to_grain when joining to time spine. Choose one or the other."
         self._parent_node = parent_node
-        self._requested_metric_time_dimension_specs = requested_metric_time_dimension_specs
+        self._requested_agg_time_dimension_specs = requested_agg_time_dimension_specs
         self._offset_window = offset_window
         self._offset_to_grain = offset_to_grain
         self._time_range_constraint = time_range_constraint
@@ -702,9 +702,9 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         return DATAFLOW_NODE_JOIN_TO_TIME_SPINE_ID_PREFIX
 
     @property
-    def requested_metric_time_dimension_specs(self) -> List[TimeDimensionSpec]:
+    def requested_agg_time_dimension_specs(self) -> List[TimeDimensionSpec]:
         """Time dimension specs to use when creating time spine table."""
-        return self._requested_metric_time_dimension_specs
+        return self._requested_agg_time_dimension_specs
 
     @property
     def time_range_constraint(self) -> Optional[TimeRangeConstraint]:
@@ -736,7 +736,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
     @property
     def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
         return super().displayed_properties + [
-            DisplayedProperty("requested_metric_time_dimension_specs", self._requested_metric_time_dimension_specs),
+            DisplayedProperty("requested_agg_time_dimension_specs", self._requested_agg_time_dimension_specs),
             DisplayedProperty("time_range_constraint", self._time_range_constraint),
             DisplayedProperty("offset_window", self._offset_window),
             DisplayedProperty("offset_to_grain", self._offset_to_grain),
@@ -753,7 +753,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
             and other_node.time_range_constraint == self.time_range_constraint
             and other_node.offset_window == self.offset_window
             and other_node.offset_to_grain == self.offset_to_grain
-            and other_node.requested_metric_time_dimension_specs == self.requested_metric_time_dimension_specs
+            and other_node.requested_agg_time_dimension_specs == self.requested_agg_time_dimension_specs
             and other_node.join_type == self.join_type
         )
 
@@ -761,7 +761,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         assert len(new_parent_nodes) == 1
         return JoinToTimeSpineNode(
             parent_node=new_parent_nodes[0],
-            requested_metric_time_dimension_specs=self.requested_metric_time_dimension_specs,
+            requested_agg_time_dimension_specs=self.requested_agg_time_dimension_specs,
             time_range_constraint=self.time_range_constraint,
             offset_window=self.offset_window,
             offset_to_grain=self.offset_to_grain,

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -673,7 +673,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         self,
         parent_node: BaseOutput,
         requested_agg_time_dimension_specs: List[TimeDimensionSpec],
-        query_includes_metric_time: bool,
+        use_custom_agg_time_dimension: bool,
         join_type: SqlJoinType,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
         offset_window: Optional[MetricTimeWindow] = None,
@@ -684,7 +684,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         Args:
             parent_node: Node that returns desired dataset to join to time spine.
             requested_agg_time_dimension_specs: Time dimensions requested in query.
-            query_includes_metric_time: Indicates if metric time was queried.
+            use_custom_agg_time_dimension: Indicates if agg_time_dimension should be used in join. If false, uses metric_time.
             time_range_constraint: Time range to constrain the time spine to.
             offset_window: Time window to offset the parent dataset by when joining to time spine.
             offset_to_grain: Granularity period to offset the parent dataset to when joining to time spine.
@@ -700,7 +700,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
 
         self._parent_node = parent_node
         self._requested_agg_time_dimension_specs = requested_agg_time_dimension_specs
-        self._query_includes_metric_time = query_includes_metric_time
+        self._use_custom_agg_time_dimension = use_custom_agg_time_dimension
         self._offset_window = offset_window
         self._offset_to_grain = offset_to_grain
         self._time_range_constraint = time_range_constraint
@@ -718,9 +718,9 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         return self._requested_agg_time_dimension_specs
 
     @property
-    def query_includes_metric_time(self) -> bool:
+    def use_custom_agg_time_dimension(self) -> bool:
         """Whether or not metric_time was included in the query."""
-        return self._query_includes_metric_time
+        return self._use_custom_agg_time_dimension
 
     @property
     def time_range_constraint(self) -> Optional[TimeRangeConstraint]:
@@ -753,7 +753,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
     def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
         return super().displayed_properties + [
             DisplayedProperty("requested_agg_time_dimension_specs", self._requested_agg_time_dimension_specs),
-            DisplayedProperty("query_includes_metric_time", self._query_includes_metric_time),
+            DisplayedProperty("use_custom_agg_time_dimension", self._use_custom_agg_time_dimension),
             DisplayedProperty("time_range_constraint", self._time_range_constraint),
             DisplayedProperty("offset_window", self._offset_window),
             DisplayedProperty("offset_to_grain", self._offset_to_grain),
@@ -771,7 +771,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
             and other_node.offset_window == self.offset_window
             and other_node.offset_to_grain == self.offset_to_grain
             and other_node.requested_agg_time_dimension_specs == self.requested_agg_time_dimension_specs
-            and other_node.query_includes_metric_time == self.query_includes_metric_time
+            and other_node.use_custom_agg_time_dimension == self.use_custom_agg_time_dimension
             and other_node.join_type == self.join_type
         )
 
@@ -780,7 +780,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         return JoinToTimeSpineNode(
             parent_node=new_parent_nodes[0],
             requested_agg_time_dimension_specs=self.requested_agg_time_dimension_specs,
-            query_includes_metric_time=self.query_includes_metric_time,
+            use_custom_agg_time_dimension=self.use_custom_agg_time_dimension,
             time_range_constraint=self.time_range_constraint,
             offset_window=self.offset_window,
             offset_to_grain=self.offset_to_grain,

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1244,10 +1244,6 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         parent_data_set = node.parent_node.accept(self)
         parent_alias = self._next_unique_table_alias()
 
-        assert (
-            len(node.requested_agg_time_dimension_specs) > 0
-        ), "Must have at least one value in requested_agg_time_dimension_specs for JoinToTimeSpineNode."
-
         # Determine if the time spine join should use metric_time or the agg_time_dimension (metric_time takes priority).
         agg_time_dimension_for_join = node.requested_agg_time_dimension_specs[0]
         for spec in node.requested_agg_time_dimension_specs[1:]:

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -249,13 +249,15 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                     from_source_alias=time_spine_table_alias,
                     joins_descs=(),
                     group_bys=(),
-                    where=_make_time_range_comparison_expr(
-                        table_alias=time_spine_table_alias,
-                        column_alias=time_spine_source.time_column_name,
-                        time_range_constraint=time_range_constraint,
-                    )
-                    if time_range_constraint
-                    else None,
+                    where=(
+                        _make_time_range_comparison_expr(
+                            table_alias=time_spine_table_alias,
+                            column_alias=time_spine_source.time_column_name,
+                            time_range_constraint=time_range_constraint,
+                        )
+                        if time_range_constraint
+                        else None
+                    ),
                     order_bys=(),
                 ),
             )
@@ -284,13 +286,15 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                     from_source_alias=time_spine_table_alias,
                     joins_descs=(),
                     group_bys=select_columns,
-                    where=_make_time_range_comparison_expr(
-                        table_alias=time_spine_table_alias,
-                        column_alias=time_spine_source.time_column_name,
-                        time_range_constraint=time_range_constraint,
-                    )
-                    if time_range_constraint
-                    else None,
+                    where=(
+                        _make_time_range_comparison_expr(
+                            table_alias=time_spine_table_alias,
+                            column_alias=time_spine_source.time_column_name,
+                            time_range_constraint=time_range_constraint,
+                        )
+                        if time_range_constraint
+                        else None
+                    ),
                     order_bys=(),
                 ),
             )
@@ -1244,13 +1248,13 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         parent_data_set = node.parent_node.accept(self)
         parent_alias = self._next_unique_table_alias()
 
-        if node.query_includes_metric_time:
-            agg_time_element_name = METRIC_TIME_ELEMENT_NAME
-            agg_time_entity_links: Tuple[EntityReference, ...] = ()
-        else:
+        if node.use_custom_agg_time_dimension:
             agg_time_dimension = node.requested_agg_time_dimension_specs[0]
             agg_time_element_name = agg_time_dimension.element_name
-            agg_time_entity_links = agg_time_dimension.entity_links
+            agg_time_entity_links: Tuple[EntityReference, ...] = agg_time_dimension.entity_links
+        else:
+            agg_time_element_name = METRIC_TIME_ELEMENT_NAME
+            agg_time_entity_links = ()
 
         # Find the time dimension instances in the parent data set that match the one we want to join with.
         agg_time_dimension_instances: List[TimeDimensionInstance] = []

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1309,7 +1309,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         time_spine_select_columns = []
         time_spine_dim_instances = []
         where: Optional[SqlExpressionNode] = None
-        for requested_time_dimension_spec in node.requested_metric_time_dimension_specs:
+        for requested_time_dimension_spec in node.requested_agg_time_dimension_specs:
             # Apply granularity to time spine column select expression.
             if requested_time_dimension_spec.time_granularity == time_spine_dim_instance.spec.time_granularity:
                 select_expr: SqlExpressionNode = time_spine_column_select_expr

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from typing import List, Optional, Sequence, Tuple, Union
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
 from dbt_semantic_interfaces.protocols.metric import MetricInputMeasure, MetricType
 from dbt_semantic_interfaces.references import MetricModelReference
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
@@ -1244,56 +1245,77 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         parent_data_set = node.parent_node.accept(self)
         parent_alias = self._next_unique_table_alias()
 
-        # Build time spine dataset
-        metric_time_dimension_instance: Optional[TimeDimensionInstance] = None
-        for instance in parent_data_set.metric_time_dimension_instances:
-            if len(instance.spec.entity_links) == 0:
-                # Use the instance with the lowest granularity
-                if not metric_time_dimension_instance or (
-                    instance.spec.time_granularity < metric_time_dimension_instance.spec.time_granularity
-                ):
-                    metric_time_dimension_instance = instance
         assert (
-            metric_time_dimension_instance
-        ), "Can't join to time spine without metric time. Validations should have prevented this."
-        metric_time_dimension_column_name = self.column_association_resolver.resolve_spec(
-            metric_time_dimension_instance.spec
+            len(node.requested_agg_time_dimension_specs) > 0
+        ), "Must have at least one value in requested_agg_time_dimension_specs for JoinToTimeSpineNode."
+
+        # Determine if the time spine join should use metric_time or the agg_time_dimension (metric_time takes priority).
+        agg_time_dimension_for_join = node.requested_agg_time_dimension_specs[0]
+        for spec in node.requested_agg_time_dimension_specs[1:]:
+            if spec.element_name == METRIC_TIME_ELEMENT_NAME:
+                agg_time_dimension_for_join = spec
+                break
+
+        # Find the time dimension instances in the parent data set that match the one we want to join with.
+        agg_time_dimension_instances: List[TimeDimensionInstance] = []
+        for instance in parent_data_set.instance_set.time_dimension_instances:
+            if (
+                instance.spec.date_part is None  # Ensure we don't join using an instance with date part
+                and instance.spec.element_name == agg_time_dimension_for_join.element_name
+                and instance.spec.entity_links == agg_time_dimension_for_join.entity_links
+            ):
+                agg_time_dimension_instances.append(instance)
+
+        # Choose the instance with the smallest granularity available.
+        agg_time_dimension_instances.sort(key=lambda instance: instance.spec.time_granularity.to_int())
+        assert (
+            len(agg_time_dimension_instances) > 0
+        ), "Couldn't find requested agg_time_dimension in parent data set. The dataflow plan may have been configured incorrectly."
+        agg_time_dimension_instance_for_join = agg_time_dimension_instances[0]
+
+        # Build time spine data set using the requested agg_time_dimension name.
+        agg_time_dimension_column_name = self.column_association_resolver.resolve_spec(
+            agg_time_dimension_instance_for_join.spec
         ).column_name
         time_spine_alias = self._next_unique_table_alias()
         time_spine_dataset = self._make_time_spine_data_set(
-            metric_time_dimension_instance=metric_time_dimension_instance,
-            metric_time_dimension_column_name=metric_time_dimension_column_name,
+            metric_time_dimension_instance=agg_time_dimension_instance_for_join,
+            metric_time_dimension_column_name=agg_time_dimension_column_name,
             time_spine_source=self._time_spine_source,
             time_range_constraint=node.time_range_constraint,
         )
 
-        # Build join expression
+        # Build join expression.
         join_description = SqlQueryPlanJoinBuilder.make_join_to_time_spine_join_description(
             node=node,
             time_spine_alias=time_spine_alias,
-            metric_time_dimension_column_name=metric_time_dimension_column_name,
+            metric_time_dimension_column_name=agg_time_dimension_column_name,
             parent_sql_select_node=parent_data_set.sql_select_node,
             parent_alias=parent_alias,
         )
 
-        # Use all instances EXCEPT metric_time from parent data set.
-        non_metric_time_parent_instance_set = InstanceSet(
+        # Select all instances from the parent data set, EXCEPT the requested agg_time_dimension.
+        # The agg_time_dimension will be selected from the time spine data set.
+        parent_instance_set = InstanceSet(
             measure_instances=parent_data_set.instance_set.measure_instances,
             dimension_instances=parent_data_set.instance_set.dimension_instances,
             time_dimension_instances=tuple(
                 time_dimension_instance
                 for time_dimension_instance in parent_data_set.instance_set.time_dimension_instances
-                if time_dimension_instance.spec.element_name != DataSet.metric_time_dimension_reference().element_name
+                if not (
+                    time_dimension_instance.spec.element_name == agg_time_dimension_for_join.element_name
+                    and time_dimension_instance.spec.entity_links == agg_time_dimension_for_join.entity_links
+                )
             ),
             entity_instances=parent_data_set.instance_set.entity_instances,
             metric_instances=parent_data_set.instance_set.metric_instances,
             metadata_instances=parent_data_set.instance_set.metadata_instances,
         )
         parent_select_columns = create_select_columns_for_instance_sets(
-            self._column_association_resolver, OrderedDict({parent_alias: non_metric_time_parent_instance_set})
+            self._column_association_resolver, OrderedDict({parent_alias: parent_instance_set})
         )
 
-        # Use time instance from time spine to replace metric_time instances.
+        # Select agg_time_dimension instance from time spine data set.
         assert (
             len(time_spine_dataset.instance_set.time_dimension_instances) == 1
             and len(time_spine_dataset.sql_select_node.select_columns) == 1
@@ -1348,7 +1370,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         time_spine_instance_set = InstanceSet(time_dimension_instances=tuple(time_spine_dim_instances))
 
         return SqlDataSet(
-            instance_set=InstanceSet.merge([time_spine_instance_set, non_metric_time_parent_instance_set]),
+            instance_set=InstanceSet.merge([time_spine_instance_set, parent_instance_set]),
             sql_select_node=SqlSelectStatementNode(
                 description=node.description,
                 select_columns=tuple(time_spine_select_columns) + parent_select_columns,

--- a/metricflow/plan_conversion/sql_join_builder.py
+++ b/metricflow/plan_conversion/sql_join_builder.py
@@ -533,13 +533,13 @@ class SqlQueryPlanJoinBuilder:
     def make_join_to_time_spine_join_description(
         node: JoinToTimeSpineNode,
         time_spine_alias: str,
-        metric_time_dimension_column_name: str,
+        agg_time_dimension_column_name: str,
         parent_sql_select_node: SqlSelectStatementNode,
         parent_alias: str,
     ) -> SqlJoinDescription:
         """Build join expression used to join a metric to a time spine dataset."""
         left_expr: SqlExpressionNode = SqlColumnReferenceExpression(
-            col_ref=SqlColumnReference(table_alias=time_spine_alias, column_name=metric_time_dimension_column_name)
+            col_ref=SqlColumnReference(table_alias=time_spine_alias, column_name=agg_time_dimension_column_name)
         )
         if node.offset_window:
             left_expr = SqlSubtractTimeIntervalExpression(
@@ -555,7 +555,7 @@ class SqlQueryPlanJoinBuilder:
                 left_expr=left_expr,
                 comparison=SqlComparison.EQUALS,
                 right_expr=SqlColumnReferenceExpression(
-                    col_ref=SqlColumnReference(table_alias=parent_alias, column_name=metric_time_dimension_column_name)
+                    col_ref=SqlColumnReference(table_alias=parent_alias, column_name=agg_time_dimension_column_name)
                 ),
             ),
             join_type=node.join_type,

--- a/metricflow/query/validation_rules/metric_time_requirements.py
+++ b/metricflow/query/validation_rules/metric_time_requirements.py
@@ -66,12 +66,10 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
         resolution_path: MetricFlowQueryResolutionPath,
     ) -> MetricFlowQueryResolutionIssueSet:
         metric = self._get_metric(metric_reference)
-        query_includes_metric_time = self._group_by_items_include_metric_time(resolver_input_for_query)
-        query_includes_metric_time_or_agg_time_dimension = (
-            query_includes_metric_time
-            or self._group_by_items_include_agg_time_dimension(
-                query_resolver_input=resolver_input_for_query, metric_reference=metric_reference
-            )
+        query_includes_metric_time_or_agg_time_dimension = self._group_by_items_include_metric_time(
+            resolver_input_for_query
+        ) or self._group_by_items_include_agg_time_dimension(
+            query_resolver_input=resolver_input_for_query, metric_reference=metric_reference
         )
 
         if metric.type is MetricType.SIMPLE or metric.type is MetricType.CONVERSION:

--- a/metricflow/query/validation_rules/metric_time_requirements.py
+++ b/metricflow/query/validation_rules/metric_time_requirements.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from typing import List, Sequence
+from typing import Sequence
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
 from dbt_semantic_interfaces.protocols import WhereFilterIntersection
-from dbt_semantic_interfaces.references import MetricReference
-from dbt_semantic_interfaces.type_enums import MetricType, TimeGranularity
-from dbt_semantic_interfaces.type_enums.date_part import DatePart
+from dbt_semantic_interfaces.references import MetricReference, TimeDimensionReference
+from dbt_semantic_interfaces.type_enums import MetricType
 from typing_extensions import override
 
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
@@ -34,33 +33,27 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
     def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
         super().__init__(manifest_lookup=manifest_lookup)
 
-        metric_time_specs: List[TimeDimensionSpec] = []
-
-        for time_granularity in TimeGranularity:
-            metric_time_specs.append(
-                TimeDimensionSpec(
-                    element_name=METRIC_TIME_ELEMENT_NAME,
-                    entity_links=(),
-                    time_granularity=time_granularity,
-                    date_part=None,
-                )
+        self._metric_time_specs = tuple(
+            TimeDimensionSpec.generate_possible_specs_for_time_dimension(
+                time_dimension_reference=TimeDimensionReference(element_name=METRIC_TIME_ELEMENT_NAME), entity_links=()
             )
-        for date_part in DatePart:
-            for time_granularity in date_part.compatible_granularities:
-                metric_time_specs.append(
-                    TimeDimensionSpec(
-                        element_name=METRIC_TIME_ELEMENT_NAME,
-                        entity_links=(),
-                        time_granularity=time_granularity,
-                        date_part=date_part,
-                    )
-                )
-
-        self._metric_time_specs = tuple(metric_time_specs)
+        )
 
     def _group_by_items_include_metric_time(self, query_resolver_input: ResolverInputForQuery) -> bool:
         for group_by_item_input in query_resolver_input.group_by_item_inputs:
             if group_by_item_input.spec_pattern.matches_any(self._metric_time_specs):
+                return True
+
+        return False
+
+    def _group_by_items_include_agg_time_dimension(
+        self, query_resolver_input: ResolverInputForQuery, metric_reference: MetricReference
+    ) -> bool:
+        valid_agg_time_dimension_specs = self._manifest_lookup.metric_lookup.get_valid_agg_time_dimensions_for_metric(
+            metric_reference
+        )
+        for group_by_item_input in query_resolver_input.group_by_item_inputs:
+            if group_by_item_input.spec_pattern.matches_any(valid_agg_time_dimension_specs):
                 return True
 
         return False
@@ -74,6 +67,12 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
     ) -> MetricFlowQueryResolutionIssueSet:
         metric = self._get_metric(metric_reference)
         query_includes_metric_time = self._group_by_items_include_metric_time(resolver_input_for_query)
+        query_includes_metric_time_or_agg_time_dimension = (
+            query_includes_metric_time
+            or self._group_by_items_include_agg_time_dimension(
+                query_resolver_input=resolver_input_for_query, metric_reference=metric_reference
+            )
+        )
 
         if metric.type is MetricType.SIMPLE or metric.type is MetricType.CONVERSION:
             return MetricFlowQueryResolutionIssueSet.empty_instance()
@@ -97,7 +96,7 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
                 for input_metric in metric.input_metrics
             )
 
-            if has_time_offset and not query_includes_metric_time:
+            if has_time_offset and not query_includes_metric_time_or_agg_time_dimension:
                 return MetricFlowQueryResolutionIssueSet.from_issue(
                     OffsetMetricRequiresMetricTimeIssue.from_parameters(
                         metric_reference=metric_reference,

--- a/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/metrics.yaml
+++ b/metricflow/test/fixtures/semantic_manifest_yamls/simple_manifest/metrics.yaml
@@ -180,6 +180,17 @@ metric:
       - name: bookers
 ---
 metric:
+  name: booking_fees_last_week_per_booker_this_week
+  description: booking_fees divided by bookers - single source multi measure expr test
+  type: derived
+  type_params:
+    expr: "booking_value * 0.05 / bookers"
+    metrics:
+      - name: booking_value
+        offset_window: 1 week
+      - name: bookers
+---
+metric:
   name: views_times_booking_value
   description: Booking_value multiplied by views - expr metric test
   type: derived

--- a/metricflow/test/integration/test_cases/itest_metrics.yaml
+++ b/metricflow/test/integration/test_cases/itest_metrics.yaml
@@ -1743,3 +1743,129 @@ integration_test:
       ) subq_11
       WHERE booking__is_instant
     )
+---
+integration_test:
+  name: offset_window_with_agg_time_dim
+  description: Tests a derived metric query with an offset_window queried with agg_time_dimension
+  model: SIMPLE_MODEL
+  metrics: ["bookings_growth_2_weeks"]
+  group_bys: ["booking__ds__day"]
+  check_query: |
+    SELECT
+      COALESCE(a.booking__ds__day, b.booking__ds__day) AS booking__ds__day
+      , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+    FROM (
+      SELECT
+        ds AS booking__ds__day
+        , SUM(1) AS bookings
+      FROM {{ source_schema }}.fct_bookings
+      GROUP BY
+        ds
+    ) a
+    FULL OUTER JOIN (
+      SELECT
+        c.ds AS booking__ds__day
+        , d.bookings_2_weeks_ago AS bookings_2_weeks_ago
+      FROM {{ mf_time_spine_source }} c
+      INNER JOIN (
+        SELECT
+          ds AS booking__ds__day
+          , SUM(1) AS bookings_2_weeks_ago
+        FROM {{ source_schema }}.fct_bookings
+        GROUP BY
+          ds
+      ) d
+      ON {{ render_date_sub("C", "ds", 14, TimeGranularity.DAY) }} = d.booking__ds__day
+    ) b
+    ON a.booking__ds__day = b.booking__ds__day
+---
+integration_test:
+  name: offset_to_grain_with_agg_time_dim
+  description: Tests a derived metric query with an offset_to_grain and agg_time_dimension.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_growth_since_start_of_month"]
+  group_bys: ["booking__ds__day"]
+  check_query: |
+    SELECT
+      COALESCE(a.booking__ds__day, b.booking__ds__day) AS booking__ds__day
+      , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+    FROM (
+      SELECT
+        ds AS booking__ds__day
+        , SUM(1) AS bookings
+      FROM {{ source_schema }}.fct_bookings
+      GROUP BY
+        ds
+    ) a
+    FULL OUTER JOIN (
+      SELECT
+        c.ds AS booking__ds__day
+        , d.bookings_at_start_of_month AS bookings_at_start_of_month
+      FROM {{ mf_time_spine_source }} c
+      INNER JOIN (
+        SELECT
+          ds AS booking__ds__day
+          , SUM(1) AS bookings_at_start_of_month
+        FROM {{ source_schema }}.fct_bookings
+        GROUP BY
+          ds
+      ) d
+      ON {{ render_date_trunc("c.ds", TimeGranularity.MONTH) }} = d.booking__ds__day
+    ) b
+    ON a.booking__ds__day = b.booking__ds__day
+---
+integration_test:
+  name: nested_derived_metric_outer_offset_with_agg_time_dimension
+  description: Tests a nested derived metric where the outer metric has an input metric with offset_window, queried with agg_time_dimension.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_offset_twice"]
+  group_by_objs: [{"name": "booking__ds__day"}]
+  check_query: |
+    SELECT
+      subq_9.ds AS booking__ds__day
+      , 2 * bookings_offset_once AS bookings_offset_twice
+    FROM {{ source_schema }}.mf_time_spine subq_9
+    INNER JOIN (
+      SELECT
+        booking__ds__day
+        , 2 * bookings AS bookings_offset_once
+      FROM (
+        SELECT
+          subq_3.ds AS booking__ds__day
+          , SUM(subq_1.bookings) AS bookings
+        FROM {{ source_schema }}.mf_time_spine subq_3
+        INNER JOIN (
+          SELECT
+            {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS booking__ds__day
+            , 1 AS bookings
+          FROM {{ source_schema }}.fct_bookings bookings_source_src_1
+        ) subq_1
+        ON
+          {{ render_date_sub("subq_3", "ds", 5, TimeGranularity.DAY) }} = subq_1.booking__ds__day
+        GROUP BY
+          subq_3.ds
+      ) subq_7
+    ) subq_8
+    ON
+      {{ render_date_sub("subq_9", "ds", 2, TimeGranularity.DAY) }} = subq_8.booking__ds__day
+---
+integration_test:
+  name: offset_metric_with_agg_time_dim_date_part
+  description: Tests a derived metric query with an offset and agg_time_dimension with date part.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_5_day_lag"]
+  group_by_objs: [{"name": "booking__ds", "date_part": "doy"}]
+  check_query: |
+    SELECT
+      {{ render_extract("a.ds", DatePart.DOY) }} AS booking__ds__extract_doy
+      , b.bookings_5_day_lag
+    FROM {{ mf_time_spine_source }} a
+    INNER JOIN (
+      SELECT
+        ds
+        , SUM(1) AS bookings_5_day_lag
+      FROM {{ source_schema }}.fct_bookings
+      GROUP BY
+        ds
+    ) b
+    ON {{ render_date_sub("a", "ds", 5, TimeGranularity.DAY) }} = b.ds

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -547,7 +547,7 @@ def test_join_to_time_spine_node_without_offset(  # noqa: D
     compute_metrics_node = ComputeMetricsNode(parent_node=aggregated_measures_node, metric_specs=[metric_spec])
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
-        requested_metric_time_dimension_specs=[MTD_SPEC_DAY],
+        requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),
@@ -611,7 +611,7 @@ def test_join_to_time_spine_node_with_offset_window(  # noqa: D
     compute_metrics_node = ComputeMetricsNode(parent_node=aggregated_measures_node, metric_specs=[metric_spec])
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
-        requested_metric_time_dimension_specs=[MTD_SPEC_DAY],
+        requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),
@@ -677,7 +677,7 @@ def test_join_to_time_spine_node_with_offset_to_grain(
     compute_metrics_node = ComputeMetricsNode(parent_node=aggregated_measures_node, metric_specs=[metric_spec])
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
-        requested_metric_time_dimension_specs=[MTD_SPEC_DAY],
+        requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -548,7 +548,7 @@ def test_join_to_time_spine_node_without_offset(  # noqa: D
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
-        query_includes_metric_time=True,
+        use_custom_agg_time_dimension=False,
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),
@@ -613,7 +613,7 @@ def test_join_to_time_spine_node_with_offset_window(  # noqa: D
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
-        query_includes_metric_time=True,
+        use_custom_agg_time_dimension=False,
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),
@@ -680,7 +680,7 @@ def test_join_to_time_spine_node_with_offset_to_grain(
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
-        query_includes_metric_time=True,
+        use_custom_agg_time_dimension=False,
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -548,6 +548,7 @@ def test_join_to_time_spine_node_without_offset(  # noqa: D
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
+        query_includes_metric_time=True,
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),
@@ -612,6 +613,7 @@ def test_join_to_time_spine_node_with_offset_window(  # noqa: D
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
+        query_includes_metric_time=True,
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),
@@ -678,6 +680,7 @@ def test_join_to_time_spine_node_with_offset_to_grain(
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
+        query_includes_metric_time=True,
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),

--- a/metricflow/test/query_rendering/test_derived_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_derived_metric_rendering.py
@@ -594,3 +594,29 @@ def test_offset_to_grain_with_agg_time_dim(  # noqa: D
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
     )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_derived_offset_metric_with_agg_time_dim(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    query_parser: MetricFlowQueryParser,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+    column_association_resolver: ColumnAssociationResolver,
+) -> None:
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("booking_fees_last_week_per_booker_this_week",),
+        group_by_names=("booking__ds__day",),
+    )
+
+    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )

--- a/metricflow/test/query_rendering/test_derived_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_derived_metric_rendering.py
@@ -542,3 +542,55 @@ def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
     )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_offset_window_with_agg_time_dim(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    query_parser: MetricFlowQueryParser,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+    column_association_resolver: ColumnAssociationResolver,
+) -> None:
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("bookings_growth_2_weeks",),
+        group_by_names=("booking__ds__day",),
+    )
+
+    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_offset_to_grain_with_agg_time_dim(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    query_parser: MetricFlowQueryParser,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    create_source_tables: bool,
+    column_association_resolver: ColumnAssociationResolver,
+) -> None:
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("bookings_growth_since_start_of_month",),
+        group_by_names=("booking__ds__day",),
+    )
+
+    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
@@ -54,7 +54,7 @@
                                 <!-- node_id = NodeId(id_str='jts_0') -->
                                 <!-- requested_agg_time_dimension_specs =                                     -->
                                 <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-                                <!-- query_includes_metric_time = True -->
+                                <!-- use_custom_agg_time_dimension = False -->
                                 <!-- time_range_constraint = None -->
                                 <!-- offset_window = None -->
                                 <!-- offset_to_grain = MONTH -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
@@ -54,6 +54,7 @@
                                 <!-- node_id = NodeId(id_str='jts_0') -->
                                 <!-- requested_agg_time_dimension_specs =                                     -->
                                 <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                                <!-- query_includes_metric_time = True -->
                                 <!-- time_range_constraint = None -->
                                 <!-- offset_window = None -->
                                 <!-- offset_to_grain = MONTH -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
@@ -52,7 +52,7 @@
                             <JoinToTimeSpineNode>
                                 <!-- description = 'Join to Time Spine Dataset' -->
                                 <!-- node_id = NodeId(id_str='jts_0') -->
-                                <!-- requested_metric_time_dimension_specs =                                  -->
+                                <!-- requested_agg_time_dimension_specs =                                     -->
                                 <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
                                 <!-- time_range_constraint = None -->
                                 <!-- offset_window = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -29,7 +29,7 @@
                             <!-- node_id = NodeId(id_str='jts_0') -->
                             <!-- requested_agg_time_dimension_specs =                                     -->
                             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-                            <!-- query_includes_metric_time = True -->
+                            <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->
                             <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -29,6 +29,7 @@
                             <!-- node_id = NodeId(id_str='jts_0') -->
                             <!-- requested_agg_time_dimension_specs =                                     -->
                             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                            <!-- query_includes_metric_time = True -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->
                             <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -27,7 +27,7 @@
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
-                            <!-- requested_metric_time_dimension_specs =                                  -->
+                            <!-- requested_agg_time_dimension_specs =                                     -->
                             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
@@ -29,6 +29,7 @@
                             <!-- node_id = NodeId(id_str='jts_0') -->
                             <!-- requested_agg_time_dimension_specs =                                       -->
                             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),] -->
+                            <!-- query_includes_metric_time = True -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->
                             <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
@@ -29,7 +29,7 @@
                             <!-- node_id = NodeId(id_str='jts_0') -->
                             <!-- requested_agg_time_dimension_specs =                                       -->
                             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),] -->
-                            <!-- query_includes_metric_time = True -->
+                            <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->
                             <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
@@ -27,7 +27,7 @@
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
-                            <!-- requested_metric_time_dimension_specs =                                    -->
+                            <!-- requested_agg_time_dimension_specs =                                       -->
                             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),] -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -27,7 +27,7 @@
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
-                            <!-- requested_metric_time_dimension_specs =                                  -->
+                            <!-- requested_agg_time_dimension_specs =                                     -->
                             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -29,7 +29,7 @@
                             <!-- node_id = NodeId(id_str='jts_0') -->
                             <!-- requested_agg_time_dimension_specs =                                     -->
                             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-                            <!-- query_includes_metric_time = True -->
+                            <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
                             <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -29,6 +29,7 @@
                             <!-- node_id = NodeId(id_str='jts_0') -->
                             <!-- requested_agg_time_dimension_specs =                                     -->
                             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                            <!-- query_includes_metric_time = True -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
                             <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -18,7 +18,7 @@
                         <!-- node_id = NodeId(id_str='jts_0') -->
                         <!-- requested_agg_time_dimension_specs =                                     -->
                         <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-                        <!-- query_includes_metric_time = True -->
+                        <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
                         <!-- offset_to_grain = None -->
@@ -60,7 +60,7 @@
                         <!-- node_id = NodeId(id_str='jts_2') -->
                         <!-- requested_agg_time_dimension_specs =                                     -->
                         <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-                        <!-- query_includes_metric_time = True -->
+                        <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
                         <!-- offset_to_grain = None -->
@@ -79,7 +79,7 @@
                                     <!-- node_id = NodeId(id_str='jts_1') -->
                                     <!-- requested_agg_time_dimension_specs =                                     -->
                                     <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-                                    <!-- query_includes_metric_time = True -->
+                                    <!-- use_custom_agg_time_dimension = False -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->
                                     <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -18,6 +18,7 @@
                         <!-- node_id = NodeId(id_str='jts_0') -->
                         <!-- requested_agg_time_dimension_specs =                                     -->
                         <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                        <!-- query_includes_metric_time = True -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
                         <!-- offset_to_grain = None -->
@@ -59,6 +60,7 @@
                         <!-- node_id = NodeId(id_str='jts_2') -->
                         <!-- requested_agg_time_dimension_specs =                                     -->
                         <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                        <!-- query_includes_metric_time = True -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
                         <!-- offset_to_grain = None -->
@@ -77,6 +79,7 @@
                                     <!-- node_id = NodeId(id_str='jts_1') -->
                                     <!-- requested_agg_time_dimension_specs =                                     -->
                                     <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                                    <!-- query_includes_metric_time = True -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->
                                     <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -16,7 +16,7 @@
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_0') -->
-                        <!-- requested_metric_time_dimension_specs =                                  -->
+                        <!-- requested_agg_time_dimension_specs =                                     -->
                         <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
@@ -57,7 +57,7 @@
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_2') -->
-                        <!-- requested_metric_time_dimension_specs =                                  -->
+                        <!-- requested_agg_time_dimension_specs =                                     -->
                         <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
@@ -75,7 +75,7 @@
                                 <JoinToTimeSpineNode>
                                     <!-- description = 'Join to Time Spine Dataset' -->
                                     <!-- node_id = NodeId(id_str='jts_1') -->
-                                    <!-- requested_metric_time_dimension_specs =                                  -->
+                                    <!-- requested_agg_time_dimension_specs =                                     -->
                                     <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
@@ -11,7 +11,7 @@
                 <!-- node_id = NodeId(id_str='jts_0') -->
                 <!-- requested_agg_time_dimension_specs =                                     -->
                 <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-                <!-- query_includes_metric_time = True -->
+                <!-- use_custom_agg_time_dimension = False -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = None -->
                 <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
@@ -11,6 +11,7 @@
                 <!-- node_id = NodeId(id_str='jts_0') -->
                 <!-- requested_agg_time_dimension_specs =                                     -->
                 <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                <!-- query_includes_metric_time = True -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = None -->
                 <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
@@ -9,7 +9,7 @@
             <JoinToTimeSpineNode>
                 <!-- description = 'Join to Time Spine Dataset' -->
                 <!-- node_id = NodeId(id_str='jts_0') -->
-                <!-- requested_metric_time_dimension_specs =                                  -->
+                <!-- requested_agg_time_dimension_specs =                                     -->
                 <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -9,7 +9,7 @@
             <JoinToTimeSpineNode>
                 <!-- description = 'Join to Time Spine Dataset' -->
                 <!-- node_id = NodeId(id_str='jts_1') -->
-                <!-- requested_metric_time_dimension_specs =                                  -->
+                <!-- requested_agg_time_dimension_specs =                                     -->
                 <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
@@ -43,7 +43,7 @@
                                 <JoinToTimeSpineNode>
                                     <!-- description = 'Join to Time Spine Dataset' -->
                                     <!-- node_id = NodeId(id_str='jts_0') -->
-                                    <!-- requested_metric_time_dimension_specs =                                  -->
+                                    <!-- requested_agg_time_dimension_specs =                                     -->
                                     <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -11,6 +11,7 @@
                 <!-- node_id = NodeId(id_str='jts_1') -->
                 <!-- requested_agg_time_dimension_specs =                                     -->
                 <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                <!-- query_includes_metric_time = True -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
                 <!-- offset_to_grain = None -->
@@ -45,6 +46,7 @@
                                     <!-- node_id = NodeId(id_str='jts_0') -->
                                     <!-- requested_agg_time_dimension_specs =                                     -->
                                     <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                                    <!-- query_includes_metric_time = True -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->
                                     <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -11,7 +11,7 @@
                 <!-- node_id = NodeId(id_str='jts_1') -->
                 <!-- requested_agg_time_dimension_specs =                                     -->
                 <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-                <!-- query_includes_metric_time = True -->
+                <!-- use_custom_agg_time_dimension = False -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
                 <!-- offset_to_grain = None -->
@@ -46,7 +46,7 @@
                                     <!-- node_id = NodeId(id_str='jts_0') -->
                                     <!-- requested_agg_time_dimension_specs =                                     -->
                                     <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-                                    <!-- query_includes_metric_time = True -->
+                                    <!-- use_custom_agg_time_dimension = False -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->
                                     <!-- offset_to_grain = None -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -7,7 +7,7 @@
             <!-- node_id = NodeId(id_str='jts_0') -->
             <!-- requested_agg_time_dimension_specs =                                     -->
             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-            <!-- query_includes_metric_time = True -->
+            <!-- use_custom_agg_time_dimension = False -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->
             <!--     start_time=datetime.datetime(2020, 1, 1, 0, 0), -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -7,6 +7,7 @@
             <!-- node_id = NodeId(id_str='jts_0') -->
             <!-- requested_agg_time_dimension_specs =                                     -->
             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+            <!-- query_includes_metric_time = True -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->
             <!--     start_time=datetime.datetime(2020, 1, 1, 0, 0), -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -5,7 +5,7 @@
         <JoinToTimeSpineNode>
             <!-- description = 'Join to Time Spine Dataset' -->
             <!-- node_id = NodeId(id_str='jts_0') -->
-            <!-- requested_metric_time_dimension_specs =                                  -->
+            <!-- requested_agg_time_dimension_specs =                                     -->
             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -7,7 +7,7 @@
             <!-- node_id = NodeId(id_str='jts_0') -->
             <!-- requested_agg_time_dimension_specs =                                     -->
             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-            <!-- query_includes_metric_time = True -->
+            <!-- use_custom_agg_time_dimension = False -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->
             <!--     start_time=datetime.datetime(2020, 1, 1, 0, 0), -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -7,6 +7,7 @@
             <!-- node_id = NodeId(id_str='jts_0') -->
             <!-- requested_agg_time_dimension_specs =                                     -->
             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+            <!-- query_includes_metric_time = True -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->
             <!--     start_time=datetime.datetime(2020, 1, 1, 0, 0), -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -5,7 +5,7 @@
         <JoinToTimeSpineNode>
             <!-- description = 'Join to Time Spine Dataset' -->
             <!-- node_id = NodeId(id_str='jts_0') -->
-            <!-- requested_metric_time_dimension_specs =                                  -->
+            <!-- requested_agg_time_dimension_specs =                                     -->
             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -7,7 +7,7 @@
             <!-- node_id = NodeId(id_str='jts_0') -->
             <!-- requested_agg_time_dimension_specs =                                     -->
             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
-            <!-- query_includes_metric_time = True -->
+            <!-- use_custom_agg_time_dimension = False -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->
             <!--     start_time=datetime.datetime(2020, 1, 1, 0, 0), -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -7,6 +7,7 @@
             <!-- node_id = NodeId(id_str='jts_0') -->
             <!-- requested_agg_time_dimension_specs =                                     -->
             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+            <!-- query_includes_metric_time = True -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->
             <!--     start_time=datetime.datetime(2020, 1, 1, 0, 0), -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -5,7 +5,7 @@
         <JoinToTimeSpineNode>
             <!-- description = 'Join to Time Spine Dataset' -->
             <!-- node_id = NodeId(id_str='jts_0') -->
-            <!-- requested_metric_time_dimension_specs =                                  -->
+            <!-- requested_agg_time_dimension_specs =                                     -->
             <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_7.booking_value) AS booking_value
+    , MAX(subq_12.bookers) AS bookers
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_6.booking__ds__day
+      , subq_6.booking_value
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_5.booking__ds__day
+        , SUM(subq_5.booking_value) AS booking_value
+      FROM (
+        -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+        SELECT
+          subq_4.booking__ds__day
+          , subq_4.booking_value
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_2.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_3.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+          ON
+            DATE_SUB(CAST(subq_2.booking__ds__day AS DATETIME), INTERVAL 1 week) = subq_1.booking__ds__day
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        booking__ds__day
+    ) subq_6
+  ) subq_7
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookers
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , COUNT(DISTINCT subq_10.bookers) AS bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookers
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_8
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_7.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    booking__ds__day
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_21.booking_value) AS booking_value
+    , MAX(subq_26.bookers) AS bookers
+  FROM (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_17.ds AS booking__ds__day
+      , SUM(bookings_source_src_10001.booking_value) AS booking_value
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      DATE_SUB(CAST(subq_17.ds AS DATETIME), INTERVAL 1 week) = DATE_TRUNC(bookings_source_src_10001.ds, day)
+    GROUP BY
+      booking__ds__day
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      DATE_TRUNC(ds, day) AS booking__ds__day
+      , COUNT(DISTINCT guest_id) AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_10001
+    GROUP BY
+      booking__ds__day
+  ) subq_26
+  ON
+    subq_21.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    booking__ds__day
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_at_start_of_month
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATE_TRUNC(subq_7.booking__ds__day, month) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    booking__ds__day
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC(ds, day) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC(ds, day) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATE_TRUNC(subq_22.ds, month) = subq_20.booking__ds__day
+    GROUP BY
+      booking__ds__day
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    booking__ds__day
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+              , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+              , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+              , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+              , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+              , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC(bookings_source_src_10001.ds, day) AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_10001.ds, isoweek) AS booking__ds__week
+                , DATE_TRUNC(bookings_source_src_10001.ds, month) AS booking__ds__month
+                , DATE_TRUNC(bookings_source_src_10001.ds, quarter) AS booking__ds__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_10001.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, day) AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, isoweek) AS booking__paid_at__week
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, month) AS booking__paid_at__month
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, quarter) AS booking__paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_10001.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_10001.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATE_SUB(CAST(subq_7.booking__ds__day AS DATETIME), INTERVAL 14 day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    booking__ds__day
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC(ds, day) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC(ds, day) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATE_SUB(CAST(subq_22.ds AS DATETIME), INTERVAL 14 day) = subq_20.booking__ds__day
+    GROUP BY
+      booking__ds__day
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    booking__ds__day
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_7.booking_value) AS booking_value
+    , MAX(subq_12.bookers) AS bookers
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_6.booking__ds__day
+      , subq_6.booking_value
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_5.booking__ds__day
+        , SUM(subq_5.booking_value) AS booking_value
+      FROM (
+        -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+        SELECT
+          subq_4.booking__ds__day
+          , subq_4.booking_value
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_2.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_3.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+          ON
+            DATEADD(week, -1, subq_2.booking__ds__day) = subq_1.booking__ds__day
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.booking__ds__day
+    ) subq_6
+  ) subq_7
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookers
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , COUNT(DISTINCT subq_10.bookers) AS bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookers
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_8
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_7.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_21.booking_value) AS booking_value
+    , MAX(subq_26.bookers) AS bookers
+  FROM (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_17.ds AS booking__ds__day
+      , SUM(bookings_source_src_10001.booking_value) AS booking_value
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      DATEADD(week, -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_10001.ds)
+    GROUP BY
+      subq_17.ds
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      DATE_TRUNC('day', ds) AS booking__ds__day
+      , COUNT(DISTINCT guest_id) AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_10001
+    GROUP BY
+      DATE_TRUNC('day', ds)
+  ) subq_26
+  ON
+    subq_21.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_at_start_of_month
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATE_TRUNC('month', subq_7.booking__ds__day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATEADD(day, -14, subq_7.booking__ds__day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATEADD(day, -14, subq_22.ds) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_7.booking_value) AS booking_value
+    , MAX(subq_12.bookers) AS bookers
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_6.booking__ds__day
+      , subq_6.booking_value
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_5.booking__ds__day
+        , SUM(subq_5.booking_value) AS booking_value
+      FROM (
+        -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+        SELECT
+          subq_4.booking__ds__day
+          , subq_4.booking_value
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_2.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_3.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+          ON
+            subq_2.booking__ds__day - INTERVAL 1 week = subq_1.booking__ds__day
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.booking__ds__day
+    ) subq_6
+  ) subq_7
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookers
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , COUNT(DISTINCT subq_10.bookers) AS bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookers
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_8
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_7.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_21.booking_value) AS booking_value
+    , MAX(subq_26.bookers) AS bookers
+  FROM (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_17.ds AS booking__ds__day
+      , SUM(bookings_source_src_10001.booking_value) AS booking_value
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      subq_17.ds - INTERVAL 1 week = DATE_TRUNC('day', bookings_source_src_10001.ds)
+    GROUP BY
+      subq_17.ds
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      DATE_TRUNC('day', ds) AS booking__ds__day
+      , COUNT(DISTINCT guest_id) AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_10001
+    GROUP BY
+      DATE_TRUNC('day', ds)
+  ) subq_26
+  ON
+    subq_21.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_at_start_of_month
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATE_TRUNC('month', subq_7.booking__ds__day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            subq_7.booking__ds__day - INTERVAL 14 day = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      subq_22.ds - INTERVAL 14 day = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_7.booking_value) AS booking_value
+    , MAX(subq_12.bookers) AS bookers
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_6.booking__ds__day
+      , subq_6.booking_value
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_5.booking__ds__day
+        , SUM(subq_5.booking_value) AS booking_value
+      FROM (
+        -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+        SELECT
+          subq_4.booking__ds__day
+          , subq_4.booking_value
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_2.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_3.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+          ON
+            subq_2.booking__ds__day - MAKE_INTERVAL(weeks => 1) = subq_1.booking__ds__day
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.booking__ds__day
+    ) subq_6
+  ) subq_7
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookers
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , COUNT(DISTINCT subq_10.bookers) AS bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookers
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_8
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_7.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_21.booking_value) AS booking_value
+    , MAX(subq_26.bookers) AS bookers
+  FROM (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_17.ds AS booking__ds__day
+      , SUM(bookings_source_src_10001.booking_value) AS booking_value
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      subq_17.ds - MAKE_INTERVAL(weeks => 1) = DATE_TRUNC('day', bookings_source_src_10001.ds)
+    GROUP BY
+      subq_17.ds
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      DATE_TRUNC('day', ds) AS booking__ds__day
+      , COUNT(DISTINCT guest_id) AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_10001
+    GROUP BY
+      DATE_TRUNC('day', ds)
+  ) subq_26
+  ON
+    subq_21.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_at_start_of_month
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATE_TRUNC('month', subq_7.booking__ds__day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            subq_7.booking__ds__day - MAKE_INTERVAL(days => 14) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      subq_22.ds - MAKE_INTERVAL(days => 14) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_7.booking_value) AS booking_value
+    , MAX(subq_12.bookers) AS bookers
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_6.booking__ds__day
+      , subq_6.booking_value
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_5.booking__ds__day
+        , SUM(subq_5.booking_value) AS booking_value
+      FROM (
+        -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+        SELECT
+          subq_4.booking__ds__day
+          , subq_4.booking_value
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_2.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_3.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+          ON
+            DATEADD(week, -1, subq_2.booking__ds__day) = subq_1.booking__ds__day
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.booking__ds__day
+    ) subq_6
+  ) subq_7
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookers
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , COUNT(DISTINCT subq_10.bookers) AS bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookers
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_8
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_7.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_21.booking_value) AS booking_value
+    , MAX(subq_26.bookers) AS bookers
+  FROM (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_17.ds AS booking__ds__day
+      , SUM(bookings_source_src_10001.booking_value) AS booking_value
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      DATEADD(week, -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_10001.ds)
+    GROUP BY
+      subq_17.ds
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      DATE_TRUNC('day', ds) AS booking__ds__day
+      , COUNT(DISTINCT guest_id) AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_10001
+    GROUP BY
+      DATE_TRUNC('day', ds)
+  ) subq_26
+  ON
+    subq_21.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_at_start_of_month
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATE_TRUNC('month', subq_7.booking__ds__day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_10001.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_10001.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATEADD(day, -14, subq_7.booking__ds__day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATEADD(day, -14, subq_22.ds) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_7.booking_value) AS booking_value
+    , MAX(subq_12.bookers) AS bookers
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_6.booking__ds__day
+      , subq_6.booking_value
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_5.booking__ds__day
+        , SUM(subq_5.booking_value) AS booking_value
+      FROM (
+        -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+        SELECT
+          subq_4.booking__ds__day
+          , subq_4.booking_value
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_2.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_3.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+          ON
+            DATEADD(week, -1, subq_2.booking__ds__day) = subq_1.booking__ds__day
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.booking__ds__day
+    ) subq_6
+  ) subq_7
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookers
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , COUNT(DISTINCT subq_10.bookers) AS bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookers
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_8
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_7.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_21.booking_value) AS booking_value
+    , MAX(subq_26.bookers) AS bookers
+  FROM (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_17.ds AS booking__ds__day
+      , SUM(bookings_source_src_10001.booking_value) AS booking_value
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      DATEADD(week, -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_10001.ds)
+    GROUP BY
+      subq_17.ds
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      DATE_TRUNC('day', ds) AS booking__ds__day
+      , COUNT(DISTINCT guest_id) AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_10001
+    GROUP BY
+      DATE_TRUNC('day', ds)
+  ) subq_26
+  ON
+    subq_21.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_at_start_of_month
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATE_TRUNC('month', subq_7.booking__ds__day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATEADD(day, -14, subq_7.booking__ds__day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATEADD(day, -14, subq_22.ds) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_7.booking_value) AS booking_value
+    , MAX(subq_12.bookers) AS bookers
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_6.booking__ds__day
+      , subq_6.booking_value
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_5.booking__ds__day
+        , SUM(subq_5.booking_value) AS booking_value
+      FROM (
+        -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+        SELECT
+          subq_4.booking__ds__day
+          , subq_4.booking_value
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_2.booking__ds__day AS booking__ds__day
+            , subq_1.ds__day AS ds__day
+            , subq_1.ds__week AS ds__week
+            , subq_1.ds__month AS ds__month
+            , subq_1.ds__quarter AS ds__quarter
+            , subq_1.ds__year AS ds__year
+            , subq_1.ds__extract_year AS ds__extract_year
+            , subq_1.ds__extract_quarter AS ds__extract_quarter
+            , subq_1.ds__extract_month AS ds__extract_month
+            , subq_1.ds__extract_day AS ds__extract_day
+            , subq_1.ds__extract_dow AS ds__extract_dow
+            , subq_1.ds__extract_doy AS ds__extract_doy
+            , subq_1.ds_partitioned__day AS ds_partitioned__day
+            , subq_1.ds_partitioned__week AS ds_partitioned__week
+            , subq_1.ds_partitioned__month AS ds_partitioned__month
+            , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_1.ds_partitioned__year AS ds_partitioned__year
+            , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_1.paid_at__day AS paid_at__day
+            , subq_1.paid_at__week AS paid_at__week
+            , subq_1.paid_at__month AS paid_at__month
+            , subq_1.paid_at__quarter AS paid_at__quarter
+            , subq_1.paid_at__year AS paid_at__year
+            , subq_1.paid_at__extract_year AS paid_at__extract_year
+            , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_1.paid_at__extract_month AS paid_at__extract_month
+            , subq_1.paid_at__extract_day AS paid_at__extract_day
+            , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_1.booking__paid_at__day AS booking__paid_at__day
+            , subq_1.booking__paid_at__week AS booking__paid_at__week
+            , subq_1.booking__paid_at__month AS booking__paid_at__month
+            , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_1.booking__paid_at__year AS booking__paid_at__year
+            , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_1.metric_time__day AS metric_time__day
+            , subq_1.metric_time__week AS metric_time__week
+            , subq_1.metric_time__month AS metric_time__month
+            , subq_1.metric_time__quarter AS metric_time__quarter
+            , subq_1.metric_time__year AS metric_time__year
+            , subq_1.metric_time__extract_year AS metric_time__extract_year
+            , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_1.metric_time__extract_month AS metric_time__extract_month
+            , subq_1.metric_time__extract_day AS metric_time__extract_day
+            , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_1.listing AS listing
+            , subq_1.guest AS guest
+            , subq_1.host AS host
+            , subq_1.booking__listing AS booking__listing
+            , subq_1.booking__guest AS booking__guest
+            , subq_1.booking__host AS booking__host
+            , subq_1.is_instant AS is_instant
+            , subq_1.booking__is_instant AS booking__is_instant
+            , subq_1.bookings AS bookings
+            , subq_1.instant_bookings AS instant_bookings
+            , subq_1.booking_value AS booking_value
+            , subq_1.max_booking_value AS max_booking_value
+            , subq_1.min_booking_value AS min_booking_value
+            , subq_1.bookers AS bookers
+            , subq_1.average_booking_value AS average_booking_value
+            , subq_1.referred_bookings AS referred_bookings
+            , subq_1.median_booking_value AS median_booking_value
+            , subq_1.booking_value_p99 AS booking_value_p99
+            , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_3.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_3
+          ) subq_2
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_0
+          ) subq_1
+          ON
+            DATE_ADD('week', -1, subq_2.booking__ds__day) = subq_1.booking__ds__day
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.booking__ds__day
+    ) subq_6
+  ) subq_7
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookers
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , COUNT(DISTINCT subq_10.bookers) AS bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookers
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_8.ds__day
+            , subq_8.ds__week
+            , subq_8.ds__month
+            , subq_8.ds__quarter
+            , subq_8.ds__year
+            , subq_8.ds__extract_year
+            , subq_8.ds__extract_quarter
+            , subq_8.ds__extract_month
+            , subq_8.ds__extract_day
+            , subq_8.ds__extract_dow
+            , subq_8.ds__extract_doy
+            , subq_8.ds_partitioned__day
+            , subq_8.ds_partitioned__week
+            , subq_8.ds_partitioned__month
+            , subq_8.ds_partitioned__quarter
+            , subq_8.ds_partitioned__year
+            , subq_8.ds_partitioned__extract_year
+            , subq_8.ds_partitioned__extract_quarter
+            , subq_8.ds_partitioned__extract_month
+            , subq_8.ds_partitioned__extract_day
+            , subq_8.ds_partitioned__extract_dow
+            , subq_8.ds_partitioned__extract_doy
+            , subq_8.paid_at__day
+            , subq_8.paid_at__week
+            , subq_8.paid_at__month
+            , subq_8.paid_at__quarter
+            , subq_8.paid_at__year
+            , subq_8.paid_at__extract_year
+            , subq_8.paid_at__extract_quarter
+            , subq_8.paid_at__extract_month
+            , subq_8.paid_at__extract_day
+            , subq_8.paid_at__extract_dow
+            , subq_8.paid_at__extract_doy
+            , subq_8.booking__ds__day
+            , subq_8.booking__ds__week
+            , subq_8.booking__ds__month
+            , subq_8.booking__ds__quarter
+            , subq_8.booking__ds__year
+            , subq_8.booking__ds__extract_year
+            , subq_8.booking__ds__extract_quarter
+            , subq_8.booking__ds__extract_month
+            , subq_8.booking__ds__extract_day
+            , subq_8.booking__ds__extract_dow
+            , subq_8.booking__ds__extract_doy
+            , subq_8.booking__ds_partitioned__day
+            , subq_8.booking__ds_partitioned__week
+            , subq_8.booking__ds_partitioned__month
+            , subq_8.booking__ds_partitioned__quarter
+            , subq_8.booking__ds_partitioned__year
+            , subq_8.booking__ds_partitioned__extract_year
+            , subq_8.booking__ds_partitioned__extract_quarter
+            , subq_8.booking__ds_partitioned__extract_month
+            , subq_8.booking__ds_partitioned__extract_day
+            , subq_8.booking__ds_partitioned__extract_dow
+            , subq_8.booking__ds_partitioned__extract_doy
+            , subq_8.booking__paid_at__day
+            , subq_8.booking__paid_at__week
+            , subq_8.booking__paid_at__month
+            , subq_8.booking__paid_at__quarter
+            , subq_8.booking__paid_at__year
+            , subq_8.booking__paid_at__extract_year
+            , subq_8.booking__paid_at__extract_quarter
+            , subq_8.booking__paid_at__extract_month
+            , subq_8.booking__paid_at__extract_day
+            , subq_8.booking__paid_at__extract_dow
+            , subq_8.booking__paid_at__extract_doy
+            , subq_8.ds__day AS metric_time__day
+            , subq_8.ds__week AS metric_time__week
+            , subq_8.ds__month AS metric_time__month
+            , subq_8.ds__quarter AS metric_time__quarter
+            , subq_8.ds__year AS metric_time__year
+            , subq_8.ds__extract_year AS metric_time__extract_year
+            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_8.ds__extract_month AS metric_time__extract_month
+            , subq_8.ds__extract_day AS metric_time__extract_day
+            , subq_8.ds__extract_dow AS metric_time__extract_dow
+            , subq_8.ds__extract_doy AS metric_time__extract_doy
+            , subq_8.listing
+            , subq_8.guest
+            , subq_8.host
+            , subq_8.booking__listing
+            , subq_8.booking__guest
+            , subq_8.booking__host
+            , subq_8.is_instant
+            , subq_8.booking__is_instant
+            , subq_8.bookings
+            , subq_8.instant_bookings
+            , subq_8.booking_value
+            , subq_8.max_booking_value
+            , subq_8.min_booking_value
+            , subq_8.bookers
+            , subq_8.average_booking_value
+            , subq_8.referred_bookings
+            , subq_8.median_booking_value
+            , subq_8.booking_value_p99
+            , subq_8.discrete_booking_value_p99
+            , subq_8.approximate_continuous_booking_value_p99
+            , subq_8.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_8
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_7.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_7.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_offset_metric_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,44 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , booking_value * 0.05 / bookers AS booking_fees_last_week_per_booker_this_week
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_21.booking_value) AS booking_value
+    , MAX(subq_26.bookers) AS bookers
+  FROM (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['booking_value', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_17.ds AS booking__ds__day
+      , SUM(bookings_source_src_10001.booking_value) AS booking_value
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_10001
+    ON
+      DATE_ADD('week', -1, subq_17.ds) = DATE_TRUNC('day', bookings_source_src_10001.ds)
+    GROUP BY
+      subq_17.ds
+  ) subq_21
+  FULL OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      DATE_TRUNC('day', ds) AS booking__ds__day
+      , COUNT(DISTINCT guest_id) AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_10001
+    GROUP BY
+      DATE_TRUNC('day', ds)
+  ) subq_26
+  ON
+    subq_21.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_21.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_at_start_of_month
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATE_TRUNC('month', subq_7.booking__ds__day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_to_grain_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_at_start_of_month AS bookings_growth_since_start_of_month
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_at_start_of_month) AS bookings_at_start_of_month
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_at_start_of_month
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATE_TRUNC('month', subq_22.ds) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0.sql
@@ -1,0 +1,545 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day) AS booking__ds__day
+    , MAX(subq_4.bookings) AS bookings
+    , MAX(subq_12.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_3.booking__ds__day
+      , subq_3.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_2.booking__ds__day
+        , SUM(subq_2.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_1.booking__ds__day
+          , subq_1.bookings
+        FROM (
+          -- Metric Time Dimension 'ds'
+          SELECT
+            subq_0.ds__day
+            , subq_0.ds__week
+            , subq_0.ds__month
+            , subq_0.ds__quarter
+            , subq_0.ds__year
+            , subq_0.ds__extract_year
+            , subq_0.ds__extract_quarter
+            , subq_0.ds__extract_month
+            , subq_0.ds__extract_day
+            , subq_0.ds__extract_dow
+            , subq_0.ds__extract_doy
+            , subq_0.ds_partitioned__day
+            , subq_0.ds_partitioned__week
+            , subq_0.ds_partitioned__month
+            , subq_0.ds_partitioned__quarter
+            , subq_0.ds_partitioned__year
+            , subq_0.ds_partitioned__extract_year
+            , subq_0.ds_partitioned__extract_quarter
+            , subq_0.ds_partitioned__extract_month
+            , subq_0.ds_partitioned__extract_day
+            , subq_0.ds_partitioned__extract_dow
+            , subq_0.ds_partitioned__extract_doy
+            , subq_0.paid_at__day
+            , subq_0.paid_at__week
+            , subq_0.paid_at__month
+            , subq_0.paid_at__quarter
+            , subq_0.paid_at__year
+            , subq_0.paid_at__extract_year
+            , subq_0.paid_at__extract_quarter
+            , subq_0.paid_at__extract_month
+            , subq_0.paid_at__extract_day
+            , subq_0.paid_at__extract_dow
+            , subq_0.paid_at__extract_doy
+            , subq_0.booking__ds__day
+            , subq_0.booking__ds__week
+            , subq_0.booking__ds__month
+            , subq_0.booking__ds__quarter
+            , subq_0.booking__ds__year
+            , subq_0.booking__ds__extract_year
+            , subq_0.booking__ds__extract_quarter
+            , subq_0.booking__ds__extract_month
+            , subq_0.booking__ds__extract_day
+            , subq_0.booking__ds__extract_dow
+            , subq_0.booking__ds__extract_doy
+            , subq_0.booking__ds_partitioned__day
+            , subq_0.booking__ds_partitioned__week
+            , subq_0.booking__ds_partitioned__month
+            , subq_0.booking__ds_partitioned__quarter
+            , subq_0.booking__ds_partitioned__year
+            , subq_0.booking__ds_partitioned__extract_year
+            , subq_0.booking__ds_partitioned__extract_quarter
+            , subq_0.booking__ds_partitioned__extract_month
+            , subq_0.booking__ds_partitioned__extract_day
+            , subq_0.booking__ds_partitioned__extract_dow
+            , subq_0.booking__ds_partitioned__extract_doy
+            , subq_0.booking__paid_at__day
+            , subq_0.booking__paid_at__week
+            , subq_0.booking__paid_at__month
+            , subq_0.booking__paid_at__quarter
+            , subq_0.booking__paid_at__year
+            , subq_0.booking__paid_at__extract_year
+            , subq_0.booking__paid_at__extract_quarter
+            , subq_0.booking__paid_at__extract_month
+            , subq_0.booking__paid_at__extract_day
+            , subq_0.booking__paid_at__extract_dow
+            , subq_0.booking__paid_at__extract_doy
+            , subq_0.ds__day AS metric_time__day
+            , subq_0.ds__week AS metric_time__week
+            , subq_0.ds__month AS metric_time__month
+            , subq_0.ds__quarter AS metric_time__quarter
+            , subq_0.ds__year AS metric_time__year
+            , subq_0.ds__extract_year AS metric_time__extract_year
+            , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_0.ds__extract_month AS metric_time__extract_month
+            , subq_0.ds__extract_day AS metric_time__extract_day
+            , subq_0.ds__extract_dow AS metric_time__extract_dow
+            , subq_0.ds__extract_doy AS metric_time__extract_doy
+            , subq_0.listing
+            , subq_0.guest
+            , subq_0.host
+            , subq_0.booking__listing
+            , subq_0.booking__guest
+            , subq_0.booking__host
+            , subq_0.is_instant
+            , subq_0.booking__is_instant
+            , subq_0.bookings
+            , subq_0.instant_bookings
+            , subq_0.booking_value
+            , subq_0.max_booking_value
+            , subq_0.min_booking_value
+            , subq_0.bookers
+            , subq_0.average_booking_value
+            , subq_0.referred_bookings
+            , subq_0.median_booking_value
+            , subq_0.booking_value_p99
+            , subq_0.discrete_booking_value_p99
+            , subq_0.approximate_continuous_booking_value_p99
+            , subq_0.approximate_discrete_booking_value_p99
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            SELECT
+              1 AS bookings
+              , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+              , bookings_source_src_10001.booking_value
+              , bookings_source_src_10001.booking_value AS max_booking_value
+              , bookings_source_src_10001.booking_value AS min_booking_value
+              , bookings_source_src_10001.guest_id AS bookers
+              , bookings_source_src_10001.booking_value AS average_booking_value
+              , bookings_source_src_10001.booking_value AS booking_payments
+              , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+              , bookings_source_src_10001.booking_value AS median_booking_value
+              , bookings_source_src_10001.booking_value AS booking_value_p99
+              , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+              , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+              , bookings_source_src_10001.is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+              , bookings_source_src_10001.is_instant AS booking__is_instant
+              , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+              , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+              , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+              , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+              , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+              , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+              , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+              , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+              , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+              , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+              , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+              , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+              , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+              , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+              , bookings_source_src_10001.listing_id AS listing
+              , bookings_source_src_10001.guest_id AS guest
+              , bookings_source_src_10001.host_id AS host
+              , bookings_source_src_10001.listing_id AS booking__listing
+              , bookings_source_src_10001.guest_id AS booking__guest
+              , bookings_source_src_10001.host_id AS booking__host
+            FROM ***************************.fct_bookings bookings_source_src_10001
+          ) subq_0
+        ) subq_1
+      ) subq_2
+      GROUP BY
+        subq_2.booking__ds__day
+    ) subq_3
+  ) subq_4
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_11.booking__ds__day
+      , subq_11.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_10.booking__ds__day
+        , SUM(subq_10.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'booking__ds__day']
+        SELECT
+          subq_9.booking__ds__day
+          , subq_9.bookings
+        FROM (
+          -- Join to Time Spine Dataset
+          SELECT
+            subq_7.booking__ds__day AS booking__ds__day
+            , subq_6.ds__day AS ds__day
+            , subq_6.ds__week AS ds__week
+            , subq_6.ds__month AS ds__month
+            , subq_6.ds__quarter AS ds__quarter
+            , subq_6.ds__year AS ds__year
+            , subq_6.ds__extract_year AS ds__extract_year
+            , subq_6.ds__extract_quarter AS ds__extract_quarter
+            , subq_6.ds__extract_month AS ds__extract_month
+            , subq_6.ds__extract_day AS ds__extract_day
+            , subq_6.ds__extract_dow AS ds__extract_dow
+            , subq_6.ds__extract_doy AS ds__extract_doy
+            , subq_6.ds_partitioned__day AS ds_partitioned__day
+            , subq_6.ds_partitioned__week AS ds_partitioned__week
+            , subq_6.ds_partitioned__month AS ds_partitioned__month
+            , subq_6.ds_partitioned__quarter AS ds_partitioned__quarter
+            , subq_6.ds_partitioned__year AS ds_partitioned__year
+            , subq_6.ds_partitioned__extract_year AS ds_partitioned__extract_year
+            , subq_6.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+            , subq_6.ds_partitioned__extract_month AS ds_partitioned__extract_month
+            , subq_6.ds_partitioned__extract_day AS ds_partitioned__extract_day
+            , subq_6.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+            , subq_6.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+            , subq_6.paid_at__day AS paid_at__day
+            , subq_6.paid_at__week AS paid_at__week
+            , subq_6.paid_at__month AS paid_at__month
+            , subq_6.paid_at__quarter AS paid_at__quarter
+            , subq_6.paid_at__year AS paid_at__year
+            , subq_6.paid_at__extract_year AS paid_at__extract_year
+            , subq_6.paid_at__extract_quarter AS paid_at__extract_quarter
+            , subq_6.paid_at__extract_month AS paid_at__extract_month
+            , subq_6.paid_at__extract_day AS paid_at__extract_day
+            , subq_6.paid_at__extract_dow AS paid_at__extract_dow
+            , subq_6.paid_at__extract_doy AS paid_at__extract_doy
+            , subq_6.booking__ds_partitioned__day AS booking__ds_partitioned__day
+            , subq_6.booking__ds_partitioned__week AS booking__ds_partitioned__week
+            , subq_6.booking__ds_partitioned__month AS booking__ds_partitioned__month
+            , subq_6.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+            , subq_6.booking__ds_partitioned__year AS booking__ds_partitioned__year
+            , subq_6.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+            , subq_6.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+            , subq_6.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+            , subq_6.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+            , subq_6.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+            , subq_6.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+            , subq_6.booking__paid_at__day AS booking__paid_at__day
+            , subq_6.booking__paid_at__week AS booking__paid_at__week
+            , subq_6.booking__paid_at__month AS booking__paid_at__month
+            , subq_6.booking__paid_at__quarter AS booking__paid_at__quarter
+            , subq_6.booking__paid_at__year AS booking__paid_at__year
+            , subq_6.booking__paid_at__extract_year AS booking__paid_at__extract_year
+            , subq_6.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+            , subq_6.booking__paid_at__extract_month AS booking__paid_at__extract_month
+            , subq_6.booking__paid_at__extract_day AS booking__paid_at__extract_day
+            , subq_6.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+            , subq_6.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+            , subq_6.metric_time__day AS metric_time__day
+            , subq_6.metric_time__week AS metric_time__week
+            , subq_6.metric_time__month AS metric_time__month
+            , subq_6.metric_time__quarter AS metric_time__quarter
+            , subq_6.metric_time__year AS metric_time__year
+            , subq_6.metric_time__extract_year AS metric_time__extract_year
+            , subq_6.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_6.metric_time__extract_month AS metric_time__extract_month
+            , subq_6.metric_time__extract_day AS metric_time__extract_day
+            , subq_6.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_6.metric_time__extract_doy AS metric_time__extract_doy
+            , subq_6.listing AS listing
+            , subq_6.guest AS guest
+            , subq_6.host AS host
+            , subq_6.booking__listing AS booking__listing
+            , subq_6.booking__guest AS booking__guest
+            , subq_6.booking__host AS booking__host
+            , subq_6.is_instant AS is_instant
+            , subq_6.booking__is_instant AS booking__is_instant
+            , subq_6.bookings AS bookings
+            , subq_6.instant_bookings AS instant_bookings
+            , subq_6.booking_value AS booking_value
+            , subq_6.max_booking_value AS max_booking_value
+            , subq_6.min_booking_value AS min_booking_value
+            , subq_6.bookers AS bookers
+            , subq_6.average_booking_value AS average_booking_value
+            , subq_6.referred_bookings AS referred_bookings
+            , subq_6.median_booking_value AS median_booking_value
+            , subq_6.booking_value_p99 AS booking_value_p99
+            , subq_6.discrete_booking_value_p99 AS discrete_booking_value_p99
+            , subq_6.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+            , subq_6.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+          FROM (
+            -- Time Spine
+            SELECT
+              subq_8.ds AS booking__ds__day
+            FROM ***************************.mf_time_spine subq_8
+          ) subq_7
+          INNER JOIN (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_5.ds__day
+              , subq_5.ds__week
+              , subq_5.ds__month
+              , subq_5.ds__quarter
+              , subq_5.ds__year
+              , subq_5.ds__extract_year
+              , subq_5.ds__extract_quarter
+              , subq_5.ds__extract_month
+              , subq_5.ds__extract_day
+              , subq_5.ds__extract_dow
+              , subq_5.ds__extract_doy
+              , subq_5.ds_partitioned__day
+              , subq_5.ds_partitioned__week
+              , subq_5.ds_partitioned__month
+              , subq_5.ds_partitioned__quarter
+              , subq_5.ds_partitioned__year
+              , subq_5.ds_partitioned__extract_year
+              , subq_5.ds_partitioned__extract_quarter
+              , subq_5.ds_partitioned__extract_month
+              , subq_5.ds_partitioned__extract_day
+              , subq_5.ds_partitioned__extract_dow
+              , subq_5.ds_partitioned__extract_doy
+              , subq_5.paid_at__day
+              , subq_5.paid_at__week
+              , subq_5.paid_at__month
+              , subq_5.paid_at__quarter
+              , subq_5.paid_at__year
+              , subq_5.paid_at__extract_year
+              , subq_5.paid_at__extract_quarter
+              , subq_5.paid_at__extract_month
+              , subq_5.paid_at__extract_day
+              , subq_5.paid_at__extract_dow
+              , subq_5.paid_at__extract_doy
+              , subq_5.booking__ds__day
+              , subq_5.booking__ds__week
+              , subq_5.booking__ds__month
+              , subq_5.booking__ds__quarter
+              , subq_5.booking__ds__year
+              , subq_5.booking__ds__extract_year
+              , subq_5.booking__ds__extract_quarter
+              , subq_5.booking__ds__extract_month
+              , subq_5.booking__ds__extract_day
+              , subq_5.booking__ds__extract_dow
+              , subq_5.booking__ds__extract_doy
+              , subq_5.booking__ds_partitioned__day
+              , subq_5.booking__ds_partitioned__week
+              , subq_5.booking__ds_partitioned__month
+              , subq_5.booking__ds_partitioned__quarter
+              , subq_5.booking__ds_partitioned__year
+              , subq_5.booking__ds_partitioned__extract_year
+              , subq_5.booking__ds_partitioned__extract_quarter
+              , subq_5.booking__ds_partitioned__extract_month
+              , subq_5.booking__ds_partitioned__extract_day
+              , subq_5.booking__ds_partitioned__extract_dow
+              , subq_5.booking__ds_partitioned__extract_doy
+              , subq_5.booking__paid_at__day
+              , subq_5.booking__paid_at__week
+              , subq_5.booking__paid_at__month
+              , subq_5.booking__paid_at__quarter
+              , subq_5.booking__paid_at__year
+              , subq_5.booking__paid_at__extract_year
+              , subq_5.booking__paid_at__extract_quarter
+              , subq_5.booking__paid_at__extract_month
+              , subq_5.booking__paid_at__extract_day
+              , subq_5.booking__paid_at__extract_dow
+              , subq_5.booking__paid_at__extract_doy
+              , subq_5.ds__day AS metric_time__day
+              , subq_5.ds__week AS metric_time__week
+              , subq_5.ds__month AS metric_time__month
+              , subq_5.ds__quarter AS metric_time__quarter
+              , subq_5.ds__year AS metric_time__year
+              , subq_5.ds__extract_year AS metric_time__extract_year
+              , subq_5.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_5.ds__extract_month AS metric_time__extract_month
+              , subq_5.ds__extract_day AS metric_time__extract_day
+              , subq_5.ds__extract_dow AS metric_time__extract_dow
+              , subq_5.ds__extract_doy AS metric_time__extract_doy
+              , subq_5.listing
+              , subq_5.guest
+              , subq_5.host
+              , subq_5.booking__listing
+              , subq_5.booking__guest
+              , subq_5.booking__host
+              , subq_5.is_instant
+              , subq_5.booking__is_instant
+              , subq_5.bookings
+              , subq_5.instant_bookings
+              , subq_5.booking_value
+              , subq_5.max_booking_value
+              , subq_5.min_booking_value
+              , subq_5.bookers
+              , subq_5.average_booking_value
+              , subq_5.referred_bookings
+              , subq_5.median_booking_value
+              , subq_5.booking_value_p99
+              , subq_5.discrete_booking_value_p99
+              , subq_5.approximate_continuous_booking_value_p99
+              , subq_5.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_10001.booking_value
+                , bookings_source_src_10001.booking_value AS max_booking_value
+                , bookings_source_src_10001.booking_value AS min_booking_value
+                , bookings_source_src_10001.guest_id AS bookers
+                , bookings_source_src_10001.booking_value AS average_booking_value
+                , bookings_source_src_10001.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_10001.booking_value AS median_booking_value
+                , bookings_source_src_10001.booking_value AS booking_value_p99
+                , bookings_source_src_10001.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_10001.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_10001.is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_10001.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_10001.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_10001.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_10001.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_10001.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_10001.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_10001.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_10001.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_10001.listing_id AS listing
+                , bookings_source_src_10001.guest_id AS guest
+                , bookings_source_src_10001.host_id AS host
+                , bookings_source_src_10001.listing_id AS booking__listing
+                , bookings_source_src_10001.guest_id AS booking__guest
+                , bookings_source_src_10001.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_10001
+            ) subq_5
+          ) subq_6
+          ON
+            DATE_ADD('day', -14, subq_7.booking__ds__day) = subq_6.booking__ds__day
+        ) subq_9
+      ) subq_10
+      GROUP BY
+        subq_10.booking__ds__day
+    ) subq_11
+  ) subq_12
+  ON
+    subq_4.booking__ds__day = subq_12.booking__ds__day
+  GROUP BY
+    COALESCE(subq_4.booking__ds__day, subq_12.booking__ds__day)
+) subq_13

--- a/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_offset_window_with_agg_time_dim__plan0_optimized.sql
@@ -1,0 +1,55 @@
+-- Compute Metrics via Expressions
+SELECT
+  booking__ds__day
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day) AS booking__ds__day
+    , MAX(subq_18.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      booking__ds__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__ds__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_16
+    GROUP BY
+      booking__ds__day
+  ) subq_18
+  FULL OUTER JOIN (
+    -- Join to Time Spine Dataset
+    -- Pass Only Elements: ['bookings', 'booking__ds__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_22.ds AS booking__ds__day
+      , SUM(subq_20.bookings) AS bookings_2_weeks_ago
+    FROM ***************************.mf_time_spine subq_22
+    INNER JOIN (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS booking__ds__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_10001
+    ) subq_20
+    ON
+      DATE_ADD('day', -14, subq_22.ds) = subq_20.booking__ds__day
+    GROUP BY
+      subq_22.ds
+  ) subq_26
+  ON
+    subq_18.booking__ds__day = subq_26.booking__ds__day
+  GROUP BY
+    COALESCE(subq_18.booking__ds__day, subq_26.booking__ds__day)
+) subq_27


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves #1006


### Description
Enable querying time offset metrics with their `agg_time_dimension` in place of `metric_time`.
Should only work for when all input metrics have the same `agg_time_dimension`.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
