### PR TITLE
Fix threading issue with the dag to text

### DIFF
--- a/metricflow/dag/dag_to_text.py
+++ b/metricflow/dag/dag_to_text.py
@@ -72,6 +72,8 @@ class MetricFlowDagTextFormatter:
 
     @property
     def _max_width_tracker(self) -> MaxWidthTracker:  # noqa: D
+        if not hasattr(self._thread_local_data, "max_width_tracker"):
+            self._thread_local_data.max_width_tracker = MaxWidthTracker(self._max_width)
         return self._thread_local_data.max_width_tracker
 
     def _displayed_property_on_one_line(self, displayed_property: DisplayedProperty) -> str:


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Get a bunch of these errors when running queries through multithreading 
```
Got an exception while converting SqlSelectStatementNode(node_id=ss_84) to text
Traceback (most recent call last):
  File "/Users/william/git/metricflow/metricflow/dag/dag_to_text.py", line 209, in dag_component_to_text
    return self._recursively_format_to_text(dag_component_leaf_node)
  File "/Users/william/git/metricflow/metricflow/dag/dag_to_text.py", line 164, in _recursively_format_to_text
    with self._max_width_tracker.update_max_width_for_indented_section(
  File "/Users/william/git/metricflow/metricflow/dag/dag_to_text.py", line 77, in _max_width_tracker
    return self._thread_local_data.max_width_tracker
AttributeError: '_thread._local' object has no attribute 'max_width_tracker'
```
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
