### PR TITLE
add exports to MFE SavedQuery object

### DIFF
--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -12,6 +12,7 @@ from dbt_semantic_interfaces.protocols.dimension import (
     DimensionTypeParams,
 )
 from dbt_semantic_interfaces.protocols.entity import Entity as SemanticManifestEntity
+from dbt_semantic_interfaces.protocols.export import Export
 from dbt_semantic_interfaces.protocols.measure import MeasureAggregationParameters
 from dbt_semantic_interfaces.protocols.metadata import Metadata
 from dbt_semantic_interfaces.protocols.metric import Metric as SemanticManifestMetric
@@ -165,6 +166,7 @@ class SavedQuery:
     label: Optional[str]
     query_params: SavedQueryQueryParams
     metadata: Optional[Metadata]
+    exports: Sequence[Export]
 
     @classmethod
     def from_pydantic(cls, pydantic_saved_query: SemanticManifestSavedQuery) -> SavedQuery:
@@ -175,4 +177,5 @@ class SavedQuery:
             label=pydantic_saved_query.label,
             query_params=pydantic_saved_query.query_params,
             metadata=pydantic_saved_query.metadata,
+            exports=pydantic_saved_query.exports,
         )


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
### Description
When using the MFE, when we retrieve saved queries object they don't have the exports field as it doesn't exist in the MFE model object.

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
