### PR TITLE
Encapsulate Input Nodes for the `DataflowPlanBuilder` Into `SourceNodeSet`

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -29,6 +29,7 @@ from metricflow.dataflow.builder.node_evaluator import (
     LinkableInstanceSatisfiabilityEvaluation,
     NodeEvaluatorForLinkableInstances,
 )
+from metricflow.dataflow.builder.source_node import SourceNodeSet
 from metricflow.dataflow.dataflow_plan import (
     AddGeneratedUuidColumnNode,
     AggregateMeasuresNode,
@@ -43,10 +44,8 @@ from metricflow.dataflow.dataflow_plan import (
     JoinOverTimeRangeNode,
     JoinToBaseOutputNode,
     JoinToTimeSpineNode,
-    MetricTimeDimensionTransformNode,
     MinMaxNode,
     OrderByLimitNode,
-    ReadSqlSourceNode,
     SemiAdditiveJoinNode,
     SinkOutput,
     WhereConstraintNode,
@@ -121,20 +120,15 @@ class DataflowPlanBuilder:
 
     def __init__(  # noqa: D
         self,
-        source_nodes: Sequence[BaseOutput],
-        read_nodes: Sequence[ReadSqlSourceNode],
-        time_spine_source_node: MetricTimeDimensionTransformNode,
+        source_node_set: SourceNodeSet,
         semantic_manifest_lookup: SemanticManifestLookup,
         node_output_resolver: Optional[DataflowPlanNodeOutputDataSetResolver] = None,
         column_association_resolver: Optional[ColumnAssociationResolver] = None,
     ) -> None:
         self._semantic_model_lookup = semantic_manifest_lookup.semantic_model_lookup
         self._metric_lookup = semantic_manifest_lookup.metric_lookup
-        self._time_spine_source = semantic_manifest_lookup.time_spine_source
-        self._time_spine_source_node = time_spine_source_node
         self._metric_time_dimension_reference = DataSet.metric_time_dimension_reference()
-        self._source_nodes = source_nodes
-        self._read_nodes = read_nodes
+        self._source_node_set = source_node_set
         self._column_association_resolver = (
             DunderColumnAssociationResolver(semantic_manifest_lookup)
             if not column_association_resolver
@@ -745,20 +739,21 @@ class DataflowPlanBuilder:
                 nodes.append(source_node)
         return nodes
 
-    def _select_read_nodes_with_linkable_specs(
-        self, linkable_specs: LinkableSpecSet, read_nodes: Sequence[ReadSqlSourceNode]
-    ) -> List[ReadSqlSourceNode]:
+    def _select_source_nodes_with_linkable_specs(
+        self, linkable_specs: LinkableSpecSet, source_nodes: Sequence[BaseOutput]
+    ) -> Sequence[BaseOutput]:
         """Find source nodes with requested linkable specs and no measures."""
-        selected_nodes: Set[ReadSqlSourceNode] = set()
+        # Use a dictionary to dedupe for consistent ordering.
+        selected_nodes: Dict[BaseOutput, None] = {}
         requested_linkable_specs_set = set(linkable_specs.as_tuple)
-        for read_node in read_nodes:
-            output_spec_set = self._node_data_set_resolver.get_output_data_set(read_node).instance_set.spec_set
+        for source_node in source_nodes:
+            output_spec_set = self._node_data_set_resolver.get_output_data_set(source_node).instance_set.spec_set
             all_linkable_specs_in_node = set(output_spec_set.linkable_specs)
             requested_linkable_specs_in_node = requested_linkable_specs_set.intersection(all_linkable_specs_in_node)
             if requested_linkable_specs_in_node:
-                selected_nodes.add(read_node)
+                selected_nodes[source_node] = None
 
-        return list(selected_nodes)
+        return tuple(selected_nodes.keys())
 
     def _find_non_additive_dimension_in_linkable_specs(
         self,
@@ -817,34 +812,28 @@ class DataflowPlanBuilder:
         time_range_constraint: Optional[TimeRangeConstraint] = None,
     ) -> Optional[DataflowRecipe]:
         linkable_specs = linkable_spec_set.as_tuple
-        potential_source_nodes: Sequence[BaseOutput]
-        input_time_spine_source_node: Optional[MetricTimeDimensionTransformNode] = None
+        candidate_nodes_for_left_side_of_join: Sequence[BaseOutput]
+        candidate_nodes_for_right_side_of_join: Sequence[BaseOutput]
         if measure_spec_properties:
-            source_nodes = self._source_nodes
-            potential_source_nodes = self._select_source_nodes_with_measures(
-                measure_specs=set(measure_spec_properties.measure_specs), source_nodes=source_nodes
+            candidate_nodes_for_right_side_of_join = self._source_node_set.source_nodes_for_metric_queries
+            candidate_nodes_for_left_side_of_join = self._select_source_nodes_with_measures(
+                measure_specs=set(measure_spec_properties.measure_specs),
+                source_nodes=self._source_node_set.source_nodes_for_metric_queries,
             )
             default_join_type = SqlJoinType.LEFT_OUTER
         else:
-            # Only read nodes can be source nodes for queries without measures
-            source_nodes = list(self._read_nodes)
-            potential_source_nodes = self._select_read_nodes_with_linkable_specs(
-                linkable_specs=linkable_spec_set, read_nodes=self._read_nodes
+            candidate_nodes_for_right_side_of_join = list(self._source_node_set.source_nodes_for_group_by_item_queries)
+            candidate_nodes_for_left_side_of_join = self._select_source_nodes_with_linkable_specs(
+                linkable_specs=linkable_spec_set,
+                source_nodes=self._source_node_set.source_nodes_for_group_by_item_queries,
             )
-            # `metric_time` does not exist if there is no metric in the query.
-            # In that case, we'll use the time spine table to represent `metric_time` values.
-            requested_metric_time_specs = [
-                time_dimension_spec
-                for time_dimension_spec in linkable_spec_set.time_dimension_specs
-                if time_dimension_spec.element_name == self._metric_time_dimension_reference.element_name
-            ]
-            if requested_metric_time_specs:
-                input_time_spine_source_node = self._time_spine_source_node
-                # Add time_spine source node to potential source nodes
-                potential_source_nodes = list(potential_source_nodes) + [self._time_spine_source_node]
             default_join_type = SqlJoinType.FULL_OUTER
 
-        logger.info(f"Starting search with {len(potential_source_nodes)} potential source nodes")
+        logger.info(
+            f"Starting search with {len(candidate_nodes_for_left_side_of_join)} potential source nodes on the left "
+            f"side of the join, and {len(candidate_nodes_for_right_side_of_join)} potential nodes on the right side "
+            f"of the join."
+        )
         start_time = time.time()
 
         node_processor = PreJoinNodeProcessor(
@@ -852,43 +841,45 @@ class DataflowPlanBuilder:
             node_data_set_resolver=self._node_data_set_resolver,
         )
         if time_range_constraint:
-            potential_source_nodes = node_processor.add_time_range_constraint(
-                source_nodes=potential_source_nodes,
+            candidate_nodes_for_left_side_of_join = node_processor.add_time_range_constraint(
+                source_nodes=candidate_nodes_for_left_side_of_join,
                 metric_time_dimension_reference=self._metric_time_dimension_reference,
                 time_range_constraint=time_range_constraint,
             )
 
-        nodes_available_for_joins = node_processor.remove_unnecessary_nodes(
+        candidate_nodes_for_right_side_of_join = node_processor.remove_unnecessary_nodes(
             desired_linkable_specs=linkable_specs,
-            nodes=source_nodes,
+            nodes=candidate_nodes_for_right_side_of_join,
             metric_time_dimension_reference=self._metric_time_dimension_reference,
+            time_spine_node=self._source_node_set.time_spine_node,
         )
-        nodes_available_for_joins = tuple(nodes_available_for_joins)
-        if input_time_spine_source_node:
-            nodes_available_for_joins += (input_time_spine_source_node,)
         logger.info(
-            f"After removing unnecessary nodes, there are {len(nodes_available_for_joins)} nodes available for joins"
+            f"After removing unnecessary nodes, there are {len(candidate_nodes_for_right_side_of_join)} candidate "
+            f"nodes for the right side of the join"
         )
         if DataflowPlanBuilder._contains_multihop_linkables(linkable_specs):
-            nodes_available_for_joins = node_processor.add_multi_hop_joins(
-                desired_linkable_specs=linkable_specs, nodes=source_nodes, join_type=default_join_type
+            candidate_nodes_for_right_side_of_join = node_processor.add_multi_hop_joins(
+                desired_linkable_specs=linkable_specs,
+                nodes=candidate_nodes_for_right_side_of_join,
+                join_type=default_join_type,
             )
             logger.info(
-                f"After adding multi-hop nodes, there are {len(nodes_available_for_joins)} nodes available for joins:\n"
-                f"{mf_pformat(nodes_available_for_joins)}"
+                f"After adding multi-hop nodes, there are {len(candidate_nodes_for_right_side_of_join)} candidate "
+                f"nodes for the right side of the join:\n"
+                f"{mf_pformat(candidate_nodes_for_right_side_of_join)}"
             )
         logger.info(f"Processing nodes took: {time.time()-start_time:.2f}s")
 
         node_evaluator = NodeEvaluatorForLinkableInstances(
             semantic_model_lookup=self._semantic_model_lookup,
-            nodes_available_for_joins=self._sort_by_suitability(nodes_available_for_joins),
+            nodes_available_for_joins=self._sort_by_suitability(candidate_nodes_for_right_side_of_join),
             node_data_set_resolver=self._node_data_set_resolver,
         )
 
         # Dict from the node that contains the source node to the evaluation results.
         node_to_evaluation: Dict[BaseOutput, LinkableInstanceSatisfiabilityEvaluation] = {}
 
-        for node in self._sort_by_suitability(potential_source_nodes):
+        for node in self._sort_by_suitability(candidate_nodes_for_left_side_of_join):
             data_set = self._node_data_set_resolver.get_output_data_set(node)
 
             if measure_spec_properties:
@@ -898,19 +889,23 @@ class DataflowPlanBuilder:
                 ]
                 if missing_specs:
                     logger.debug(
-                        f"Skipping evaluation for node since it does not have all of the measure specs {missing_specs}:"
-                        f"\n\n{node.text_structure()}"
+                        f"Skipping evaluation for:\n"
+                        f"{indent(node.text_structure())}"
+                        f"since it does not have all of the measure specs:\n"
+                        f"{indent(mf_pformat(missing_specs))}"
                     )
                     continue
 
-            logger.debug(f"Evaluating source node:\n{mf_pformat(node.text_structure())}")
+            logger.debug(
+                f"Evaluating candidate node for the left side of the join:\n{indent(mf_pformat(node.text_structure()))}"
+            )
 
             start_time = time.time()
             evaluation = node_evaluator.evaluate_node(
                 start_node=node,
                 required_linkable_specs=list(linkable_specs),
                 default_join_type=default_join_type,
-                time_spine_source_node=input_time_spine_source_node,
+                time_spine_source_node=self._source_node_set.time_spine_node,
             )
             logger.info(f"Evaluation of {node} took {time.time() - start_time:.2f}s")
 
@@ -1294,8 +1289,8 @@ class DataflowPlanBuilder:
                 linkable_spec_set=required_linkable_specs,
             )
             logger.info(
-                f"With {len(self._source_nodes)} source nodes, finding a recipe took "
-                f"{time.time() - find_recipe_start_time:.2f}s"
+                f"With {len(self._source_node_set.source_nodes_for_metric_queries)} source nodes, finding a recipe "
+                f"took {time.time() - find_recipe_start_time:.2f}s"
             )
 
         logger.info(f"Using recipe:\n{indent(mf_pformat(measure_recipe))}")

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -874,6 +874,7 @@ class DataflowPlanBuilder:
             semantic_model_lookup=self._semantic_model_lookup,
             nodes_available_for_joins=self._sort_by_suitability(candidate_nodes_for_right_side_of_join),
             node_data_set_resolver=self._node_data_set_resolver,
+            time_spine_node=self._source_node_set.time_spine_node,
         )
 
         # Dict from the node that contains the source node to the evaluation results.
@@ -905,7 +906,6 @@ class DataflowPlanBuilder:
                 start_node=node,
                 required_linkable_specs=list(linkable_specs),
                 default_join_type=default_join_type,
-                time_spine_source_node=self._source_node_set.time_spine_node,
             )
             logger.info(f"Evaluation of {node} took {time.time() - start_time:.2f}s")
 

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -903,7 +903,7 @@ class DataflowPlanBuilder:
 
             start_time = time.time()
             evaluation = node_evaluator.evaluate_node(
-                start_node=node,
+                left_node=node,
                 required_linkable_specs=list(linkable_specs),
                 default_join_type=default_join_type,
             )

--- a/metricflow/dataflow/builder/partitions.py
+++ b/metricflow/dataflow/builder/partitions.py
@@ -63,10 +63,10 @@ class PartitionJoinResolver:
         return sorted_dimension_specs[0]
 
     def resolve_partition_dimension_joins(
-        self, start_node_spec_set: InstanceSpecSet, node_to_join_spec_set: InstanceSpecSet
+        self, left_node_spec_set: InstanceSpecSet, node_to_join_spec_set: InstanceSpecSet
     ) -> Tuple[PartitionDimensionJoinDescription, ...]:
         """Figures out which partition dimensions to join on."""
-        start_node_partitions = self._get_partitions(start_node_spec_set)
+        start_node_partitions = self._get_partitions(left_node_spec_set)
         join_node_partitions = self._get_partitions(node_to_join_spec_set)
 
         partition_join_descriptions = []
@@ -103,10 +103,10 @@ class PartitionJoinResolver:
         return sorted_specs[0]
 
     def resolve_partition_time_dimension_joins(
-        self, start_node_spec_set: InstanceSpecSet, node_to_join_spec_set: InstanceSpecSet
+        self, left_node_spec_set: InstanceSpecSet, node_to_join_spec_set: InstanceSpecSet
     ) -> Tuple[PartitionTimeDimensionJoinDescription, ...]:
         """Figures out which partition time dimensions to join on."""
-        start_node_partitions = self._get_partitions(start_node_spec_set)
+        start_node_partitions = self._get_partitions(left_node_spec_set)
         join_node_partitions = self._get_partitions(node_to_join_spec_set)
         partition_join_descriptions: List[PartitionTimeDimensionJoinDescription] = []
 

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -345,17 +345,14 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             self._source_data_sets.append(data_set)
             logger.info(f"Created source dataset from semantic model '{semantic_model.name}'")
 
-        source_node_builder = SourceNodeBuilder(self._semantic_manifest_lookup)
-        source_nodes = source_node_builder.create_from_data_sets(self._source_data_sets)
-        read_nodes = source_node_builder.create_read_nodes_from_data_sets(self._source_data_sets)
-        time_spine_source_node = SourceNodeBuilder.build_time_spine_source_node(
-            time_spine_source=self._time_spine_source, data_set_converter=converter
+        source_node_builder = SourceNodeBuilder(
+            column_association_resolver=self._column_association_resolver,
+            semantic_manifest_lookup=self._semantic_manifest_lookup,
         )
+        source_node_set = source_node_builder.create_from_data_sets(self._source_data_sets)
 
         self._dataflow_plan_builder = DataflowPlanBuilder(
-            source_nodes=source_nodes,
-            read_nodes=read_nodes,
-            time_spine_source_node=time_spine_source_node,
+            source_node_set=source_node_set,
             semantic_manifest_lookup=self._semantic_manifest_lookup,
         )
         self._to_sql_query_plan_converter = DataflowToSqlQueryPlanConverter(

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -60,7 +60,10 @@ class QueryRenderingTools:
 
     def __init__(self, manifest: SemanticManifest) -> None:  # noqa: D
         self.semantic_manifest_lookup = SemanticManifestLookup(semantic_manifest=manifest)
-        self.source_node_builder = SourceNodeBuilder(semantic_manifest_lookup=self.semantic_manifest_lookup)
+        self.source_node_builder = SourceNodeBuilder(
+            column_association_resolver=DunderColumnAssociationResolver(self.semantic_manifest_lookup),
+            semantic_manifest_lookup=self.semantic_manifest_lookup,
+        )
         self.time_spine_source = self.semantic_manifest_lookup.time_spine_source
         self.converter = SemanticModelToDataSetConverter(
             column_association_resolver=DunderColumnAssociationResolver(
@@ -108,7 +111,7 @@ class DataWarehouseTaskBuilder:
 
         source_nodes = render_tools.source_node_builder.create_from_data_sets(
             (render_tools.converter.create_sql_source_data_set(fetched_semantic_model),)
-        )
+        ).source_nodes_for_metric_queries
 
         assert len(source_nodes) >= 1
         return source_nodes

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1268,9 +1268,10 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
 
         # Choose the instance with the smallest granularity available.
         agg_time_dimension_instances.sort(key=lambda instance: instance.spec.time_granularity.to_int())
-        assert (
-            len(agg_time_dimension_instances) > 0
-        ), "Couldn't find requested agg_time_dimension in parent data set. The dataflow plan may have been configured incorrectly."
+        assert len(agg_time_dimension_instances) > 0, (
+            "Couldn't find requested agg_time_dimension in parent data set. The dataflow plan may have been "
+            "configured incorrectly."
+        )
         agg_time_dimension_instance_for_join = agg_time_dimension_instances[0]
 
         # Build time spine data set using the requested agg_time_dimension name.

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -14,6 +14,7 @@ from metricflow.dataflow.dataflow_plan import (
     FilterElementsNode,
     JoinDescription,
     JoinToBaseOutputNode,
+    MetricTimeDimensionTransformNode,
 )
 from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.mf_logging.pretty_print import mf_pformat
@@ -301,6 +302,7 @@ class PreJoinNodeProcessor:
         desired_linkable_specs: Sequence[LinkableInstanceSpec],
         nodes: Sequence[BaseOutput],
         metric_time_dimension_reference: TimeDimensionReference,
+        time_spine_node: MetricTimeDimensionTransformNode,
     ) -> Sequence[BaseOutput]:
         """Filters out many of the nodes that can't possibly be useful for joins to obtain the desired linkable specs.
 
@@ -332,10 +334,19 @@ class PreJoinNodeProcessor:
         relevant_nodes = []
 
         for node in nodes:
+            logger.debug(f"Examining {node} for pruning")
             data_set = self._node_data_set_resolver.get_output_data_set(node)
             element_names_in_data_set = ToElementNameSet().transform(data_set.instance_set.spec_set)
-
-            if len(element_names_in_data_set.intersection(relevant_element_names)) > 0:
+            element_names_intersection = element_names_in_data_set.intersection(relevant_element_names)
+            if len(element_names_intersection) > 0:
+                logger.debug(f"Including {node} since `element_names_intersection` is {element_names_intersection}")
                 relevant_nodes.append(node)
+                continue
+
+            # Used for group-by-item-values queries.
+            if node == time_spine_node:
+                logger.debug(f"Including {node} since it matches `time_spine_node`")
+                relevant_nodes.append(node)
+                continue
 
         return relevant_nodes

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -229,11 +229,11 @@ class PreJoinNodeProcessor:
                 )
 
                 join_on_partition_dimensions = self._partition_resolver.resolve_partition_dimension_joins(
-                    start_node_spec_set=data_set_of_first_node_that_could_be_joined.instance_set.spec_set,
+                    left_node_spec_set=data_set_of_first_node_that_could_be_joined.instance_set.spec_set,
                     node_to_join_spec_set=data_set_of_second_node_that_can_be_joined.instance_set.spec_set,
                 )
                 join_on_partition_time_dimensions = self._partition_resolver.resolve_partition_time_dimension_joins(
-                    start_node_spec_set=data_set_of_first_node_that_could_be_joined.instance_set.spec_set,
+                    left_node_spec_set=data_set_of_first_node_that_could_be_joined.instance_set.spec_set,
                     node_to_join_spec_set=data_set_of_second_node_that_can_be_joined.instance_set.spec_set,
                 )
 

--- a/metricflow/test/dataflow/builder/test_node_evaluator.py
+++ b/metricflow/test/dataflow/builder/test_node_evaluator.py
@@ -51,6 +51,7 @@ def node_evaluator(
         ].semantic_manifest_lookup.semantic_model_lookup,
         nodes_available_for_joins=tuple(mf_engine_fixture.read_node_mapping.values()),
         node_data_set_resolver=node_data_set_resolver,
+        time_spine_node=mf_engine_fixture.source_node_set.time_spine_node,
     )
 
 
@@ -87,6 +88,7 @@ def make_multihop_node_evaluator(
         semantic_model_lookup=semantic_manifest_lookup_with_multihop_links.semantic_model_lookup,
         nodes_available_for_joins=nodes_available_for_joins,
         node_data_set_resolver=node_data_set_resolver,
+        time_spine_node=source_node_set.time_spine_node,
     )
 
 
@@ -510,13 +512,14 @@ def test_node_evaluator_with_scd_target(
         semantic_manifest_lookup=scd_semantic_manifest_lookup,
     )
 
-    source_nodes = tuple(mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].read_node_mapping.values())
+    mf_engine_fixture = mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST]
 
     node_evaluator = NodeEvaluatorForLinkableInstances(
         semantic_model_lookup=scd_semantic_manifest_lookup.semantic_model_lookup,
         # Use all nodes in the simple model as candidates for joins.
-        nodes_available_for_joins=source_nodes,
+        nodes_available_for_joins=tuple(mf_engine_fixture.read_node_mapping.values()),
         node_data_set_resolver=node_data_set_resolver,
+        time_spine_node=mf_engine_fixture.source_node_set.time_spine_node,
     )
 
     evaluation = node_evaluator.evaluate_node(

--- a/metricflow/test/dataflow/builder/test_node_evaluator.py
+++ b/metricflow/test/dataflow/builder/test_node_evaluator.py
@@ -100,7 +100,7 @@ def test_node_evaluator_with_no_linkable_specs(  # noqa: D
         "bookings_source"
     ]
     evaluation = node_evaluator.evaluate_node(
-        required_linkable_specs=[], start_node=bookings_source_node, default_join_type=SqlJoinType.LEFT_OUTER
+        required_linkable_specs=[], left_node=bookings_source_node, default_join_type=SqlJoinType.LEFT_OUTER
     )
     assert evaluation == LinkableInstanceSatisfiabilityEvaluation(
         local_linkable_specs=(), joinable_linkable_specs=(), join_recipes=(), unjoinable_linkable_specs=()
@@ -121,7 +121,7 @@ def test_node_evaluator_with_unjoinable_specs(  # noqa: D
                 entity_links=(EntityReference(element_name="verification"),),
             )
         ],
-        start_node=bookings_source_node,
+        left_node=bookings_source_node,
         default_join_type=SqlJoinType.LEFT_OUTER,
     )
     assert evaluation == LinkableInstanceSatisfiabilityEvaluation(
@@ -147,7 +147,7 @@ def test_node_evaluator_with_local_spec(  # noqa: D
     ]
     evaluation = node_evaluator.evaluate_node(
         required_linkable_specs=[DimensionSpec(element_name="is_instant", entity_links=(EntityReference("booking"),))],
-        start_node=bookings_source_node,
+        left_node=bookings_source_node,
         default_join_type=SqlJoinType.LEFT_OUTER,
     )
     assert evaluation == LinkableInstanceSatisfiabilityEvaluation(
@@ -170,7 +170,7 @@ def test_node_evaluator_with_local_spec_using_primary_entity(  # noqa: D
         required_linkable_specs=[
             DimensionSpec(element_name="home_state_latest", entity_links=(EntityReference(element_name="user"),))
         ],
-        start_node=bookings_source_node,
+        left_node=bookings_source_node,
         default_join_type=SqlJoinType.LEFT_OUTER,
     )
 
@@ -209,7 +209,7 @@ def test_node_evaluator_with_joined_spec(  # noqa: D
                 entity_links=(EntityReference(element_name="listing"),),
             ),
         ],
-        start_node=bookings_source_node,
+        left_node=bookings_source_node,
         default_join_type=SqlJoinType.LEFT_OUTER,
     )
 
@@ -265,7 +265,7 @@ def test_node_evaluator_with_joined_spec_on_unique_id(  # noqa: D
                 entity_links=(EntityReference(element_name="user"),),
             ),
         ],
-        start_node=listings_node,
+        left_node=listings_node,
         default_join_type=SqlJoinType.LEFT_OUTER,
     )
 
@@ -317,7 +317,7 @@ def test_node_evaluator_with_multiple_joined_specs(  # noqa: D
                 entity_links=(EntityReference(element_name="listing"),),
             ),
         ],
-        start_node=views_source,
+        left_node=views_source,
         default_join_type=SqlJoinType.LEFT_OUTER,
     )
 
@@ -397,7 +397,7 @@ def test_node_evaluator_with_multihop_joined_spec(  # noqa: D
     )
 
     evaluation = multihop_node_evaluator.evaluate_node(
-        required_linkable_specs=linkable_specs, start_node=txn_source, default_join_type=SqlJoinType.LEFT_OUTER
+        required_linkable_specs=linkable_specs, left_node=txn_source, default_join_type=SqlJoinType.LEFT_OUTER
     )
 
     assert evaluation == LinkableInstanceSatisfiabilityEvaluation(
@@ -456,7 +456,7 @@ def test_node_evaluator_with_partition_joined_spec(  # noqa: D
                 entity_links=(EntityReference(element_name="user"),),
             ),
         ],
-        start_node=mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
+        left_node=mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
             "id_verifications"
         ],
         default_join_type=SqlJoinType.LEFT_OUTER,
@@ -529,7 +529,7 @@ def test_node_evaluator_with_scd_target(
                 entity_links=(EntityReference(element_name="listing"),),
             )
         ],
-        start_node=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].read_node_mapping[
+        left_node=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].read_node_mapping[
             "bookings_source"
         ],
         default_join_type=SqlJoinType.LEFT_OUTER,
@@ -586,7 +586,7 @@ def test_node_evaluator_with_multi_hop_scd_target(
 
     evaluation = node_evaluator.evaluate_node(
         required_linkable_specs=linkable_specs,
-        start_node=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].read_node_mapping[
+        left_node=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].read_node_mapping[
             "bookings_source"
         ],
         default_join_type=SqlJoinType.LEFT_OUTER,
@@ -651,7 +651,7 @@ def test_node_evaluator_with_multi_hop_through_scd(
 
     evaluation = node_evaluator.evaluate_node(
         required_linkable_specs=linkable_specs,
-        start_node=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].read_node_mapping[
+        left_node=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].read_node_mapping[
             "bookings_source"
         ],
         default_join_type=SqlJoinType.LEFT_OUTER,
@@ -711,7 +711,7 @@ def test_node_evaluator_with_invalid_multi_hop_scd(
 
     evaluation = node_evaluator.evaluate_node(
         required_linkable_specs=linkable_specs,
-        start_node=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].read_node_mapping[
+        left_node=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].read_node_mapping[
             "bookings_source"
         ],
         default_join_type=SqlJoinType.LEFT_OUTER,

--- a/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_count_with_no_group_by__plan0.xml
+++ b/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_count_with_no_group_by__plan0.xml
@@ -1,15 +1,15 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_22') -->
+        <!-- node_id = NodeId(id_str='ss_21') -->
         <!-- col0 =                                                                                                     -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_726), column_alias='visit_buy_conversions') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_725), column_alias='visit_buy_conversions') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_21') -->
+            <!-- node_id = NodeId(id_str='ss_20') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX), -->
@@ -20,10 +20,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
             <!--     column_alias='buys',                                                       -->
             <!--   )                                                                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_20), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_19), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=CROSS_JOIN,                               -->
             <!--   )                                                     -->
@@ -31,210 +31,210 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_12') -->
+                <!-- node_id = NodeId(id_str='ss_11') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits',]" -->
-                    <!-- node_id = NodeId(id_str='ss_11') -->
+                    <!-- node_id = NodeId(id_str='ss_10') -->
                     <!-- col0 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_570), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_569), column_alias='visits') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_10') -->
+                        <!-- node_id = NodeId(id_str='ss_9') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_532), column_alias='ds__day') -->
                         <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_534), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__week') -->
                         <!-- col2 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
                         <!--     column_alias='ds__month',                          -->
                         <!--   )                                                    -->
                         <!-- col3 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
                         <!--     column_alias='ds__quarter',                        -->
                         <!--   )                                                    -->
                         <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_537), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_536), column_alias='ds__year') -->
                         <!-- col5 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
                         <!--     column_alias='ds__extract_year',                   -->
                         <!--   )                                                    -->
                         <!-- col6 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
                         <!--     column_alias='ds__extract_quarter',                -->
                         <!--   )                                                    -->
                         <!-- col7 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
                         <!--     column_alias='ds__extract_month',                  -->
                         <!--   )                                                    -->
                         <!-- col8 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
                         <!--     column_alias='ds__extract_day',                    -->
                         <!--   )                                                    -->
                         <!-- col9 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
                         <!--     column_alias='ds__extract_dow',                    -->
                         <!--   )                                                    -->
                         <!-- col10 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
                         <!--     column_alias='ds__extract_doy',                    -->
                         <!--   )                                                    -->
                         <!-- col11 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
                         <!--     column_alias='visit__ds__day',                     -->
                         <!--   )                                                    -->
                         <!-- col12 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
                         <!--     column_alias='visit__ds__week',                    -->
                         <!--   )                                                    -->
                         <!-- col13 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
                         <!--     column_alias='visit__ds__month',                   -->
                         <!--   )                                                    -->
                         <!-- col14 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
                         <!--     column_alias='visit__ds__quarter',                 -->
                         <!--   )                                                    -->
                         <!-- col15 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
                         <!--     column_alias='visit__ds__year',                    -->
                         <!--   )                                                    -->
                         <!-- col16 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
                         <!--     column_alias='visit__ds__extract_year',            -->
                         <!--   )                                                    -->
                         <!-- col17 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
                         <!--     column_alias='visit__ds__extract_quarter',         -->
                         <!--   )                                                    -->
                         <!-- col18 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
                         <!--     column_alias='visit__ds__extract_month',           -->
                         <!--   )                                                    -->
                         <!-- col19 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
                         <!--     column_alias='visit__ds__extract_day',             -->
                         <!--   )                                                    -->
                         <!-- col20 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
                         <!--     column_alias='visit__ds__extract_dow',             -->
                         <!--   )                                                    -->
                         <!-- col21 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
                         <!--     column_alias='visit__ds__extract_doy',             -->
                         <!--   )                                                    -->
                         <!-- col22 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col23 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
                         <!--     column_alias='metric_time__week',                  -->
                         <!--   )                                                    -->
                         <!-- col24 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
                         <!--     column_alias='metric_time__month',                 -->
                         <!--   )                                                    -->
                         <!-- col25 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
                         <!--     column_alias='metric_time__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col26 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
                         <!--     column_alias='metric_time__year',                  -->
                         <!--   )                                                    -->
                         <!-- col27 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
                         <!--     column_alias='metric_time__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col28 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
                         <!--     column_alias='metric_time__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col29 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
                         <!--     column_alias='metric_time__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col30 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
                         <!--     column_alias='metric_time__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col31 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
                         <!--     column_alias='metric_time__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col32 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
                         <!--     column_alias='metric_time__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col33 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_565), column_alias='user') -->
                         <!-- col34 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_567), column_alias='session') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='session') -->
                         <!-- col35 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
                         <!--     column_alias='visit__user',                        -->
                         <!--   )                                                    -->
                         <!-- col36 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
                         <!--     column_alias='visit__session',                     -->
                         <!--   )                                                    -->
                         <!-- col37 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
                         <!--     column_alias='referrer_id',                        -->
                         <!--   )                                                    -->
                         <!-- col38 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col39 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visits') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='visits') -->
                         <!-- col40 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_530), column_alias='visitors') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visitors') -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
@@ -396,39 +396,39 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_20') -->
+                <!-- node_id = NodeId(id_str='ss_19') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys',]" -->
-                    <!-- node_id = NodeId(id_str='ss_19') -->
-                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_722), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                    <!-- node_id = NodeId(id_str='ss_18') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_721), column_alias='buys') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_18') -->
+                        <!-- node_id = NodeId(id_str='ss_17') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_720), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_719), column_alias='ds__day') -->
                         <!-- col1 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_721), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_720), column_alias='user') -->
                         <!-- col2 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_718), column_alias='buys') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_717), column_alias='buys') -->
                         <!-- col3 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_719), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_718), column_alias='visits') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_17') -->
+                            <!-- node_id = NodeId(id_str='ss_16') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -446,15 +446,15 @@
                             <!--   )                                                                             -->
                             <!-- col3 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_716), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_715), -->
                             <!--     column_alias='mf_internal_uuid',                   -->
                             <!--   )                                                    -->
                             <!-- col4 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_717), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_716), column_alias='buys') -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                             <!-- join_0 =                                                -->
                             <!--   SqlJoinDescription(                                   -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_16), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
                             <!--     right_source_alias='subq_9',                        -->
                             <!--     join_type=INNER,                                    -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
@@ -463,231 +463,231 @@
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['visits', 'ds__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_14') -->
+                                <!-- node_id = NodeId(id_str='ss_13') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
                                 <!--     column_alias='visits',                             -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_13') -->
+                                    <!-- node_id = NodeId(id_str='ss_12') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
                                     <!--     column_alias='visit__ds__day',                     -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
                                     <!--     column_alias='visit__ds__week',                    -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
                                     <!--     column_alias='visit__ds__month',                   -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
                                     <!--     column_alias='visit__ds__quarter',                 -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
                                     <!--     column_alias='visit__ds__year',                    -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
                                     <!--     column_alias='visit__ds__extract_year',            -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
                                     <!--     column_alias='visit__ds__extract_quarter',         -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
                                     <!--     column_alias='visit__ds__extract_month',           -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
                                     <!--     column_alias='visit__ds__extract_day',             -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
                                     <!--     column_alias='visit__ds__extract_dow',             -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
                                     <!--     column_alias='visit__ds__extract_doy',             -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
                                     <!--     column_alias='session',                            -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
                                     <!--     column_alias='visit__user',                        -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
                                     <!--     column_alias='visit__session',                     -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
                                     <!--     column_alias='referrer_id',                        -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
                                     <!--     column_alias='visit__referrer_id',                 -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
                                     <!--     column_alias='visits',                             -->
                                     <!--   )                                                    -->
                                     <!-- col40 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
                                     <!--     column_alias='visitors',                           -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
@@ -859,200 +859,200 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_16') -->
+                                <!-- node_id = NodeId(id_str='ss_15') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
                                 <!--     column_alias='ds__week',                           -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
                                 <!--     column_alias='ds__month',                          -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
                                 <!--     column_alias='ds__quarter',                        -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
                                 <!--     column_alias='ds__year',                           -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
                                 <!--     column_alias='ds__extract_year',                   -->
                                 <!--   )                                                    -->
                                 <!-- col6 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
                                 <!--     column_alias='ds__extract_quarter',                -->
                                 <!--   )                                                    -->
                                 <!-- col7 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
                                 <!--     column_alias='ds__extract_month',                  -->
                                 <!--   )                                                    -->
                                 <!-- col8 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
                                 <!--     column_alias='ds__extract_day',                    -->
                                 <!--   )                                                    -->
                                 <!-- col9 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
                                 <!--     column_alias='ds__extract_dow',                    -->
                                 <!--   )                                                    -->
                                 <!-- col10 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
                                 <!--     column_alias='ds__extract_doy',                    -->
                                 <!--   )                                                    -->
                                 <!-- col11 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
                                 <!--     column_alias='buy__ds__day',                       -->
                                 <!--   )                                                    -->
                                 <!-- col12 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
                                 <!--     column_alias='buy__ds__week',                      -->
                                 <!--   )                                                    -->
                                 <!-- col13 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
                                 <!--     column_alias='buy__ds__month',                     -->
                                 <!--   )                                                    -->
                                 <!-- col14 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
                                 <!--     column_alias='buy__ds__quarter',                   -->
                                 <!--   )                                                    -->
                                 <!-- col15 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
                                 <!--     column_alias='buy__ds__year',                      -->
                                 <!--   )                                                    -->
                                 <!-- col16 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
                                 <!--     column_alias='buy__ds__extract_year',              -->
                                 <!--   )                                                    -->
                                 <!-- col17 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
                                 <!--     column_alias='buy__ds__extract_quarter',           -->
                                 <!--   )                                                    -->
                                 <!-- col18 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
                                 <!--     column_alias='buy__ds__extract_month',             -->
                                 <!--   )                                                    -->
                                 <!-- col19 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
                                 <!--     column_alias='buy__ds__extract_day',               -->
                                 <!--   )                                                    -->
                                 <!-- col20 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
                                 <!--     column_alias='buy__ds__extract_dow',               -->
                                 <!--   )                                                    -->
                                 <!-- col21 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
                                 <!--     column_alias='buy__ds__extract_doy',               -->
                                 <!--   )                                                    -->
                                 <!-- col22 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col23 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
                                 <!--     column_alias='metric_time__week',                  -->
                                 <!--   )                                                    -->
                                 <!-- col24 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
                                 <!--     column_alias='metric_time__month',                 -->
                                 <!--   )                                                    -->
                                 <!-- col25 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
                                 <!--     column_alias='metric_time__quarter',               -->
                                 <!--   )                                                    -->
                                 <!-- col26 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
                                 <!--     column_alias='metric_time__year',                  -->
                                 <!--   )                                                    -->
                                 <!-- col27 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
                                 <!--     column_alias='metric_time__extract_year',          -->
                                 <!--   )                                                    -->
                                 <!-- col28 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
                                 <!--     column_alias='metric_time__extract_quarter',       -->
                                 <!--   )                                                    -->
                                 <!-- col29 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
                                 <!--     column_alias='metric_time__extract_month',         -->
                                 <!--   )                                                    -->
                                 <!-- col30 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
                                 <!--     column_alias='metric_time__extract_day',           -->
                                 <!--   )                                                    -->
                                 <!-- col31 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
                                 <!--     column_alias='metric_time__extract_dow',           -->
                                 <!--   )                                                    -->
                                 <!-- col32 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
                                 <!--     column_alias='metric_time__extract_doy',           -->
                                 <!--   )                                                    -->
                                 <!-- col33 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col34 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
                                 <!--     column_alias='session_id',                         -->
                                 <!--   )                                                    -->
                                 <!-- col35 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
                                 <!--     column_alias='buy__user',                          -->
                                 <!--   )                                                    -->
                                 <!-- col36 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
                                 <!--     column_alias='buy__session_id',                    -->
                                 <!--   )                                                    -->
                                 <!-- col37 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
                                 <!-- col38 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
                                 <!--     column_alias='buyers',                             -->
                                 <!--   )                                                    -->
                                 <!-- col39 =                                             -->
@@ -1060,205 +1060,205 @@
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_15') -->
+                                    <!-- node_id = NodeId(id_str='ss_14') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
                                     <!--     column_alias='buy__ds__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
                                     <!--     column_alias='buy__ds__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
                                     <!--     column_alias='buy__ds__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
                                     <!--     column_alias='buy__ds__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
                                     <!--     column_alias='buy__ds__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
                                     <!--     column_alias='buy__ds__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
                                     <!--     column_alias='buy__ds__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
                                     <!--     column_alias='buy__ds__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
                                     <!--     column_alias='buy__ds__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
                                     <!--     column_alias='buy__ds__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
                                     <!--     column_alias='buy__ds__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
                                     <!--     column_alias='session_id',                         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
                                     <!--     column_alias='buy__user',                          -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
                                     <!--     column_alias='buy__session_id',                    -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
                                     <!--     column_alias='buys',                               -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
                                     <!--     column_alias='buyers',                             -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->

--- a/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate__plan0.xml
+++ b/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate__plan0.xml
@@ -1,17 +1,17 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_22') -->
+        <!-- node_id = NodeId(id_str='ss_21') -->
         <!-- col0 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_742), column_alias='visit__referrer_id') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_741), column_alias='visit__referrer_id') -->
         <!-- col1 =                                                                                                        -->
         <!--   SqlSelectColumn(expr=SqlRatioComputationExpression(node_id=rc_0), column_alias='visit_buy_conversion_rate') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_21') -->
+            <!-- node_id = NodeId(id_str='ss_20') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
@@ -27,10 +27,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_20),  -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_19),  -->
             <!--     right_source_alias='subq_13',                        -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_2), -->
@@ -44,10 +44,10 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_12') -->
+                <!-- node_id = NodeId(id_str='ss_11') -->
                 <!-- col0 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- col1 =                                                                    -->
@@ -55,214 +55,214 @@
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- group_by0 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id']" -->
-                    <!-- node_id = NodeId(id_str='ss_11') -->
+                    <!-- node_id = NodeId(id_str='ss_10') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
                     <!-- col1 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_570), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_569), column_alias='visits') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_10') -->
+                        <!-- node_id = NodeId(id_str='ss_9') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_532), column_alias='ds__day') -->
                         <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_534), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__week') -->
                         <!-- col2 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
                         <!--     column_alias='ds__month',                          -->
                         <!--   )                                                    -->
                         <!-- col3 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
                         <!--     column_alias='ds__quarter',                        -->
                         <!--   )                                                    -->
                         <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_537), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_536), column_alias='ds__year') -->
                         <!-- col5 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
                         <!--     column_alias='ds__extract_year',                   -->
                         <!--   )                                                    -->
                         <!-- col6 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
                         <!--     column_alias='ds__extract_quarter',                -->
                         <!--   )                                                    -->
                         <!-- col7 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
                         <!--     column_alias='ds__extract_month',                  -->
                         <!--   )                                                    -->
                         <!-- col8 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
                         <!--     column_alias='ds__extract_day',                    -->
                         <!--   )                                                    -->
                         <!-- col9 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
                         <!--     column_alias='ds__extract_dow',                    -->
                         <!--   )                                                    -->
                         <!-- col10 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
                         <!--     column_alias='ds__extract_doy',                    -->
                         <!--   )                                                    -->
                         <!-- col11 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
                         <!--     column_alias='visit__ds__day',                     -->
                         <!--   )                                                    -->
                         <!-- col12 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
                         <!--     column_alias='visit__ds__week',                    -->
                         <!--   )                                                    -->
                         <!-- col13 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
                         <!--     column_alias='visit__ds__month',                   -->
                         <!--   )                                                    -->
                         <!-- col14 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
                         <!--     column_alias='visit__ds__quarter',                 -->
                         <!--   )                                                    -->
                         <!-- col15 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
                         <!--     column_alias='visit__ds__year',                    -->
                         <!--   )                                                    -->
                         <!-- col16 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
                         <!--     column_alias='visit__ds__extract_year',            -->
                         <!--   )                                                    -->
                         <!-- col17 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
                         <!--     column_alias='visit__ds__extract_quarter',         -->
                         <!--   )                                                    -->
                         <!-- col18 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
                         <!--     column_alias='visit__ds__extract_month',           -->
                         <!--   )                                                    -->
                         <!-- col19 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
                         <!--     column_alias='visit__ds__extract_day',             -->
                         <!--   )                                                    -->
                         <!-- col20 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
                         <!--     column_alias='visit__ds__extract_dow',             -->
                         <!--   )                                                    -->
                         <!-- col21 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
                         <!--     column_alias='visit__ds__extract_doy',             -->
                         <!--   )                                                    -->
                         <!-- col22 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col23 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
                         <!--     column_alias='metric_time__week',                  -->
                         <!--   )                                                    -->
                         <!-- col24 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
                         <!--     column_alias='metric_time__month',                 -->
                         <!--   )                                                    -->
                         <!-- col25 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
                         <!--     column_alias='metric_time__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col26 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
                         <!--     column_alias='metric_time__year',                  -->
                         <!--   )                                                    -->
                         <!-- col27 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
                         <!--     column_alias='metric_time__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col28 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
                         <!--     column_alias='metric_time__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col29 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
                         <!--     column_alias='metric_time__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col30 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
                         <!--     column_alias='metric_time__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col31 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
                         <!--     column_alias='metric_time__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col32 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
                         <!--     column_alias='metric_time__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col33 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_565), column_alias='user') -->
                         <!-- col34 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_567), column_alias='session') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='session') -->
                         <!-- col35 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
                         <!--     column_alias='visit__user',                        -->
                         <!--   )                                                    -->
                         <!-- col36 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
                         <!--     column_alias='visit__session',                     -->
                         <!--   )                                                    -->
                         <!-- col37 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
                         <!--     column_alias='referrer_id',                        -->
                         <!--   )                                                    -->
                         <!-- col38 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col39 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visits') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='visits') -->
                         <!-- col40 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_530), column_alias='visitors') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visitors') -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
@@ -424,10 +424,10 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_20') -->
+                <!-- node_id = NodeId(id_str='ss_19') -->
                 <!-- col0 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_735), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_734), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- col1 =                                                                    -->
@@ -435,48 +435,48 @@
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
                 <!-- group_by0 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_735), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_734), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id']" -->
-                    <!-- node_id = NodeId(id_str='ss_19') -->
+                    <!-- node_id = NodeId(id_str='ss_18') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_733), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_732), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
-                    <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_732), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                    <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_731), column_alias='buys') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of INF' -->
-                        <!-- node_id = NodeId(id_str='ss_18') -->
+                        <!-- node_id = NodeId(id_str='ss_17') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_730), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_729), column_alias='ds__day') -->
                         <!-- col1 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_731), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_730), column_alias='user') -->
                         <!-- col2 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_729), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_728), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col3 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_727), column_alias='buys') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_726), column_alias='buys') -->
                         <!-- col4 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_728), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_727), column_alias='visits') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_17') -->
+                            <!-- node_id = NodeId(id_str='ss_16') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -499,15 +499,15 @@
                             <!--   )                                                                             -->
                             <!-- col4 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_725), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_724), -->
                             <!--     column_alias='mf_internal_uuid',                   -->
                             <!--   )                                                    -->
                             <!-- col5 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_726), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_725), column_alias='buys') -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                             <!-- join_0 =                                                -->
                             <!--   SqlJoinDescription(                                   -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_16), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
                             <!--     right_source_alias='subq_9',                        -->
                             <!--     join_type=INNER,                                    -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
@@ -517,236 +517,236 @@
                             <SqlSelectStatementNode>
                                 <!-- description =                                                               -->
                                 <!--   "Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_14') -->
+                                <!-- node_id = NodeId(id_str='ss_13') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
                                 <!--     column_alias='visit__referrer_id',                 -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
                                 <!--     column_alias='visits',                             -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_13') -->
+                                    <!-- node_id = NodeId(id_str='ss_12') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
                                     <!--     column_alias='visit__ds__day',                     -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
                                     <!--     column_alias='visit__ds__week',                    -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
                                     <!--     column_alias='visit__ds__month',                   -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
                                     <!--     column_alias='visit__ds__quarter',                 -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
                                     <!--     column_alias='visit__ds__year',                    -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
                                     <!--     column_alias='visit__ds__extract_year',            -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
                                     <!--     column_alias='visit__ds__extract_quarter',         -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
                                     <!--     column_alias='visit__ds__extract_month',           -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
                                     <!--     column_alias='visit__ds__extract_day',             -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
                                     <!--     column_alias='visit__ds__extract_dow',             -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
                                     <!--     column_alias='visit__ds__extract_doy',             -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
                                     <!--     column_alias='session',                            -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
                                     <!--     column_alias='visit__user',                        -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
                                     <!--     column_alias='visit__session',                     -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
                                     <!--     column_alias='referrer_id',                        -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
                                     <!--     column_alias='visit__referrer_id',                 -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
                                     <!--     column_alias='visits',                             -->
                                     <!--   )                                                    -->
                                     <!-- col40 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
                                     <!--     column_alias='visitors',                           -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
@@ -918,200 +918,200 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_16') -->
+                                <!-- node_id = NodeId(id_str='ss_15') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
                                 <!--     column_alias='ds__week',                           -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
                                 <!--     column_alias='ds__month',                          -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
                                 <!--     column_alias='ds__quarter',                        -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
                                 <!--     column_alias='ds__year',                           -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
                                 <!--     column_alias='ds__extract_year',                   -->
                                 <!--   )                                                    -->
                                 <!-- col6 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
                                 <!--     column_alias='ds__extract_quarter',                -->
                                 <!--   )                                                    -->
                                 <!-- col7 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
                                 <!--     column_alias='ds__extract_month',                  -->
                                 <!--   )                                                    -->
                                 <!-- col8 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
                                 <!--     column_alias='ds__extract_day',                    -->
                                 <!--   )                                                    -->
                                 <!-- col9 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
                                 <!--     column_alias='ds__extract_dow',                    -->
                                 <!--   )                                                    -->
                                 <!-- col10 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
                                 <!--     column_alias='ds__extract_doy',                    -->
                                 <!--   )                                                    -->
                                 <!-- col11 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
                                 <!--     column_alias='buy__ds__day',                       -->
                                 <!--   )                                                    -->
                                 <!-- col12 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
                                 <!--     column_alias='buy__ds__week',                      -->
                                 <!--   )                                                    -->
                                 <!-- col13 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
                                 <!--     column_alias='buy__ds__month',                     -->
                                 <!--   )                                                    -->
                                 <!-- col14 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
                                 <!--     column_alias='buy__ds__quarter',                   -->
                                 <!--   )                                                    -->
                                 <!-- col15 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
                                 <!--     column_alias='buy__ds__year',                      -->
                                 <!--   )                                                    -->
                                 <!-- col16 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
                                 <!--     column_alias='buy__ds__extract_year',              -->
                                 <!--   )                                                    -->
                                 <!-- col17 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
                                 <!--     column_alias='buy__ds__extract_quarter',           -->
                                 <!--   )                                                    -->
                                 <!-- col18 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
                                 <!--     column_alias='buy__ds__extract_month',             -->
                                 <!--   )                                                    -->
                                 <!-- col19 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
                                 <!--     column_alias='buy__ds__extract_day',               -->
                                 <!--   )                                                    -->
                                 <!-- col20 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
                                 <!--     column_alias='buy__ds__extract_dow',               -->
                                 <!--   )                                                    -->
                                 <!-- col21 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
                                 <!--     column_alias='buy__ds__extract_doy',               -->
                                 <!--   )                                                    -->
                                 <!-- col22 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col23 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
                                 <!--     column_alias='metric_time__week',                  -->
                                 <!--   )                                                    -->
                                 <!-- col24 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
                                 <!--     column_alias='metric_time__month',                 -->
                                 <!--   )                                                    -->
                                 <!-- col25 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
                                 <!--     column_alias='metric_time__quarter',               -->
                                 <!--   )                                                    -->
                                 <!-- col26 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
                                 <!--     column_alias='metric_time__year',                  -->
                                 <!--   )                                                    -->
                                 <!-- col27 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
                                 <!--     column_alias='metric_time__extract_year',          -->
                                 <!--   )                                                    -->
                                 <!-- col28 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
                                 <!--     column_alias='metric_time__extract_quarter',       -->
                                 <!--   )                                                    -->
                                 <!-- col29 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
                                 <!--     column_alias='metric_time__extract_month',         -->
                                 <!--   )                                                    -->
                                 <!-- col30 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
                                 <!--     column_alias='metric_time__extract_day',           -->
                                 <!--   )                                                    -->
                                 <!-- col31 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
                                 <!--     column_alias='metric_time__extract_dow',           -->
                                 <!--   )                                                    -->
                                 <!-- col32 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
                                 <!--     column_alias='metric_time__extract_doy',           -->
                                 <!--   )                                                    -->
                                 <!-- col33 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col34 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
                                 <!--     column_alias='session_id',                         -->
                                 <!--   )                                                    -->
                                 <!-- col35 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
                                 <!--     column_alias='buy__user',                          -->
                                 <!--   )                                                    -->
                                 <!-- col36 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
                                 <!--     column_alias='buy__session_id',                    -->
                                 <!--   )                                                    -->
                                 <!-- col37 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
                                 <!-- col38 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
                                 <!--     column_alias='buyers',                             -->
                                 <!--   )                                                    -->
                                 <!-- col39 =                                             -->
@@ -1119,205 +1119,205 @@
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_15') -->
+                                    <!-- node_id = NodeId(id_str='ss_14') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
                                     <!--     column_alias='buy__ds__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
                                     <!--     column_alias='buy__ds__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
                                     <!--     column_alias='buy__ds__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
                                     <!--     column_alias='buy__ds__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
                                     <!--     column_alias='buy__ds__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
                                     <!--     column_alias='buy__ds__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
                                     <!--     column_alias='buy__ds__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
                                     <!--     column_alias='buy__ds__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
                                     <!--     column_alias='buy__ds__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
                                     <!--     column_alias='buy__ds__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
                                     <!--     column_alias='buy__ds__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
                                     <!--     column_alias='session_id',                         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
                                     <!--     column_alias='buy__user',                          -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
                                     <!--     column_alias='buy__session_id',                    -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
                                     <!--     column_alias='buys',                               -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
                                     <!--     column_alias='buyers',                             -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->

--- a/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_constant_properties__plan0.xml
+++ b/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_constant_properties__plan0.xml
@@ -1,21 +1,21 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_22') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_775), column_alias='metric_time__day') -->
+        <!-- node_id = NodeId(id_str='ss_21') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_774), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_774), column_alias='visit__referrer_id') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_773), column_alias='visit__referrer_id') -->
         <!-- col2 =                                                   -->
         <!--   SqlSelectColumn(                                       -->
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0),    -->
         <!--     column_alias='visit_buy_conversion_rate_by_session', -->
         <!--   )                                                      -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_21') -->
+            <!-- node_id = NodeId(id_str='ss_20') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -36,10 +36,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_20), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_19), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=FULL_OUTER,                               -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_2),    -->
@@ -58,12 +58,12 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_12') -->
+                <!-- node_id = NodeId(id_str='ss_11') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_575), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_574), column_alias='metric_time__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- col2 =                                                                    -->
@@ -71,221 +71,221 @@
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_575), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_574), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_11') -->
+                    <!-- node_id = NodeId(id_str='ss_10') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
                     <!-- col2 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_570), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_569), column_alias='visits') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_10') -->
+                        <!-- node_id = NodeId(id_str='ss_9') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_532), column_alias='ds__day') -->
                         <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_534), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__week') -->
                         <!-- col2 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
                         <!--     column_alias='ds__month',                          -->
                         <!--   )                                                    -->
                         <!-- col3 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
                         <!--     column_alias='ds__quarter',                        -->
                         <!--   )                                                    -->
                         <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_537), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_536), column_alias='ds__year') -->
                         <!-- col5 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
                         <!--     column_alias='ds__extract_year',                   -->
                         <!--   )                                                    -->
                         <!-- col6 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
                         <!--     column_alias='ds__extract_quarter',                -->
                         <!--   )                                                    -->
                         <!-- col7 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
                         <!--     column_alias='ds__extract_month',                  -->
                         <!--   )                                                    -->
                         <!-- col8 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
                         <!--     column_alias='ds__extract_day',                    -->
                         <!--   )                                                    -->
                         <!-- col9 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
                         <!--     column_alias='ds__extract_dow',                    -->
                         <!--   )                                                    -->
                         <!-- col10 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
                         <!--     column_alias='ds__extract_doy',                    -->
                         <!--   )                                                    -->
                         <!-- col11 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
                         <!--     column_alias='visit__ds__day',                     -->
                         <!--   )                                                    -->
                         <!-- col12 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
                         <!--     column_alias='visit__ds__week',                    -->
                         <!--   )                                                    -->
                         <!-- col13 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
                         <!--     column_alias='visit__ds__month',                   -->
                         <!--   )                                                    -->
                         <!-- col14 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
                         <!--     column_alias='visit__ds__quarter',                 -->
                         <!--   )                                                    -->
                         <!-- col15 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
                         <!--     column_alias='visit__ds__year',                    -->
                         <!--   )                                                    -->
                         <!-- col16 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
                         <!--     column_alias='visit__ds__extract_year',            -->
                         <!--   )                                                    -->
                         <!-- col17 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
                         <!--     column_alias='visit__ds__extract_quarter',         -->
                         <!--   )                                                    -->
                         <!-- col18 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
                         <!--     column_alias='visit__ds__extract_month',           -->
                         <!--   )                                                    -->
                         <!-- col19 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
                         <!--     column_alias='visit__ds__extract_day',             -->
                         <!--   )                                                    -->
                         <!-- col20 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
                         <!--     column_alias='visit__ds__extract_dow',             -->
                         <!--   )                                                    -->
                         <!-- col21 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
                         <!--     column_alias='visit__ds__extract_doy',             -->
                         <!--   )                                                    -->
                         <!-- col22 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col23 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
                         <!--     column_alias='metric_time__week',                  -->
                         <!--   )                                                    -->
                         <!-- col24 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
                         <!--     column_alias='metric_time__month',                 -->
                         <!--   )                                                    -->
                         <!-- col25 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
                         <!--     column_alias='metric_time__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col26 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
                         <!--     column_alias='metric_time__year',                  -->
                         <!--   )                                                    -->
                         <!-- col27 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
                         <!--     column_alias='metric_time__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col28 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
                         <!--     column_alias='metric_time__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col29 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
                         <!--     column_alias='metric_time__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col30 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
                         <!--     column_alias='metric_time__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col31 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
                         <!--     column_alias='metric_time__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col32 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
                         <!--     column_alias='metric_time__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col33 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_565), column_alias='user') -->
                         <!-- col34 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_567), column_alias='session') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='session') -->
                         <!-- col35 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
                         <!--     column_alias='visit__user',                        -->
                         <!--   )                                                    -->
                         <!-- col36 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
                         <!--     column_alias='visit__session',                     -->
                         <!--   )                                                    -->
                         <!-- col37 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
                         <!--     column_alias='referrer_id',                        -->
                         <!--   )                                                    -->
                         <!-- col38 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col39 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visits') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='visits') -->
                         <!-- col40 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_530), column_alias='visitors') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visitors') -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
@@ -447,12 +447,12 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_20') -->
+                <!-- node_id = NodeId(id_str='ss_19') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_763), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_762), column_alias='metric_time__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_762), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_761), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- col2 =                                                                    -->
@@ -460,62 +460,62 @@
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
                 <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_763), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_762), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_762), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_761), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_19') -->
+                    <!-- node_id = NodeId(id_str='ss_18') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_760), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_759), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_759), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_758), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
-                    <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_758), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                    <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_757), column_alias='buys') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_18') -->
+                        <!-- node_id = NodeId(id_str='ss_17') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_754), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_753), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_755), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_754), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_756), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_755), column_alias='user') -->
                         <!-- col3 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_757), column_alias='session') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_756), column_alias='session') -->
                         <!-- col4 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_753), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_752), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col5 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_751), column_alias='buys') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_750), column_alias='buys') -->
                         <!-- col6 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_752), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_751), column_alias='visits') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_17') -->
+                            <!-- node_id = NodeId(id_str='ss_16') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -548,15 +548,15 @@
                             <!--   )                                                                             -->
                             <!-- col6 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_749), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_748), -->
                             <!--     column_alias='mf_internal_uuid',                   -->
                             <!--   )                                                    -->
                             <!-- col7 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_750), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_749), column_alias='buys') -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                             <!-- join_0 =                                                -->
                             <!--   SqlJoinDescription(                                   -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_16), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
                             <!--     right_source_alias='subq_9',                        -->
                             <!--     join_type=INNER,                                    -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
@@ -567,246 +567,246 @@
                                 <!-- description =                                                         -->
                                 <!--   ("Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', " -->
                                 <!--    "'metric_time__day', 'user', 'session']")                          -->
-                                <!-- node_id = NodeId(id_str='ss_14') -->
+                                <!-- node_id = NodeId(id_str='ss_13') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
                                 <!--     column_alias='session',                            -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
                                 <!--     column_alias='visit__referrer_id',                 -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
                                 <!--     column_alias='visits',                             -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_13') -->
+                                    <!-- node_id = NodeId(id_str='ss_12') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
                                     <!--     column_alias='visit__ds__day',                     -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
                                     <!--     column_alias='visit__ds__week',                    -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
                                     <!--     column_alias='visit__ds__month',                   -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
                                     <!--     column_alias='visit__ds__quarter',                 -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
                                     <!--     column_alias='visit__ds__year',                    -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
                                     <!--     column_alias='visit__ds__extract_year',            -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
                                     <!--     column_alias='visit__ds__extract_quarter',         -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
                                     <!--     column_alias='visit__ds__extract_month',           -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
                                     <!--     column_alias='visit__ds__extract_day',             -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
                                     <!--     column_alias='visit__ds__extract_dow',             -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
                                     <!--     column_alias='visit__ds__extract_doy',             -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
                                     <!--     column_alias='session',                            -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
                                     <!--     column_alias='visit__user',                        -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
                                     <!--     column_alias='visit__session',                     -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
                                     <!--     column_alias='referrer_id',                        -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
                                     <!--     column_alias='visit__referrer_id',                 -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
                                     <!--     column_alias='visits',                             -->
                                     <!--   )                                                    -->
                                     <!-- col40 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
                                     <!--     column_alias='visitors',                           -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
@@ -978,200 +978,200 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_16') -->
+                                <!-- node_id = NodeId(id_str='ss_15') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
                                 <!--     column_alias='ds__week',                           -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
                                 <!--     column_alias='ds__month',                          -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
                                 <!--     column_alias='ds__quarter',                        -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
                                 <!--     column_alias='ds__year',                           -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
                                 <!--     column_alias='ds__extract_year',                   -->
                                 <!--   )                                                    -->
                                 <!-- col6 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
                                 <!--     column_alias='ds__extract_quarter',                -->
                                 <!--   )                                                    -->
                                 <!-- col7 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
                                 <!--     column_alias='ds__extract_month',                  -->
                                 <!--   )                                                    -->
                                 <!-- col8 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
                                 <!--     column_alias='ds__extract_day',                    -->
                                 <!--   )                                                    -->
                                 <!-- col9 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
                                 <!--     column_alias='ds__extract_dow',                    -->
                                 <!--   )                                                    -->
                                 <!-- col10 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
                                 <!--     column_alias='ds__extract_doy',                    -->
                                 <!--   )                                                    -->
                                 <!-- col11 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
                                 <!--     column_alias='buy__ds__day',                       -->
                                 <!--   )                                                    -->
                                 <!-- col12 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
                                 <!--     column_alias='buy__ds__week',                      -->
                                 <!--   )                                                    -->
                                 <!-- col13 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
                                 <!--     column_alias='buy__ds__month',                     -->
                                 <!--   )                                                    -->
                                 <!-- col14 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
                                 <!--     column_alias='buy__ds__quarter',                   -->
                                 <!--   )                                                    -->
                                 <!-- col15 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
                                 <!--     column_alias='buy__ds__year',                      -->
                                 <!--   )                                                    -->
                                 <!-- col16 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
                                 <!--     column_alias='buy__ds__extract_year',              -->
                                 <!--   )                                                    -->
                                 <!-- col17 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
                                 <!--     column_alias='buy__ds__extract_quarter',           -->
                                 <!--   )                                                    -->
                                 <!-- col18 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
                                 <!--     column_alias='buy__ds__extract_month',             -->
                                 <!--   )                                                    -->
                                 <!-- col19 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
                                 <!--     column_alias='buy__ds__extract_day',               -->
                                 <!--   )                                                    -->
                                 <!-- col20 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
                                 <!--     column_alias='buy__ds__extract_dow',               -->
                                 <!--   )                                                    -->
                                 <!-- col21 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
                                 <!--     column_alias='buy__ds__extract_doy',               -->
                                 <!--   )                                                    -->
                                 <!-- col22 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col23 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
                                 <!--     column_alias='metric_time__week',                  -->
                                 <!--   )                                                    -->
                                 <!-- col24 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
                                 <!--     column_alias='metric_time__month',                 -->
                                 <!--   )                                                    -->
                                 <!-- col25 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
                                 <!--     column_alias='metric_time__quarter',               -->
                                 <!--   )                                                    -->
                                 <!-- col26 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
                                 <!--     column_alias='metric_time__year',                  -->
                                 <!--   )                                                    -->
                                 <!-- col27 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
                                 <!--     column_alias='metric_time__extract_year',          -->
                                 <!--   )                                                    -->
                                 <!-- col28 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
                                 <!--     column_alias='metric_time__extract_quarter',       -->
                                 <!--   )                                                    -->
                                 <!-- col29 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
                                 <!--     column_alias='metric_time__extract_month',         -->
                                 <!--   )                                                    -->
                                 <!-- col30 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
                                 <!--     column_alias='metric_time__extract_day',           -->
                                 <!--   )                                                    -->
                                 <!-- col31 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
                                 <!--     column_alias='metric_time__extract_dow',           -->
                                 <!--   )                                                    -->
                                 <!-- col32 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
                                 <!--     column_alias='metric_time__extract_doy',           -->
                                 <!--   )                                                    -->
                                 <!-- col33 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col34 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_698), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
                                 <!--     column_alias='session_id',                         -->
                                 <!--   )                                                    -->
                                 <!-- col35 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_699), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_698), -->
                                 <!--     column_alias='buy__user',                          -->
                                 <!--   )                                                    -->
                                 <!-- col36 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_700), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_699), -->
                                 <!--     column_alias='buy__session_id',                    -->
                                 <!--   )                                                    -->
                                 <!-- col37 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
                                 <!-- col38 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
                                 <!--     column_alias='buyers',                             -->
                                 <!--   )                                                    -->
                                 <!-- col39 =                                             -->
@@ -1179,205 +1179,205 @@
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_15') -->
+                                    <!-- node_id = NodeId(id_str='ss_14') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
                                     <!--     column_alias='buy__ds__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
                                     <!--     column_alias='buy__ds__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
                                     <!--     column_alias='buy__ds__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
                                     <!--     column_alias='buy__ds__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
                                     <!--     column_alias='buy__ds__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
                                     <!--     column_alias='buy__ds__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
                                     <!--     column_alias='buy__ds__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
                                     <!--     column_alias='buy__ds__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
                                     <!--     column_alias='buy__ds__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
                                     <!--     column_alias='buy__ds__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
                                     <!--     column_alias='buy__ds__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
                                     <!--     column_alias='session_id',                         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
                                     <!--     column_alias='buy__user',                          -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
                                     <!--     column_alias='buy__session_id',                    -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
                                     <!--     column_alias='buys',                               -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
                                     <!--     column_alias='buyers',                             -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->

--- a/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_no_group_by__plan0.xml
+++ b/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_no_group_by__plan0.xml
@@ -1,18 +1,18 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_22') -->
+        <!-- node_id = NodeId(id_str='ss_21') -->
         <!-- col0 =                                                -->
         <!--   SqlSelectColumn(                                    -->
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0), -->
         <!--     column_alias='visit_buy_conversion_rate_7days',   -->
         <!--   )                                                   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_21') -->
+            <!-- node_id = NodeId(id_str='ss_20') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX), -->
@@ -23,10 +23,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_20), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_19), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=CROSS_JOIN,                               -->
             <!--   )                                                     -->
@@ -34,210 +34,210 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_12') -->
+                <!-- node_id = NodeId(id_str='ss_11') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits',]" -->
-                    <!-- node_id = NodeId(id_str='ss_11') -->
+                    <!-- node_id = NodeId(id_str='ss_10') -->
                     <!-- col0 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_570), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_569), column_alias='visits') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_10') -->
+                        <!-- node_id = NodeId(id_str='ss_9') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_532), column_alias='ds__day') -->
                         <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_534), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__week') -->
                         <!-- col2 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
                         <!--     column_alias='ds__month',                          -->
                         <!--   )                                                    -->
                         <!-- col3 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
                         <!--     column_alias='ds__quarter',                        -->
                         <!--   )                                                    -->
                         <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_537), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_536), column_alias='ds__year') -->
                         <!-- col5 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
                         <!--     column_alias='ds__extract_year',                   -->
                         <!--   )                                                    -->
                         <!-- col6 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
                         <!--     column_alias='ds__extract_quarter',                -->
                         <!--   )                                                    -->
                         <!-- col7 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
                         <!--     column_alias='ds__extract_month',                  -->
                         <!--   )                                                    -->
                         <!-- col8 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
                         <!--     column_alias='ds__extract_day',                    -->
                         <!--   )                                                    -->
                         <!-- col9 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
                         <!--     column_alias='ds__extract_dow',                    -->
                         <!--   )                                                    -->
                         <!-- col10 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
                         <!--     column_alias='ds__extract_doy',                    -->
                         <!--   )                                                    -->
                         <!-- col11 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
                         <!--     column_alias='visit__ds__day',                     -->
                         <!--   )                                                    -->
                         <!-- col12 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
                         <!--     column_alias='visit__ds__week',                    -->
                         <!--   )                                                    -->
                         <!-- col13 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
                         <!--     column_alias='visit__ds__month',                   -->
                         <!--   )                                                    -->
                         <!-- col14 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
                         <!--     column_alias='visit__ds__quarter',                 -->
                         <!--   )                                                    -->
                         <!-- col15 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
                         <!--     column_alias='visit__ds__year',                    -->
                         <!--   )                                                    -->
                         <!-- col16 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
                         <!--     column_alias='visit__ds__extract_year',            -->
                         <!--   )                                                    -->
                         <!-- col17 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
                         <!--     column_alias='visit__ds__extract_quarter',         -->
                         <!--   )                                                    -->
                         <!-- col18 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
                         <!--     column_alias='visit__ds__extract_month',           -->
                         <!--   )                                                    -->
                         <!-- col19 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
                         <!--     column_alias='visit__ds__extract_day',             -->
                         <!--   )                                                    -->
                         <!-- col20 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
                         <!--     column_alias='visit__ds__extract_dow',             -->
                         <!--   )                                                    -->
                         <!-- col21 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
                         <!--     column_alias='visit__ds__extract_doy',             -->
                         <!--   )                                                    -->
                         <!-- col22 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col23 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
                         <!--     column_alias='metric_time__week',                  -->
                         <!--   )                                                    -->
                         <!-- col24 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
                         <!--     column_alias='metric_time__month',                 -->
                         <!--   )                                                    -->
                         <!-- col25 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
                         <!--     column_alias='metric_time__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col26 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
                         <!--     column_alias='metric_time__year',                  -->
                         <!--   )                                                    -->
                         <!-- col27 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
                         <!--     column_alias='metric_time__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col28 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
                         <!--     column_alias='metric_time__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col29 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
                         <!--     column_alias='metric_time__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col30 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
                         <!--     column_alias='metric_time__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col31 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
                         <!--     column_alias='metric_time__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col32 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
                         <!--     column_alias='metric_time__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col33 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_565), column_alias='user') -->
                         <!-- col34 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_567), column_alias='session') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='session') -->
                         <!-- col35 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
                         <!--     column_alias='visit__user',                        -->
                         <!--   )                                                    -->
                         <!-- col36 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
                         <!--     column_alias='visit__session',                     -->
                         <!--   )                                                    -->
                         <!-- col37 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
                         <!--     column_alias='referrer_id',                        -->
                         <!--   )                                                    -->
                         <!-- col38 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col39 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visits') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='visits') -->
                         <!-- col40 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_530), column_alias='visitors') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visitors') -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
@@ -399,39 +399,39 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_20') -->
+                <!-- node_id = NodeId(id_str='ss_19') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys',]" -->
-                    <!-- node_id = NodeId(id_str='ss_19') -->
-                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_722), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                    <!-- node_id = NodeId(id_str='ss_18') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_721), column_alias='buys') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_18') -->
+                        <!-- node_id = NodeId(id_str='ss_17') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_720), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_719), column_alias='ds__day') -->
                         <!-- col1 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_721), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_720), column_alias='user') -->
                         <!-- col2 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_718), column_alias='buys') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_717), column_alias='buys') -->
                         <!-- col3 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_719), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_718), column_alias='visits') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_17') -->
+                            <!-- node_id = NodeId(id_str='ss_16') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -449,15 +449,15 @@
                             <!--   )                                                                             -->
                             <!-- col3 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_716), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_715), -->
                             <!--     column_alias='mf_internal_uuid',                   -->
                             <!--   )                                                    -->
                             <!-- col4 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_717), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_716), column_alias='buys') -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                             <!-- join_0 =                                                -->
                             <!--   SqlJoinDescription(                                   -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_16), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
                             <!--     right_source_alias='subq_9',                        -->
                             <!--     join_type=INNER,                                    -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
@@ -466,231 +466,231 @@
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['visits', 'ds__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_14') -->
+                                <!-- node_id = NodeId(id_str='ss_13') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
                                 <!--     column_alias='visits',                             -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_13') -->
+                                    <!-- node_id = NodeId(id_str='ss_12') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
                                     <!--     column_alias='visit__ds__day',                     -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
                                     <!--     column_alias='visit__ds__week',                    -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
                                     <!--     column_alias='visit__ds__month',                   -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
                                     <!--     column_alias='visit__ds__quarter',                 -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
                                     <!--     column_alias='visit__ds__year',                    -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
                                     <!--     column_alias='visit__ds__extract_year',            -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
                                     <!--     column_alias='visit__ds__extract_quarter',         -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
                                     <!--     column_alias='visit__ds__extract_month',           -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
                                     <!--     column_alias='visit__ds__extract_day',             -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
                                     <!--     column_alias='visit__ds__extract_dow',             -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
                                     <!--     column_alias='visit__ds__extract_doy',             -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
                                     <!--     column_alias='session',                            -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
                                     <!--     column_alias='visit__user',                        -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
                                     <!--     column_alias='visit__session',                     -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
                                     <!--     column_alias='referrer_id',                        -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
                                     <!--     column_alias='visit__referrer_id',                 -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
                                     <!--     column_alias='visits',                             -->
                                     <!--   )                                                    -->
                                     <!-- col40 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
                                     <!--     column_alias='visitors',                           -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
@@ -862,200 +862,200 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_16') -->
+                                <!-- node_id = NodeId(id_str='ss_15') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
                                 <!--     column_alias='ds__week',                           -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
                                 <!--     column_alias='ds__month',                          -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
                                 <!--     column_alias='ds__quarter',                        -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
                                 <!--     column_alias='ds__year',                           -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
                                 <!--     column_alias='ds__extract_year',                   -->
                                 <!--   )                                                    -->
                                 <!-- col6 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
                                 <!--     column_alias='ds__extract_quarter',                -->
                                 <!--   )                                                    -->
                                 <!-- col7 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
                                 <!--     column_alias='ds__extract_month',                  -->
                                 <!--   )                                                    -->
                                 <!-- col8 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
                                 <!--     column_alias='ds__extract_day',                    -->
                                 <!--   )                                                    -->
                                 <!-- col9 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
                                 <!--     column_alias='ds__extract_dow',                    -->
                                 <!--   )                                                    -->
                                 <!-- col10 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
                                 <!--     column_alias='ds__extract_doy',                    -->
                                 <!--   )                                                    -->
                                 <!-- col11 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
                                 <!--     column_alias='buy__ds__day',                       -->
                                 <!--   )                                                    -->
                                 <!-- col12 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
                                 <!--     column_alias='buy__ds__week',                      -->
                                 <!--   )                                                    -->
                                 <!-- col13 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
                                 <!--     column_alias='buy__ds__month',                     -->
                                 <!--   )                                                    -->
                                 <!-- col14 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
                                 <!--     column_alias='buy__ds__quarter',                   -->
                                 <!--   )                                                    -->
                                 <!-- col15 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
                                 <!--     column_alias='buy__ds__year',                      -->
                                 <!--   )                                                    -->
                                 <!-- col16 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
                                 <!--     column_alias='buy__ds__extract_year',              -->
                                 <!--   )                                                    -->
                                 <!-- col17 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
                                 <!--     column_alias='buy__ds__extract_quarter',           -->
                                 <!--   )                                                    -->
                                 <!-- col18 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
                                 <!--     column_alias='buy__ds__extract_month',             -->
                                 <!--   )                                                    -->
                                 <!-- col19 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
                                 <!--     column_alias='buy__ds__extract_day',               -->
                                 <!--   )                                                    -->
                                 <!-- col20 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
                                 <!--     column_alias='buy__ds__extract_dow',               -->
                                 <!--   )                                                    -->
                                 <!-- col21 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
                                 <!--     column_alias='buy__ds__extract_doy',               -->
                                 <!--   )                                                    -->
                                 <!-- col22 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col23 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
                                 <!--     column_alias='metric_time__week',                  -->
                                 <!--   )                                                    -->
                                 <!-- col24 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
                                 <!--     column_alias='metric_time__month',                 -->
                                 <!--   )                                                    -->
                                 <!-- col25 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
                                 <!--     column_alias='metric_time__quarter',               -->
                                 <!--   )                                                    -->
                                 <!-- col26 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
                                 <!--     column_alias='metric_time__year',                  -->
                                 <!--   )                                                    -->
                                 <!-- col27 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
                                 <!--     column_alias='metric_time__extract_year',          -->
                                 <!--   )                                                    -->
                                 <!-- col28 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
                                 <!--     column_alias='metric_time__extract_quarter',       -->
                                 <!--   )                                                    -->
                                 <!-- col29 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
                                 <!--     column_alias='metric_time__extract_month',         -->
                                 <!--   )                                                    -->
                                 <!-- col30 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
                                 <!--     column_alias='metric_time__extract_day',           -->
                                 <!--   )                                                    -->
                                 <!-- col31 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
                                 <!--     column_alias='metric_time__extract_dow',           -->
                                 <!--   )                                                    -->
                                 <!-- col32 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
                                 <!--     column_alias='metric_time__extract_doy',           -->
                                 <!--   )                                                    -->
                                 <!-- col33 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col34 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
                                 <!--     column_alias='session_id',                         -->
                                 <!--   )                                                    -->
                                 <!-- col35 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
                                 <!--     column_alias='buy__user',                          -->
                                 <!--   )                                                    -->
                                 <!-- col36 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
                                 <!--     column_alias='buy__session_id',                    -->
                                 <!--   )                                                    -->
                                 <!-- col37 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
                                 <!-- col38 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
                                 <!--     column_alias='buyers',                             -->
                                 <!--   )                                                    -->
                                 <!-- col39 =                                             -->
@@ -1063,205 +1063,205 @@
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_15') -->
+                                    <!-- node_id = NodeId(id_str='ss_14') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
                                     <!--     column_alias='buy__ds__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
                                     <!--     column_alias='buy__ds__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
                                     <!--     column_alias='buy__ds__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
                                     <!--     column_alias='buy__ds__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
                                     <!--     column_alias='buy__ds__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
                                     <!--     column_alias='buy__ds__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
                                     <!--     column_alias='buy__ds__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
                                     <!--     column_alias='buy__ds__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
                                     <!--     column_alias='buy__ds__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
                                     <!--     column_alias='buy__ds__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
                                     <!--     column_alias='buy__ds__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
                                     <!--     column_alias='session_id',                         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
                                     <!--     column_alias='buy__user',                          -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
                                     <!--     column_alias='buy__session_id',                    -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
                                     <!--     column_alias='buys',                               -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
                                     <!--     column_alias='buyers',                             -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->

--- a/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_window__plan0.xml
+++ b/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_window__plan0.xml
@@ -1,21 +1,21 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_22') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_759), column_alias='metric_time__day') -->
+        <!-- node_id = NodeId(id_str='ss_21') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_758), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_758), column_alias='visit__referrer_id') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_757), column_alias='visit__referrer_id') -->
         <!-- col2 =                                                -->
         <!--   SqlSelectColumn(                                    -->
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0), -->
         <!--     column_alias='visit_buy_conversion_rate_7days',   -->
         <!--   )                                                   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_21') -->
+            <!-- node_id = NodeId(id_str='ss_20') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -36,10 +36,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_20), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_19), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=FULL_OUTER,                               -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_2),    -->
@@ -58,12 +58,12 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_12') -->
+                <!-- node_id = NodeId(id_str='ss_11') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_575), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_574), column_alias='metric_time__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- col2 =                                                                    -->
@@ -71,221 +71,221 @@
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_575), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_574), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_11') -->
+                    <!-- node_id = NodeId(id_str='ss_10') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
                     <!-- col2 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_570), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_569), column_alias='visits') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_10') -->
+                        <!-- node_id = NodeId(id_str='ss_9') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_532), column_alias='ds__day') -->
                         <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_534), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__week') -->
                         <!-- col2 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
                         <!--     column_alias='ds__month',                          -->
                         <!--   )                                                    -->
                         <!-- col3 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
                         <!--     column_alias='ds__quarter',                        -->
                         <!--   )                                                    -->
                         <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_537), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_536), column_alias='ds__year') -->
                         <!-- col5 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
                         <!--     column_alias='ds__extract_year',                   -->
                         <!--   )                                                    -->
                         <!-- col6 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
                         <!--     column_alias='ds__extract_quarter',                -->
                         <!--   )                                                    -->
                         <!-- col7 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
                         <!--     column_alias='ds__extract_month',                  -->
                         <!--   )                                                    -->
                         <!-- col8 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
                         <!--     column_alias='ds__extract_day',                    -->
                         <!--   )                                                    -->
                         <!-- col9 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
                         <!--     column_alias='ds__extract_dow',                    -->
                         <!--   )                                                    -->
                         <!-- col10 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
                         <!--     column_alias='ds__extract_doy',                    -->
                         <!--   )                                                    -->
                         <!-- col11 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
                         <!--     column_alias='visit__ds__day',                     -->
                         <!--   )                                                    -->
                         <!-- col12 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
                         <!--     column_alias='visit__ds__week',                    -->
                         <!--   )                                                    -->
                         <!-- col13 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
                         <!--     column_alias='visit__ds__month',                   -->
                         <!--   )                                                    -->
                         <!-- col14 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
                         <!--     column_alias='visit__ds__quarter',                 -->
                         <!--   )                                                    -->
                         <!-- col15 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
                         <!--     column_alias='visit__ds__year',                    -->
                         <!--   )                                                    -->
                         <!-- col16 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
                         <!--     column_alias='visit__ds__extract_year',            -->
                         <!--   )                                                    -->
                         <!-- col17 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
                         <!--     column_alias='visit__ds__extract_quarter',         -->
                         <!--   )                                                    -->
                         <!-- col18 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
                         <!--     column_alias='visit__ds__extract_month',           -->
                         <!--   )                                                    -->
                         <!-- col19 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
                         <!--     column_alias='visit__ds__extract_day',             -->
                         <!--   )                                                    -->
                         <!-- col20 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
                         <!--     column_alias='visit__ds__extract_dow',             -->
                         <!--   )                                                    -->
                         <!-- col21 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
                         <!--     column_alias='visit__ds__extract_doy',             -->
                         <!--   )                                                    -->
                         <!-- col22 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col23 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
                         <!--     column_alias='metric_time__week',                  -->
                         <!--   )                                                    -->
                         <!-- col24 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
                         <!--     column_alias='metric_time__month',                 -->
                         <!--   )                                                    -->
                         <!-- col25 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
                         <!--     column_alias='metric_time__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col26 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
                         <!--     column_alias='metric_time__year',                  -->
                         <!--   )                                                    -->
                         <!-- col27 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
                         <!--     column_alias='metric_time__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col28 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
                         <!--     column_alias='metric_time__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col29 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
                         <!--     column_alias='metric_time__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col30 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
                         <!--     column_alias='metric_time__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col31 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
                         <!--     column_alias='metric_time__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col32 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
                         <!--     column_alias='metric_time__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col33 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_565), column_alias='user') -->
                         <!-- col34 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_567), column_alias='session') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='session') -->
                         <!-- col35 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
                         <!--     column_alias='visit__user',                        -->
                         <!--   )                                                    -->
                         <!-- col36 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
                         <!--     column_alias='visit__session',                     -->
                         <!--   )                                                    -->
                         <!-- col37 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
                         <!--     column_alias='referrer_id',                        -->
                         <!--   )                                                    -->
                         <!-- col38 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col39 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visits') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='visits') -->
                         <!-- col40 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_530), column_alias='visitors') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visitors') -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
@@ -447,12 +447,12 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_20') -->
+                <!-- node_id = NodeId(id_str='ss_19') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_747), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_746), column_alias='metric_time__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_746), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_745), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- col2 =                                                                    -->
@@ -460,60 +460,60 @@
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
                 <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_747), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_746), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_746), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_745), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_19') -->
+                    <!-- node_id = NodeId(id_str='ss_18') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_744), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_743), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_743), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_742), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
-                    <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_742), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                    <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_741), column_alias='buys') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_18') -->
+                        <!-- node_id = NodeId(id_str='ss_17') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_739), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_738), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_740), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_739), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_741), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_740), column_alias='user') -->
                         <!-- col3 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_738), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_737), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col4 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_736), column_alias='buys') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_735), column_alias='buys') -->
                         <!-- col5 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_737), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_736), column_alias='visits') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_17') -->
+                            <!-- node_id = NodeId(id_str='ss_16') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -541,15 +541,15 @@
                             <!--   )                                                                             -->
                             <!-- col5 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_734), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_733), -->
                             <!--     column_alias='mf_internal_uuid',                   -->
                             <!--   )                                                    -->
                             <!-- col6 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_735), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_734), column_alias='buys') -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                             <!-- join_0 =                                                -->
                             <!--   SqlJoinDescription(                                   -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_16), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
                             <!--     right_source_alias='subq_9',                        -->
                             <!--     join_type=INNER,                                    -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
@@ -560,241 +560,241 @@
                                 <!-- description =                                                         -->
                                 <!--   ("Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', " -->
                                 <!--    "'metric_time__day', 'user']")                                     -->
-                                <!-- node_id = NodeId(id_str='ss_14') -->
+                                <!-- node_id = NodeId(id_str='ss_13') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
                                 <!--     column_alias='visit__referrer_id',                 -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
                                 <!--     column_alias='visits',                             -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_13') -->
+                                    <!-- node_id = NodeId(id_str='ss_12') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
                                     <!--     column_alias='visit__ds__day',                     -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
                                     <!--     column_alias='visit__ds__week',                    -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
                                     <!--     column_alias='visit__ds__month',                   -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
                                     <!--     column_alias='visit__ds__quarter',                 -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
                                     <!--     column_alias='visit__ds__year',                    -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
                                     <!--     column_alias='visit__ds__extract_year',            -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
                                     <!--     column_alias='visit__ds__extract_quarter',         -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
                                     <!--     column_alias='visit__ds__extract_month',           -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
                                     <!--     column_alias='visit__ds__extract_day',             -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
                                     <!--     column_alias='visit__ds__extract_dow',             -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
                                     <!--     column_alias='visit__ds__extract_doy',             -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
                                     <!--     column_alias='session',                            -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
                                     <!--     column_alias='visit__user',                        -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
                                     <!--     column_alias='visit__session',                     -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
                                     <!--     column_alias='referrer_id',                        -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
                                     <!--     column_alias='visit__referrer_id',                 -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
                                     <!--     column_alias='visits',                             -->
                                     <!--   )                                                    -->
                                     <!-- col40 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
                                     <!--     column_alias='visitors',                           -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
@@ -966,200 +966,200 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_16') -->
+                                <!-- node_id = NodeId(id_str='ss_15') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
                                 <!--     column_alias='ds__week',                           -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
                                 <!--     column_alias='ds__month',                          -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
                                 <!--     column_alias='ds__quarter',                        -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
                                 <!--     column_alias='ds__year',                           -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
                                 <!--     column_alias='ds__extract_year',                   -->
                                 <!--   )                                                    -->
                                 <!-- col6 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
                                 <!--     column_alias='ds__extract_quarter',                -->
                                 <!--   )                                                    -->
                                 <!-- col7 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
                                 <!--     column_alias='ds__extract_month',                  -->
                                 <!--   )                                                    -->
                                 <!-- col8 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
                                 <!--     column_alias='ds__extract_day',                    -->
                                 <!--   )                                                    -->
                                 <!-- col9 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
                                 <!--     column_alias='ds__extract_dow',                    -->
                                 <!--   )                                                    -->
                                 <!-- col10 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
                                 <!--     column_alias='ds__extract_doy',                    -->
                                 <!--   )                                                    -->
                                 <!-- col11 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
                                 <!--     column_alias='buy__ds__day',                       -->
                                 <!--   )                                                    -->
                                 <!-- col12 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
                                 <!--     column_alias='buy__ds__week',                      -->
                                 <!--   )                                                    -->
                                 <!-- col13 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
                                 <!--     column_alias='buy__ds__month',                     -->
                                 <!--   )                                                    -->
                                 <!-- col14 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
                                 <!--     column_alias='buy__ds__quarter',                   -->
                                 <!--   )                                                    -->
                                 <!-- col15 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
                                 <!--     column_alias='buy__ds__year',                      -->
                                 <!--   )                                                    -->
                                 <!-- col16 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
                                 <!--     column_alias='buy__ds__extract_year',              -->
                                 <!--   )                                                    -->
                                 <!-- col17 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
                                 <!--     column_alias='buy__ds__extract_quarter',           -->
                                 <!--   )                                                    -->
                                 <!-- col18 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
                                 <!--     column_alias='buy__ds__extract_month',             -->
                                 <!--   )                                                    -->
                                 <!-- col19 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
                                 <!--     column_alias='buy__ds__extract_day',               -->
                                 <!--   )                                                    -->
                                 <!-- col20 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
                                 <!--     column_alias='buy__ds__extract_dow',               -->
                                 <!--   )                                                    -->
                                 <!-- col21 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
                                 <!--     column_alias='buy__ds__extract_doy',               -->
                                 <!--   )                                                    -->
                                 <!-- col22 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col23 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
                                 <!--     column_alias='metric_time__week',                  -->
                                 <!--   )                                                    -->
                                 <!-- col24 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
                                 <!--     column_alias='metric_time__month',                 -->
                                 <!--   )                                                    -->
                                 <!-- col25 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
                                 <!--     column_alias='metric_time__quarter',               -->
                                 <!--   )                                                    -->
                                 <!-- col26 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
                                 <!--     column_alias='metric_time__year',                  -->
                                 <!--   )                                                    -->
                                 <!-- col27 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
                                 <!--     column_alias='metric_time__extract_year',          -->
                                 <!--   )                                                    -->
                                 <!-- col28 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
                                 <!--     column_alias='metric_time__extract_quarter',       -->
                                 <!--   )                                                    -->
                                 <!-- col29 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
                                 <!--     column_alias='metric_time__extract_month',         -->
                                 <!--   )                                                    -->
                                 <!-- col30 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
                                 <!--     column_alias='metric_time__extract_day',           -->
                                 <!--   )                                                    -->
                                 <!-- col31 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
                                 <!--     column_alias='metric_time__extract_dow',           -->
                                 <!--   )                                                    -->
                                 <!-- col32 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
                                 <!--     column_alias='metric_time__extract_doy',           -->
                                 <!--   )                                                    -->
                                 <!-- col33 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col34 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
                                 <!--     column_alias='session_id',                         -->
                                 <!--   )                                                    -->
                                 <!-- col35 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_698), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
                                 <!--     column_alias='buy__user',                          -->
                                 <!--   )                                                    -->
                                 <!-- col36 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_699), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_698), -->
                                 <!--     column_alias='buy__session_id',                    -->
                                 <!--   )                                                    -->
                                 <!-- col37 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
                                 <!-- col38 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
                                 <!--     column_alias='buyers',                             -->
                                 <!--   )                                                    -->
                                 <!-- col39 =                                             -->
@@ -1167,205 +1167,205 @@
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_15') -->
+                                    <!-- node_id = NodeId(id_str='ss_14') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
                                     <!--     column_alias='buy__ds__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
                                     <!--     column_alias='buy__ds__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
                                     <!--     column_alias='buy__ds__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
                                     <!--     column_alias='buy__ds__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
                                     <!--     column_alias='buy__ds__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
                                     <!--     column_alias='buy__ds__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
                                     <!--     column_alias='buy__ds__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
                                     <!--     column_alias='buy__ds__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
                                     <!--     column_alias='buy__ds__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
                                     <!--     column_alias='buy__ds__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
                                     <!--     column_alias='buy__ds__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
                                     <!--     column_alias='session_id',                         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
                                     <!--     column_alias='buy__user',                          -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
                                     <!--     column_alias='buy__session_id',                    -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
                                     <!--     column_alias='buys',                               -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
                                     <!--     column_alias='buyers',                             -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->

--- a/metricflow/test/snapshots/test_cyclic_join.py/DataflowPlan/test_cyclic_join__dfp_0.xml
+++ b/metricflow/test/snapshots/test_cyclic_join.py/DataflowPlan/test_cyclic_join__dfp_0.xml
@@ -36,11 +36,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_0') -->
+                                <!-- node_id = NodeId(id_str='sma_12001') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                    <!-- node_id = NodeId(id_str='rss_0') -->
+                                    <!-- node_id = NodeId(id_str='rss_12003') -->
                                     <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
@@ -53,7 +53,7 @@
                             <!-- distinct = False -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('listings_latest_cyclic')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_12004') -->
                                 <!-- data_set = SemanticModelDataSet('listings_latest_cyclic') -->
                             </ReadSqlSourceNode>
                         </FilterElementsNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_common_semantic_model__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_common_semantic_model__dfp_0.xml
@@ -42,11 +42,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -59,11 +59,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_5') -->
+                                    <!-- node_id = NodeId(id_str='sma_28006') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                        <!-- node_id = NodeId(id_str='rss_5') -->
+                                        <!-- node_id = NodeId(id_str='rss_28018') -->
                                         <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -110,11 +110,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -127,11 +127,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_5') -->
+                                    <!-- node_id = NodeId(id_str='sma_28006') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                        <!-- node_id = NodeId(id_str='rss_5') -->
+                                        <!-- node_id = NodeId(id_str='rss_28018') -->
                                         <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_no_window_or_grain_with_metric_time__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_no_window_or_grain_with_metric_time__dfp_0.xml
@@ -20,11 +20,11 @@
                         <!-- node_id = NodeId(id_str='jotr_0') -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_6') -->
+                            <!-- node_id = NodeId(id_str='sma_28007') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('revenue')" -->
-                                <!-- node_id = NodeId(id_str='rss_7') -->
+                                <!-- node_id = NodeId(id_str='rss_28020') -->
                                 <!-- data_set = SemanticModelDataSet('revenue') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_no_window_or_grain_without_metric_time__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_no_window_or_grain_without_metric_time__dfp_0.xml
@@ -16,11 +16,11 @@
                     <!-- distinct = False -->
                     <MetricTimeDimensionTransformNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='sma_6') -->
+                        <!-- node_id = NodeId(id_str='sma_28007') -->
                         <!-- aggregation_time_dimension = 'ds' -->
                         <ReadSqlSourceNode>
                             <!-- description = "Read From SemanticModelDataSet('revenue')" -->
-                            <!-- node_id = NodeId(id_str='rss_7') -->
+                            <!-- node_id = NodeId(id_str='rss_28020') -->
                             <!-- data_set = SemanticModelDataSet('revenue') -->
                         </ReadSqlSourceNode>
                     </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_window__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_window__dfp_0.xml
@@ -20,11 +20,11 @@
                         <!-- node_id = NodeId(id_str='jotr_0') -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_6') -->
+                            <!-- node_id = NodeId(id_str='sma_28007') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('revenue')" -->
-                                <!-- node_id = NodeId(id_str='rss_7') -->
+                                <!-- node_id = NodeId(id_str='rss_28020') -->
                                 <!-- data_set = SemanticModelDataSet('revenue') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
@@ -24,11 +24,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
@@ -61,11 +61,11 @@
                                 <!-- join_type = INNER -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -36,11 +36,11 @@
                             <!-- join_type = INNER -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
@@ -36,11 +36,11 @@
                             <!-- join_type = INNER -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -39,11 +39,11 @@
                                 <!-- node_id = NodeId(id_str='jotr_0') -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dimensions_with_time_constraint__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dimensions_with_time_constraint__dfp_0.xml
@@ -21,7 +21,7 @@
                     <!--   JoinDescription(join_node=FilterElementsNode(node_id=pfe_1), join_type=CROSS_JOIN) -->
                     <ReadSqlSourceNode>
                         <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                        <!-- node_id = NodeId(id_str='rss_28005') -->
+                        <!-- node_id = NodeId(id_str='rss_28018') -->
                         <!-- data_set = SemanticModelDataSet('listings_latest') -->
                     </ReadSqlSourceNode>
                     <FilterElementsNode>
@@ -31,11 +31,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_9') -->
+                            <!-- node_id = NodeId(id_str='sma_28000') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = 'Read From SqlDataSet()' -->
-                                <!-- node_id = NodeId(id_str='rss_12') -->
+                                <!-- node_id = NodeId(id_str='rss_28012') -->
                                 <!-- data_set = SqlDataSet() -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -45,7 +45,7 @@
                     <!--   )                                             -->
                     <ReadSqlSourceNode>
                         <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                        <!-- node_id = NodeId(id_str='rss_28005') -->
+                        <!-- node_id = NodeId(id_str='rss_28018') -->
                         <!-- data_set = SemanticModelDataSet('listings_latest') -->
                     </ReadSqlSourceNode>
                 </WhereConstraintNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
@@ -59,7 +59,7 @@
                         <!--   )                                                         -->
                         <ReadSqlSourceNode>
                             <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                            <!-- node_id = NodeId(id_str='rss_28005') -->
+                            <!-- node_id = NodeId(id_str='rss_28018') -->
                             <!-- data_set = SemanticModelDataSet('listings_latest') -->
                         </ReadSqlSourceNode>
                         <FilterElementsNode>
@@ -70,7 +70,7 @@
                             <!-- distinct = False -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('users_latest')" -->
-                                <!-- node_id = NodeId(id_str='rss_28009') -->
+                                <!-- node_id = NodeId(id_str='rss_28022') -->
                                 <!-- data_set = SemanticModelDataSet('users_latest') -->
                             </ReadSqlSourceNode>
                         </FilterElementsNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dont_join_to_time_spine_if_no_time_dimension_requested__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dont_join_to_time_spine_if_no_time_dimension_requested__dfp_0.xml
@@ -16,11 +16,11 @@
                     <!-- distinct = False -->
                     <MetricTimeDimensionTransformNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='sma_1') -->
+                        <!-- node_id = NodeId(id_str='sma_28002') -->
                         <!-- aggregation_time_dimension = 'ds' -->
                         <ReadSqlSourceNode>
                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                            <!-- node_id = NodeId(id_str='rss_1') -->
+                            <!-- node_id = NodeId(id_str='rss_28014') -->
                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                         </ReadSqlSourceNode>
                     </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -34,11 +34,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -86,11 +86,11 @@
                                     <!-- join_type = INNER -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
+                                        <!-- node_id = NodeId(id_str='sma_28002') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
+                                            <!-- node_id = NodeId(id_str='rss_28014') -->
                                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
@@ -27,11 +27,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28002') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28014') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_non_metric_time__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_non_metric_time__dfp_0.xml
@@ -22,11 +22,11 @@
                     <!-- distinct = False -->
                     <MetricTimeDimensionTransformNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='sma_1') -->
+                        <!-- node_id = NodeId(id_str='sma_28002') -->
                         <!-- aggregation_time_dimension = 'ds' -->
                         <ReadSqlSourceNode>
                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                            <!-- node_id = NodeId(id_str='rss_1') -->
+                            <!-- node_id = NodeId(id_str='rss_28014') -->
                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                         </ReadSqlSourceNode>
                     </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_joined_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_joined_plan__dfp_0.xml
@@ -47,11 +47,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
@@ -64,11 +64,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_5') -->
+                                <!-- node_id = NodeId(id_str='sma_28006') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                    <!-- node_id = NodeId(id_str='rss_5') -->
+                                    <!-- node_id = NodeId(id_str='rss_28018') -->
                                     <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_limit_rows_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_limit_rows_plan__dfp_0.xml
@@ -21,11 +21,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28002') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28014') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -98,12 +98,12 @@
                                             <!-- distinct = False -->
                                             <MetricTimeDimensionTransformNode>
                                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                                 <!-- aggregation_time_dimension = 'ds' -->
                                                 <ReadSqlSourceNode>
                                                     <!-- description =                                         -->
                                                     <!--   "Read From SemanticModelDataSet('bookings_source')" -->
-                                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                                 </ReadSqlSourceNode>
                                             </MetricTimeDimensionTransformNode>
@@ -116,12 +116,12 @@
                                             <!-- distinct = False -->
                                             <MetricTimeDimensionTransformNode>
                                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                                <!-- node_id = NodeId(id_str='sma_5') -->
+                                                <!-- node_id = NodeId(id_str='sma_28006') -->
                                                 <!-- aggregation_time_dimension = 'ds' -->
                                                 <ReadSqlSourceNode>
                                                     <!-- description =                                         -->
                                                     <!--   "Read From SemanticModelDataSet('listings_latest')" -->
-                                                    <!-- node_id = NodeId(id_str='rss_5') -->
+                                                    <!-- node_id = NodeId(id_str='rss_28018') -->
                                                     <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                                 </ReadSqlSourceNode>
                                             </MetricTimeDimensionTransformNode>
@@ -220,12 +220,12 @@
                                             <!-- distinct = False -->
                                             <MetricTimeDimensionTransformNode>
                                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                                 <!-- aggregation_time_dimension = 'ds' -->
                                                 <ReadSqlSourceNode>
                                                     <!-- description =                                         -->
                                                     <!--   "Read From SemanticModelDataSet('bookings_source')" -->
-                                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                                 </ReadSqlSourceNode>
                                             </MetricTimeDimensionTransformNode>
@@ -238,12 +238,12 @@
                                             <!-- distinct = False -->
                                             <MetricTimeDimensionTransformNode>
                                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                                <!-- node_id = NodeId(id_str='sma_5') -->
+                                                <!-- node_id = NodeId(id_str='sma_28006') -->
                                                 <!-- aggregation_time_dimension = 'ds' -->
                                                 <ReadSqlSourceNode>
                                                     <!-- description =                                         -->
                                                     <!--   "Read From SemanticModelDataSet('listings_latest')" -->
-                                                    <!-- node_id = NodeId(id_str='rss_5') -->
+                                                    <!-- node_id = NodeId(id_str='rss_28018') -->
                                                     <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                                 </ReadSqlSourceNode>
                                             </MetricTimeDimensionTransformNode>
@@ -269,11 +269,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -80,11 +80,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
+                                        <!-- node_id = NodeId(id_str='sma_28002') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
+                                            <!-- node_id = NodeId(id_str='rss_28014') -->
                                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
@@ -108,11 +108,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_only__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_only__dfp_0.xml
@@ -9,11 +9,11 @@
             <!-- distinct = True -->
             <MetricTimeDimensionTransformNode>
                 <!-- description = "Metric Time Dimension 'ds'" -->
-                <!-- node_id = NodeId(id_str='sma_9') -->
+                <!-- node_id = NodeId(id_str='sma_28000') -->
                 <!-- aggregation_time_dimension = 'ds' -->
                 <ReadSqlSourceNode>
                     <!-- description = 'Read From SqlDataSet()' -->
-                    <!-- node_id = NodeId(id_str='rss_12') -->
+                    <!-- node_id = NodeId(id_str='rss_28012') -->
                     <!-- data_set = SqlDataSet() -->
                 </ReadSqlSourceNode>
             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_quarter__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_quarter__dfp_0.xml
@@ -9,11 +9,11 @@
             <!-- distinct = True -->
             <MetricTimeDimensionTransformNode>
                 <!-- description = "Metric Time Dimension 'ds'" -->
-                <!-- node_id = NodeId(id_str='sma_9') -->
+                <!-- node_id = NodeId(id_str='sma_28000') -->
                 <!-- aggregation_time_dimension = 'ds' -->
                 <ReadSqlSourceNode>
                     <!-- description = 'Read From SqlDataSet()' -->
-                    <!-- node_id = NodeId(id_str='rss_12') -->
+                    <!-- node_id = NodeId(id_str='rss_28012') -->
                     <!-- data_set = SqlDataSet() -->
                 </ReadSqlSourceNode>
             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_with_other_dimensions__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_with_other_dimensions__dfp_0.xml
@@ -27,7 +27,7 @@
                 <!--   )                                                         -->
                 <ReadSqlSourceNode>
                     <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                    <!-- node_id = NodeId(id_str='rss_28005') -->
+                    <!-- node_id = NodeId(id_str='rss_28018') -->
                     <!-- data_set = SemanticModelDataSet('listings_latest') -->
                 </ReadSqlSourceNode>
                 <FilterElementsNode>
@@ -38,11 +38,11 @@
                     <!-- distinct = False -->
                     <MetricTimeDimensionTransformNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='sma_9') -->
+                        <!-- node_id = NodeId(id_str='sma_28000') -->
                         <!-- aggregation_time_dimension = 'ds' -->
                         <ReadSqlSourceNode>
                             <!-- description = 'Read From SqlDataSet()' -->
-                            <!-- node_id = NodeId(id_str='rss_12') -->
+                            <!-- node_id = NodeId(id_str='rss_28012') -->
                             <!-- data_set = SqlDataSet() -->
                         </ReadSqlSourceNode>
                     </MetricTimeDimensionTransformNode>
@@ -55,7 +55,7 @@
                     <!-- distinct = False -->
                     <ReadSqlSourceNode>
                         <!-- description = "Read From SemanticModelDataSet('users_latest')" -->
-                        <!-- node_id = NodeId(id_str='rss_28009') -->
+                        <!-- node_id = NodeId(id_str='rss_28022') -->
                         <!-- data_set = SemanticModelDataSet('users_latest') -->
                     </ReadSqlSourceNode>
                 </FilterElementsNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_categorical__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_categorical__dfp_0.xml
@@ -16,7 +16,7 @@
                 <!-- distinct = True -->
                 <ReadSqlSourceNode>
                     <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                    <!-- node_id = NodeId(id_str='rss_28005') -->
+                    <!-- node_id = NodeId(id_str='rss_28018') -->
                     <!-- data_set = SemanticModelDataSet('listings_latest') -->
                 </ReadSqlSourceNode>
             </FilterElementsNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time__dfp_0.xml
@@ -17,7 +17,7 @@
                 <!-- distinct = True -->
                 <ReadSqlSourceNode>
                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                    <!-- node_id = NodeId(id_str='rss_28001') -->
+                    <!-- node_id = NodeId(id_str='rss_28014') -->
                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                 </ReadSqlSourceNode>
             </FilterElementsNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time_year__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time_year__dfp_0.xml
@@ -17,7 +17,7 @@
                 <!-- distinct = True -->
                 <ReadSqlSourceNode>
                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                    <!-- node_id = NodeId(id_str='rss_28001') -->
+                    <!-- node_id = NodeId(id_str='rss_28014') -->
                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                 </ReadSqlSourceNode>
             </FilterElementsNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_semantic_model_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_semantic_model_ratio_metrics_plan__dfp_0.xml
@@ -47,11 +47,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
+                                        <!-- node_id = NodeId(id_str='sma_28002') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
+                                            <!-- node_id = NodeId(id_str='rss_28014') -->
                                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
@@ -64,11 +64,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_5') -->
+                                        <!-- node_id = NodeId(id_str='sma_28006') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                            <!-- node_id = NodeId(id_str='rss_5') -->
+                                            <!-- node_id = NodeId(id_str='rss_28018') -->
                                             <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
@@ -115,11 +115,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_7') -->
+                                        <!-- node_id = NodeId(id_str='sma_28008') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('views_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_10') -->
+                                            <!-- node_id = NodeId(id_str='rss_28023') -->
                                             <!-- data_set = SemanticModelDataSet('views_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
@@ -132,11 +132,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_5') -->
+                                        <!-- node_id = NodeId(id_str='sma_28006') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                            <!-- node_id = NodeId(id_str='rss_5') -->
+                                            <!-- node_id = NodeId(id_str='rss_28018') -->
                                             <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
@@ -52,11 +52,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_0') -->
+                                <!-- node_id = NodeId(id_str='sma_22001') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('account_month_txns')" -->
-                                    <!-- node_id = NodeId(id_str='rss_0') -->
+                                    <!-- node_id = NodeId(id_str='rss_22006') -->
                                     <!-- data_set = SemanticModelDataSet('account_month_txns') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
@@ -97,7 +97,7 @@
                                 <!--   )                                                                -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bridge_table')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_22007') -->
                                     <!-- data_set = SemanticModelDataSet('bridge_table') -->
                                 </ReadSqlSourceNode>
                                 <FilterElementsNode>
@@ -266,7 +266,7 @@
                                     <!-- distinct = False -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('customer_table')" -->
-                                        <!-- node_id = NodeId(id_str='rss_3') -->
+                                        <!-- node_id = NodeId(id_str='rss_22009') -->
                                         <!-- data_set = SemanticModelDataSet('customer_table') -->
                                     </ReadSqlSourceNode>
                                 </FilterElementsNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multiple_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multiple_metrics_plan__dfp_0.xml
@@ -25,11 +25,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28002') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28014') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -57,11 +57,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28002') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28014') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -53,11 +53,11 @@
                                     <!-- join_type = INNER -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
+                                        <!-- node_id = NodeId(id_str='sma_28002') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
+                                            <!-- node_id = NodeId(id_str='rss_28014') -->
                                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
@@ -27,11 +27,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28002') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28014') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_primary_entity_dimension__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_primary_entity_dimension__dfp_0.xml
@@ -21,11 +21,11 @@
                     <!-- distinct = False -->
                     <MetricTimeDimensionTransformNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='sma_1') -->
+                        <!-- node_id = NodeId(id_str='sma_28002') -->
                         <!-- aggregation_time_dimension = 'ds' -->
                         <ReadSqlSourceNode>
                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                            <!-- node_id = NodeId(id_str='rss_1') -->
+                            <!-- node_id = NodeId(id_str='rss_28014') -->
                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                         </ReadSqlSourceNode>
                     </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_simple_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_simple_plan__dfp_0.xml
@@ -21,11 +21,11 @@
                     <!-- distinct = False -->
                     <MetricTimeDimensionTransformNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='sma_1') -->
+                        <!-- node_id = NodeId(id_str='sma_28002') -->
                         <!-- aggregation_time_dimension = 'ds' -->
                         <ReadSqlSourceNode>
                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                            <!-- node_id = NodeId(id_str='rss_1') -->
+                            <!-- node_id = NodeId(id_str='rss_28014') -->
                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                         </ReadSqlSourceNode>
                     </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_semantic_model_ratio_metrics_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_semantic_model_ratio_metrics_plan__dfp_0.xml
@@ -47,11 +47,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
+                                        <!-- node_id = NodeId(id_str='sma_28002') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
+                                            <!-- node_id = NodeId(id_str='rss_28014') -->
                                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
@@ -64,11 +64,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_5') -->
+                                        <!-- node_id = NodeId(id_str='sma_28006') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                            <!-- node_id = NodeId(id_str='rss_5') -->
+                                            <!-- node_id = NodeId(id_str='rss_28018') -->
                                             <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
@@ -115,11 +115,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
+                                        <!-- node_id = NodeId(id_str='sma_28002') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
+                                            <!-- node_id = NodeId(id_str='rss_28014') -->
                                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
@@ -132,11 +132,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_5') -->
+                                        <!-- node_id = NodeId(id_str='sma_28006') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                            <!-- node_id = NodeId(id_str='rss_5') -->
+                                            <!-- node_id = NodeId(id_str='rss_28018') -->
                                             <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -99,11 +99,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
+                                        <!-- node_id = NodeId(id_str='sma_28002') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
+                                            <!-- node_id = NodeId(id_str='rss_28014') -->
                                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
@@ -116,11 +116,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_5') -->
+                                        <!-- node_id = NodeId(id_str='sma_28006') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                            <!-- node_id = NodeId(id_str='rss_5') -->
+                                            <!-- node_id = NodeId(id_str='rss_28018') -->
                                             <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -66,11 +66,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -77,11 +77,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -94,11 +94,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_5') -->
+                                    <!-- node_id = NodeId(id_str='sma_28006') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                        <!-- node_id = NodeId(id_str='rss_5') -->
+                                        <!-- node_id = NodeId(id_str='rss_28018') -->
                                         <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
@@ -1,17 +1,17 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_27') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_872), column_alias='ds__day') -->
+        <!-- node_id = NodeId(id_str='ss_26') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_871), column_alias='ds__day') -->
         <!-- col1 =                                                                                                       -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_871), column_alias='listing__country_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_870), column_alias='listing__country_latest') -->
         <!-- col2 = SqlSelectColumn(expr=SqlRatioComputationExpression(node_id=rc_0), column_alias='bookings_per_view') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_26) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_26') -->
+            <!-- node_id = NodeId(id_str='ss_25') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -32,10 +32,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='views',                                                 -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_25), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_24), -->
             <!--     right_source_alias='subq_19',                       -->
             <!--     join_type=FULL_OUTER,                               -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_0),    -->
@@ -54,25 +54,25 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='ss_17') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_712), column_alias='ds__day') -->
+                <!-- node_id = NodeId(id_str='ss_16') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_711), column_alias='ds__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_711), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_710), -->
                 <!--     column_alias='listing__country_latest',            -->
                 <!--   )                                                    -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_713), column_alias='bookings') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_712), column_alias='bookings') -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_16') -->
+                    <!-- node_id = NodeId(id_str='ss_15') -->
                     <!-- col0 =                                                                                       -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_710), column_alias='ds__day') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_709), column_alias='ds__day') -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_709), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_708), -->
                     <!--     column_alias='listing__country_latest',            -->
                     <!--   )                                                    -->
                     <!-- col2 =                                                                    -->
@@ -80,58 +80,58 @@
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                     <!--     column_alias='bookings',                                              -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                     <!-- group_by0 =                                                                                  -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_710), column_alias='ds__day') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_709), column_alias='ds__day') -->
                     <!-- group_by1 =                                            -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_709), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_708), -->
                     <!--     column_alias='listing__country_latest',            -->
                     <!--   )                                                    -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_15') -->
+                        <!-- node_id = NodeId(id_str='ss_14') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_707), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_706), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_706), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_705), -->
                         <!--     column_alias='listing__country_latest',            -->
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_705), column_alias='bookings') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_704), column_alias='bookings') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Join Standard Outputs' -->
-                            <!-- node_id = NodeId(id_str='ss_14') -->
+                            <!-- node_id = NodeId(id_str='ss_13') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_702), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_701), -->
                             <!--     column_alias='ds__day',                            -->
                             <!--   )                                                    -->
                             <!-- col1 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_703), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_702), -->
                             <!--     column_alias='listing',                            -->
                             <!--   )                                                    -->
                             <!-- col2 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_704), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_703), -->
                             <!--     column_alias='listing__country_latest',            -->
                             <!--   )                                                    -->
                             <!-- col3 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_701), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_700), -->
                             <!--     column_alias='bookings',                           -->
                             <!--   )                                                    -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_13),  -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_12),  -->
                             <!--     right_source_alias='subq_5',                         -->
                             <!--     join_type=LEFT_OUTER,                                -->
                             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -140,516 +140,516 @@
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['bookings', 'ds__day', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_11') -->
+                                <!-- node_id = NodeId(id_str='ss_10') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
                                 <!--     column_alias='listing',                            -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
                                 <!--     column_alias='bookings',                           -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_10') -->
+                                    <!-- node_id = NodeId(id_str='ss_9') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
                                     <!--     column_alias='ds_partitioned__day',                -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
                                     <!--     column_alias='ds_partitioned__week',               -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
                                     <!--     column_alias='ds_partitioned__month',              -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
                                     <!--     column_alias='ds_partitioned__quarter',            -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
                                     <!--     column_alias='ds_partitioned__year',               -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
                                     <!--     column_alias='ds_partitioned__extract_year',       -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
                                     <!--     column_alias='ds_partitioned__extract_quarter',    -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
                                     <!--     column_alias='ds_partitioned__extract_month',      -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
                                     <!--     column_alias='ds_partitioned__extract_day',        -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
                                     <!--     column_alias='ds_partitioned__extract_dow',        -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
                                     <!--     column_alias='ds_partitioned__extract_doy',        -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_566), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
                                     <!--     column_alias='paid_at__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_566), -->
                                     <!--     column_alias='paid_at__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
                                     <!--     column_alias='paid_at__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
                                     <!--     column_alias='paid_at__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
                                     <!--     column_alias='paid_at__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
                                     <!--     column_alias='paid_at__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
                                     <!--     column_alias='paid_at__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
                                     <!--     column_alias='paid_at__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
                                     <!--     column_alias='paid_at__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
                                     <!--     column_alias='paid_at__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
                                     <!--     column_alias='paid_at__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
                                     <!--     column_alias='booking__ds__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
                                     <!--     column_alias='booking__ds__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
                                     <!--     column_alias='booking__ds__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
                                     <!--     column_alias='booking__ds__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
                                     <!--     column_alias='booking__ds__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
                                     <!--     column_alias='booking__ds__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
                                     <!--     column_alias='booking__ds__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col40 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
                                     <!--     column_alias='booking__ds__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col41 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
                                     <!--     column_alias='booking__ds__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col42 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
                                     <!--     column_alias='booking__ds__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col43 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
                                     <!--     column_alias='booking__ds__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col44 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
                                     <!--     column_alias='booking__ds_partitioned__day',       -->
                                     <!--   )                                                    -->
                                     <!-- col45 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
                                     <!--     column_alias='booking__ds_partitioned__week',      -->
                                     <!--   )                                                    -->
                                     <!-- col46 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
                                     <!--     column_alias='booking__ds_partitioned__month',     -->
                                     <!--   )                                                    -->
                                     <!-- col47 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
                                     <!--     column_alias='booking__ds_partitioned__quarter',   -->
                                     <!--   )                                                    -->
                                     <!-- col48 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
                                     <!--     column_alias='booking__ds_partitioned__year',      -->
                                     <!--   )                                                    -->
                                     <!-- col49 =                                                   -->
                                     <!--   SqlSelectColumn(                                        -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593),    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592),    -->
                                     <!--     column_alias='booking__ds_partitioned__extract_year', -->
                                     <!--   )                                                       -->
                                     <!-- col50 =                                                      -->
                                     <!--   SqlSelectColumn(                                           -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594),       -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593),       -->
                                     <!--     column_alias='booking__ds_partitioned__extract_quarter', -->
                                     <!--   )                                                          -->
                                     <!-- col51 =                                                    -->
                                     <!--   SqlSelectColumn(                                         -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595),     -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594),     -->
                                     <!--     column_alias='booking__ds_partitioned__extract_month', -->
                                     <!--   )                                                        -->
                                     <!-- col52 =                                                  -->
                                     <!--   SqlSelectColumn(                                       -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596),   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595),   -->
                                     <!--     column_alias='booking__ds_partitioned__extract_day', -->
                                     <!--   )                                                      -->
                                     <!-- col53 =                                                  -->
                                     <!--   SqlSelectColumn(                                       -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597),   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596),   -->
                                     <!--     column_alias='booking__ds_partitioned__extract_dow', -->
                                     <!--   )                                                      -->
                                     <!-- col54 =                                                  -->
                                     <!--   SqlSelectColumn(                                       -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598),   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597),   -->
                                     <!--     column_alias='booking__ds_partitioned__extract_doy', -->
                                     <!--   )                                                      -->
                                     <!-- col55 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
                                     <!--     column_alias='booking__paid_at__day',              -->
                                     <!--   )                                                    -->
                                     <!-- col56 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
                                     <!--     column_alias='booking__paid_at__week',             -->
                                     <!--   )                                                    -->
                                     <!-- col57 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
                                     <!--     column_alias='booking__paid_at__month',            -->
                                     <!--   )                                                    -->
                                     <!-- col58 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
                                     <!--     column_alias='booking__paid_at__quarter',          -->
                                     <!--   )                                                    -->
                                     <!-- col59 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
                                     <!--     column_alias='booking__paid_at__year',             -->
                                     <!--   )                                                    -->
                                     <!-- col60 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
                                     <!--     column_alias='booking__paid_at__extract_year',     -->
                                     <!--   )                                                    -->
                                     <!-- col61 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
                                     <!--     column_alias='booking__paid_at__extract_quarter',  -->
                                     <!--   )                                                    -->
                                     <!-- col62 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
                                     <!--     column_alias='booking__paid_at__extract_month',    -->
                                     <!--   )                                                    -->
                                     <!-- col63 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
                                     <!--     column_alias='booking__paid_at__extract_day',      -->
                                     <!--   )                                                    -->
                                     <!-- col64 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
                                     <!--     column_alias='booking__paid_at__extract_dow',      -->
                                     <!--   )                                                    -->
                                     <!-- col65 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
                                     <!--     column_alias='booking__paid_at__extract_doy',      -->
                                     <!--   )                                                    -->
                                     <!-- col66 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col67 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col68 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col69 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col70 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col71 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col72 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col73 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col74 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col75 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col76 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col77 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
                                     <!--     column_alias='listing',                            -->
                                     <!--   )                                                    -->
                                     <!-- col78 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
                                     <!--     column_alias='guest',                              -->
                                     <!--   )                                                    -->
                                     <!-- col79 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
                                     <!--     column_alias='host',                               -->
                                     <!--   )                                                    -->
                                     <!-- col80 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
                                     <!--     column_alias='booking__listing',                   -->
                                     <!--   )                                                    -->
                                     <!-- col81 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
                                     <!--     column_alias='booking__guest',                     -->
                                     <!--   )                                                    -->
                                     <!-- col82 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
                                     <!--     column_alias='booking__host',                      -->
                                     <!--   )                                                    -->
                                     <!-- col83 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
                                     <!--     column_alias='is_instant',                         -->
                                     <!--   )                                                    -->
                                     <!-- col84 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
                                     <!--     column_alias='booking__is_instant',                -->
                                     <!--   )                                                    -->
                                     <!-- col85 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_529), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_528), -->
                                     <!--     column_alias='bookings',                           -->
                                     <!--   )                                                    -->
                                     <!-- col86 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_529), -->
                                     <!--     column_alias='instant_bookings',                   -->
                                     <!--   )                                                    -->
                                     <!-- col87 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
                                     <!--     column_alias='booking_value',                      -->
                                     <!--   )                                                    -->
                                     <!-- col88 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
                                     <!--     column_alias='max_booking_value',                  -->
                                     <!--   )                                                    -->
                                     <!-- col89 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_533), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
                                     <!--     column_alias='min_booking_value',                  -->
                                     <!--   )                                                    -->
                                     <!-- col90 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_533), -->
                                     <!--     column_alias='bookers',                            -->
                                     <!--   )                                                    -->
                                     <!-- col91 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
                                     <!--     column_alias='average_booking_value',              -->
                                     <!--   )                                                    -->
                                     <!-- col92 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
                                     <!--     column_alias='referred_bookings',                  -->
                                     <!--   )                                                    -->
                                     <!-- col93 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
                                     <!--     column_alias='median_booking_value',               -->
                                     <!--   )                                                    -->
                                     <!-- col94 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
                                     <!--     column_alias='booking_value_p99',                  -->
                                     <!--   )                                                    -->
                                     <!-- col95 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
                                     <!--     column_alias='discrete_booking_value_p99',         -->
                                     <!--   )                                                    -->
                                     <!-- col96 =                                                      -->
                                     <!--   SqlSelectColumn(                                           -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_540),       -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_539),       -->
                                     <!--     column_alias='approximate_continuous_booking_value_p99', -->
                                     <!--   )                                                          -->
                                     <!-- col97 =                                                    -->
                                     <!--   SqlSelectColumn(                                         -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_541),     -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_540),     -->
                                     <!--     column_alias='approximate_discrete_booking_value_p99', -->
                                     <!--   )                                                        -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
@@ -1111,356 +1111,356 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_13') -->
+                                <!-- node_id = NodeId(id_str='ss_12') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_698), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
                                 <!--     column_alias='listing',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
                                 <!--     column_alias='country_latest',                     -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_12') -->
+                                    <!-- node_id = NodeId(id_str='ss_11') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
                                     <!--     column_alias='created_at__day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
                                     <!--     column_alias='created_at__week',                   -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
                                     <!--     column_alias='created_at__month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
                                     <!--     column_alias='created_at__quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
                                     <!--     column_alias='created_at__year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
                                     <!--     column_alias='created_at__extract_year',           -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
                                     <!--     column_alias='created_at__extract_quarter',        -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
                                     <!--     column_alias='created_at__extract_month',          -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
                                     <!--     column_alias='created_at__extract_day',            -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
                                     <!--     column_alias='created_at__extract_dow',            -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
                                     <!--     column_alias='created_at__extract_doy',            -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
                                     <!--     column_alias='listing__ds__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
                                     <!--     column_alias='listing__ds__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
                                     <!--     column_alias='listing__ds__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
                                     <!--     column_alias='listing__ds__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
                                     <!--     column_alias='listing__ds__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
                                     <!--     column_alias='listing__ds__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
                                     <!--     column_alias='listing__ds__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
                                     <!--     column_alias='listing__ds__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
                                     <!--     column_alias='listing__ds__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
                                     <!--     column_alias='listing__ds__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
                                     <!--     column_alias='listing__ds__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
                                     <!--     column_alias='listing__created_at__day',           -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
                                     <!--     column_alias='listing__created_at__week',          -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
                                     <!--     column_alias='listing__created_at__month',         -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
                                     <!--     column_alias='listing__created_at__quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
                                     <!--     column_alias='listing__created_at__year',          -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
                                     <!--     column_alias='listing__created_at__extract_year',  -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                  -->
                                     <!--   SqlSelectColumn(                                       -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_678),   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_677),   -->
                                     <!--     column_alias='listing__created_at__extract_quarter', -->
                                     <!--   )                                                      -->
                                     <!-- col40 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
                                     <!--     column_alias='listing__created_at__extract_month', -->
                                     <!--   )                                                    -->
                                     <!-- col41 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
                                     <!--     column_alias='listing__created_at__extract_day',   -->
                                     <!--   )                                                    -->
                                     <!-- col42 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
                                     <!--     column_alias='listing__created_at__extract_dow',   -->
                                     <!--   )                                                    -->
                                     <!-- col43 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
                                     <!--     column_alias='listing__created_at__extract_doy',   -->
                                     <!--   )                                                    -->
                                     <!-- col44 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col45 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col46 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col47 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col48 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col49 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col50 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col51 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col52 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col53 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col54 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col55 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
                                     <!--     column_alias='listing',                            -->
                                     <!--   )                                                    -->
                                     <!-- col56 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col57 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
                                     <!--     column_alias='listing__user',                      -->
                                     <!--   )                                                    -->
                                     <!-- col58 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
                                     <!--     column_alias='country_latest',                     -->
                                     <!--   )                                                    -->
                                     <!-- col59 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
                                     <!--     column_alias='is_lux_latest',                      -->
                                     <!--   )                                                    -->
                                     <!-- col60 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
                                     <!--     column_alias='capacity_latest',                    -->
                                     <!--   )                                                    -->
                                     <!-- col61 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
                                     <!--     column_alias='listing__country_latest',            -->
                                     <!--   )                                                    -->
                                     <!-- col62 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
                                     <!--     column_alias='listing__is_lux_latest',             -->
                                     <!--   )                                                    -->
                                     <!-- col63 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
                                     <!--     column_alias='listing__capacity_latest',           -->
                                     <!--   )                                                    -->
                                     <!-- col64 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
                                     <!--     column_alias='listings',                           -->
                                     <!--   )                                                    -->
                                     <!-- col65 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
                                     <!--     column_alias='largest_listing',                    -->
                                     <!--   )                                                    -->
                                     <!-- col66 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
                                     <!--     column_alias='smallest_listing',                   -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
@@ -1767,25 +1767,25 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='ss_25') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_859), column_alias='ds__day') -->
+                <!-- node_id = NodeId(id_str='ss_24') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_858), column_alias='ds__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_858), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_857), -->
                 <!--     column_alias='listing__country_latest',            -->
                 <!--   )                                                    -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_860), column_alias='views') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_24) -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_859), column_alias='views') -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_24') -->
+                    <!-- node_id = NodeId(id_str='ss_23') -->
                     <!-- col0 =                                                                                       -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_857), column_alias='ds__day') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_856), column_alias='ds__day') -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_856), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_855), -->
                     <!--     column_alias='listing__country_latest',            -->
                     <!--   )                                                    -->
                     <!-- col2 =                                                                    -->
@@ -1793,58 +1793,58 @@
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                     <!--     column_alias='views',                                                 -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
                     <!-- group_by0 =                                                                                  -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_857), column_alias='ds__day') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_856), column_alias='ds__day') -->
                     <!-- group_by1 =                                            -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_856), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_855), -->
                     <!--     column_alias='listing__country_latest',            -->
                     <!--   )                                                    -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['views', 'listing__country_latest', 'ds__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_23') -->
+                        <!-- node_id = NodeId(id_str='ss_22') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_854), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_853), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_853), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_852), -->
                         <!--     column_alias='listing__country_latest',            -->
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_852), column_alias='views') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_851), column_alias='views') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Join Standard Outputs' -->
-                            <!-- node_id = NodeId(id_str='ss_22') -->
+                            <!-- node_id = NodeId(id_str='ss_21') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_849), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_848), -->
                             <!--     column_alias='ds__day',                            -->
                             <!--   )                                                    -->
                             <!-- col1 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_850), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_849), -->
                             <!--     column_alias='listing',                            -->
                             <!--   )                                                    -->
                             <!-- col2 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_851), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_850), -->
                             <!--     column_alias='listing__country_latest',            -->
                             <!--   )                                                    -->
                             <!-- col3 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_848), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_847), -->
                             <!--     column_alias='views',                              -->
                             <!--   )                                                    -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_21),  -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_20),  -->
                             <!--     right_source_alias='subq_15',                        -->
                             <!--     join_type=LEFT_OUTER,                                -->
                             <!--     on_condition=SqlComparisonExpression(node_id=cmp_1), -->
@@ -1853,326 +1853,326 @@
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['views', 'ds__day', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_19') -->
+                                <!-- node_id = NodeId(id_str='ss_18') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_775), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_774), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_776), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_775), -->
                                 <!--     column_alias='listing',                            -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_774), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_773), -->
                                 <!--     column_alias='views',                              -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_18') -->
+                                    <!-- node_id = NodeId(id_str='ss_17') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_715), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_714), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_716), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_715), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_717), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_716), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_718), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_717), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_719), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_718), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_720), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_719), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_721), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_720), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_722), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_721), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_723), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_722), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_724), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_723), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_725), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_724), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_726), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_725), -->
                                     <!--     column_alias='ds_partitioned__day',                -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_727), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_726), -->
                                     <!--     column_alias='ds_partitioned__week',               -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_728), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_727), -->
                                     <!--     column_alias='ds_partitioned__month',              -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_729), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_728), -->
                                     <!--     column_alias='ds_partitioned__quarter',            -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_730), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_729), -->
                                     <!--     column_alias='ds_partitioned__year',               -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_731), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_730), -->
                                     <!--     column_alias='ds_partitioned__extract_year',       -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_732), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_731), -->
                                     <!--     column_alias='ds_partitioned__extract_quarter',    -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_733), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_732), -->
                                     <!--     column_alias='ds_partitioned__extract_month',      -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_734), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_733), -->
                                     <!--     column_alias='ds_partitioned__extract_day',        -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_735), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_734), -->
                                     <!--     column_alias='ds_partitioned__extract_dow',        -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_736), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_735), -->
                                     <!--     column_alias='ds_partitioned__extract_doy',        -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_737), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_736), -->
                                     <!--     column_alias='view__ds__day',                      -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_738), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_737), -->
                                     <!--     column_alias='view__ds__week',                     -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_739), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_738), -->
                                     <!--     column_alias='view__ds__month',                    -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_740), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_739), -->
                                     <!--     column_alias='view__ds__quarter',                  -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_741), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_740), -->
                                     <!--     column_alias='view__ds__year',                     -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_742), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_741), -->
                                     <!--     column_alias='view__ds__extract_year',             -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_743), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_742), -->
                                     <!--     column_alias='view__ds__extract_quarter',          -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_744), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_743), -->
                                     <!--     column_alias='view__ds__extract_month',            -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_745), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_744), -->
                                     <!--     column_alias='view__ds__extract_day',              -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_746), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_745), -->
                                     <!--     column_alias='view__ds__extract_dow',              -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_747), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_746), -->
                                     <!--     column_alias='view__ds__extract_doy',              -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_748), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_747), -->
                                     <!--     column_alias='view__ds_partitioned__day',          -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_749), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_748), -->
                                     <!--     column_alias='view__ds_partitioned__week',         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_750), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_749), -->
                                     <!--     column_alias='view__ds_partitioned__month',        -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_751), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_750), -->
                                     <!--     column_alias='view__ds_partitioned__quarter',      -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_752), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_751), -->
                                     <!--     column_alias='view__ds_partitioned__year',         -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_753), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_752), -->
                                     <!--     column_alias='view__ds_partitioned__extract_year', -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                   -->
                                     <!--   SqlSelectColumn(                                        -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_754),    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_753),    -->
                                     <!--     column_alias='view__ds_partitioned__extract_quarter', -->
                                     <!--   )                                                       -->
                                     <!-- col40 =                                                 -->
                                     <!--   SqlSelectColumn(                                      -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_755),  -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_754),  -->
                                     <!--     column_alias='view__ds_partitioned__extract_month', -->
                                     <!--   )                                                     -->
                                     <!-- col41 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_756), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_755), -->
                                     <!--     column_alias='view__ds_partitioned__extract_day',  -->
                                     <!--   )                                                    -->
                                     <!-- col42 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_757), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_756), -->
                                     <!--     column_alias='view__ds_partitioned__extract_dow',  -->
                                     <!--   )                                                    -->
                                     <!-- col43 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_758), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_757), -->
                                     <!--     column_alias='view__ds_partitioned__extract_doy',  -->
                                     <!--   )                                                    -->
                                     <!-- col44 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_759), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_758), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col45 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_760), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_759), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col46 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_761), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_760), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col47 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_762), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_761), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col48 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_763), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_762), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col49 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_764), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_763), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col50 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_765), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_764), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col51 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_766), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_765), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col52 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_767), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_766), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col53 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_768), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_767), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col54 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_769), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_768), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col55 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_770), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_769), -->
                                     <!--     column_alias='listing',                            -->
                                     <!--   )                                                    -->
                                     <!-- col56 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_771), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_770), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col57 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_772), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_771), -->
                                     <!--     column_alias='view__listing',                      -->
                                     <!--   )                                                    -->
                                     <!-- col58 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_773), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_772), -->
                                     <!--     column_alias='view__user',                         -->
                                     <!--   )                                                    -->
                                     <!-- col59 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_714), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_713), -->
                                     <!--     column_alias='views',                              -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28010) -->
@@ -2439,356 +2439,356 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_21') -->
+                                <!-- node_id = NodeId(id_str='ss_20') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_845), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_844), -->
                                 <!--     column_alias='listing',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_844), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_843), -->
                                 <!--     column_alias='country_latest',                     -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_20') -->
+                                    <!-- node_id = NodeId(id_str='ss_19') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_786), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_785), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_787), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_786), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_788), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_787), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_789), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_788), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_790), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_789), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_791), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_790), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_792), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_791), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_793), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_792), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_794), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_793), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_795), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_794), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_796), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_795), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_797), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_796), -->
                                     <!--     column_alias='created_at__day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_798), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_797), -->
                                     <!--     column_alias='created_at__week',                   -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_799), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_798), -->
                                     <!--     column_alias='created_at__month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_800), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_799), -->
                                     <!--     column_alias='created_at__quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_801), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_800), -->
                                     <!--     column_alias='created_at__year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_802), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_801), -->
                                     <!--     column_alias='created_at__extract_year',           -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_803), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_802), -->
                                     <!--     column_alias='created_at__extract_quarter',        -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_804), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_803), -->
                                     <!--     column_alias='created_at__extract_month',          -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_805), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_804), -->
                                     <!--     column_alias='created_at__extract_day',            -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_806), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_805), -->
                                     <!--     column_alias='created_at__extract_dow',            -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_807), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_806), -->
                                     <!--     column_alias='created_at__extract_doy',            -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_808), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_807), -->
                                     <!--     column_alias='listing__ds__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_809), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_808), -->
                                     <!--     column_alias='listing__ds__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_810), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_809), -->
                                     <!--     column_alias='listing__ds__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_811), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_810), -->
                                     <!--     column_alias='listing__ds__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_812), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_811), -->
                                     <!--     column_alias='listing__ds__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_813), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_812), -->
                                     <!--     column_alias='listing__ds__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_814), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_813), -->
                                     <!--     column_alias='listing__ds__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_815), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_814), -->
                                     <!--     column_alias='listing__ds__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_816), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_815), -->
                                     <!--     column_alias='listing__ds__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_817), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_816), -->
                                     <!--     column_alias='listing__ds__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_818), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_817), -->
                                     <!--     column_alias='listing__ds__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_819), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_818), -->
                                     <!--     column_alias='listing__created_at__day',           -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_820), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_819), -->
                                     <!--     column_alias='listing__created_at__week',          -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_821), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_820), -->
                                     <!--     column_alias='listing__created_at__month',         -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_822), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_821), -->
                                     <!--     column_alias='listing__created_at__quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_823), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_822), -->
                                     <!--     column_alias='listing__created_at__year',          -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_824), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_823), -->
                                     <!--     column_alias='listing__created_at__extract_year',  -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                  -->
                                     <!--   SqlSelectColumn(                                       -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_825),   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_824),   -->
                                     <!--     column_alias='listing__created_at__extract_quarter', -->
                                     <!--   )                                                      -->
                                     <!-- col40 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_826), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_825), -->
                                     <!--     column_alias='listing__created_at__extract_month', -->
                                     <!--   )                                                    -->
                                     <!-- col41 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_827), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_826), -->
                                     <!--     column_alias='listing__created_at__extract_day',   -->
                                     <!--   )                                                    -->
                                     <!-- col42 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_828), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_827), -->
                                     <!--     column_alias='listing__created_at__extract_dow',   -->
                                     <!--   )                                                    -->
                                     <!-- col43 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_829), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_828), -->
                                     <!--     column_alias='listing__created_at__extract_doy',   -->
                                     <!--   )                                                    -->
                                     <!-- col44 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_830), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_829), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col45 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_831), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_830), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col46 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_832), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_831), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col47 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_833), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_832), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col48 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_834), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_833), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col49 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_835), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_834), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col50 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_836), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_835), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col51 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_837), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_836), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col52 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_838), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_837), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col53 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_839), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_838), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col54 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_840), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_839), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col55 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_841), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_840), -->
                                     <!--     column_alias='listing',                            -->
                                     <!--   )                                                    -->
                                     <!-- col56 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_842), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_841), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col57 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_843), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_842), -->
                                     <!--     column_alias='listing__user',                      -->
                                     <!--   )                                                    -->
                                     <!-- col58 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_780), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_779), -->
                                     <!--     column_alias='country_latest',                     -->
                                     <!--   )                                                    -->
                                     <!-- col59 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_781), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_780), -->
                                     <!--     column_alias='is_lux_latest',                      -->
                                     <!--   )                                                    -->
                                     <!-- col60 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_782), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_781), -->
                                     <!--     column_alias='capacity_latest',                    -->
                                     <!--   )                                                    -->
                                     <!-- col61 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_783), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_782), -->
                                     <!--     column_alias='listing__country_latest',            -->
                                     <!--   )                                                    -->
                                     <!-- col62 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_784), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_783), -->
                                     <!--     column_alias='listing__is_lux_latest',             -->
                                     <!--   )                                                    -->
                                     <!-- col63 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_785), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_784), -->
                                     <!--     column_alias='listing__capacity_latest',           -->
                                     <!--   )                                                    -->
                                     <!-- col64 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_777), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_776), -->
                                     <!--     column_alias='listings',                           -->
                                     <!--   )                                                    -->
                                     <!-- col65 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_778), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_777), -->
                                     <!--     column_alias='largest_listing',                    -->
                                     <!--   )                                                    -->
                                     <!-- col66 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_779), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_778), -->
                                     <!--     column_alias='smallest_listing',                   -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimension_with_joined_where_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimension_with_joined_where_constraint__plan0.xml
@@ -3,407 +3,407 @@
         <!-- description = "Pass Only Elements: ['user__home_state_latest',]" -->
         <!-- node_id = NodeId(id_str='ss_4') -->
         <!-- col0 =                                                                                                       -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_140), column_alias='user__home_state_latest') -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- group_by0 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_140), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Output with WHERE' -->
             <!-- node_id = NodeId(id_str='ss_3') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_74), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_75), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_76), column_alias='ds__year') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_93), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_77), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_78), column_alias='ds__extract_quarter') -->
-            <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='ds__extract_month') -->
-            <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='ds__extract_day') -->
-            <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='ds__extract_dow') -->
-            <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='ds__extract_doy') -->
-            <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='created_at__day') -->
-            <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='created_at__week') -->
-            <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='created_at__month') -->
-            <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='created_at__quarter') -->
-            <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_87), column_alias='created_at__year') -->
-            <!-- col16 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
-            <!--     column_alias='created_at__extract_year',          -->
-            <!--   )                                                   -->
-            <!-- col17 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
-            <!--     column_alias='created_at__extract_quarter',       -->
-            <!--   )                                                   -->
-            <!-- col18 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
-            <!--     column_alias='created_at__extract_month',         -->
-            <!--   )                                                   -->
-            <!-- col19 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
-            <!--     column_alias='created_at__extract_day',           -->
-            <!--   )                                                   -->
-            <!-- col20 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
-            <!--     column_alias='created_at__extract_dow',           -->
-            <!--   )                                                   -->
-            <!-- col21 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
-            <!--     column_alias='created_at__extract_doy',           -->
-            <!--   )                                                   -->
-            <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='listing__ds__day') -->
-            <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='listing__ds__week') -->
-            <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='listing__ds__month') -->
-            <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='listing__ds__quarter') -->
-            <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='listing__ds__year') -->
-            <!-- col27 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
-            <!--     column_alias='listing__ds__extract_year',         -->
-            <!--   )                                                   -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_99), column_alias='ds__extract_quarter') -->
+            <!-- col7 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_100), column_alias='ds__extract_month') -->
+            <!-- col8 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_101), column_alias='ds__extract_day') -->
+            <!-- col9 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='ds__extract_dow') -->
+            <!-- col10 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='ds__extract_doy') -->
+            <!-- col11 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='created_at__day') -->
+            <!-- col12 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='created_at__week') -->
+            <!-- col13 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='created_at__month') -->
+            <!-- col14 =                                                                                                  -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='created_at__quarter') -->
+            <!-- col15 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='created_at__year') -->
+            <!-- col16 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
+            <!--     column_alias='created_at__extract_year',           -->
+            <!--   )                                                    -->
+            <!-- col17 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
+            <!--     column_alias='created_at__extract_quarter',        -->
+            <!--   )                                                    -->
+            <!-- col18 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
+            <!--     column_alias='created_at__extract_month',          -->
+            <!--   )                                                    -->
+            <!-- col19 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
+            <!--     column_alias='created_at__extract_day',            -->
+            <!--   )                                                    -->
+            <!-- col20 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
+            <!--     column_alias='created_at__extract_dow',            -->
+            <!--   )                                                    -->
+            <!-- col21 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
+            <!--     column_alias='created_at__extract_doy',            -->
+            <!--   )                                                    -->
+            <!-- col22 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_115), column_alias='listing__ds__day') -->
+            <!-- col23 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_116), column_alias='listing__ds__week') -->
+            <!-- col24 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_117), column_alias='listing__ds__month') -->
+            <!-- col25 =                                                                                                   -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__ds__quarter') -->
+            <!-- col26 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='listing__ds__year') -->
+            <!-- col27 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
+            <!--     column_alias='listing__ds__extract_year',          -->
+            <!--   )                                                    -->
             <!-- col28 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
             <!--     column_alias='listing__ds__extract_quarter',       -->
             <!--   )                                                    -->
             <!-- col29 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
             <!--     column_alias='listing__ds__extract_month',         -->
             <!--   )                                                    -->
             <!-- col30 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
             <!--     column_alias='listing__ds__extract_day',           -->
             <!--   )                                                    -->
             <!-- col31 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
             <!--     column_alias='listing__ds__extract_dow',           -->
             <!--   )                                                    -->
             <!-- col32 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
             <!--     column_alias='listing__ds__extract_doy',           -->
             <!--   )                                                    -->
             <!-- col33 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
             <!--     column_alias='listing__created_at__day',           -->
             <!--   )                                                    -->
             <!-- col34 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
             <!--     column_alias='listing__created_at__week',          -->
             <!--   )                                                    -->
             <!-- col35 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
             <!--     column_alias='listing__created_at__month',         -->
             <!--   )                                                    -->
             <!-- col36 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
             <!--     column_alias='listing__created_at__quarter',       -->
             <!--   )                                                    -->
             <!-- col37 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
             <!--     column_alias='listing__created_at__year',          -->
             <!--   )                                                    -->
             <!-- col38 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
             <!--     column_alias='listing__created_at__extract_year',  -->
             <!--   )                                                    -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_111),   -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_132),   -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
             <!--     column_alias='listing__created_at__extract_day',   -->
             <!--   )                                                    -->
             <!-- col42 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
             <!--     column_alias='listing__created_at__extract_dow',   -->
             <!--   )                                                    -->
             <!-- col43 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_115), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
             <!--     column_alias='listing__created_at__extract_doy',   -->
             <!--   )                                                    -->
-            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_116), column_alias='listing') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_117), column_alias='user') -->
+            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_137), column_alias='listing') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_138), column_alias='user') -->
             <!-- col46 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__user') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_139), column_alias='listing__user') -->
             <!-- col47 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_65), column_alias='country_latest') -->
-            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_66), column_alias='is_lux_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='country_latest') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_87), column_alias='is_lux_latest') -->
             <!-- col49 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_67), column_alias='capacity_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_88), column_alias='capacity_latest') -->
             <!-- col50 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
             <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
             <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
             <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
             <!--     column_alias='user__home_state_latest',           -->
             <!--   )                                                   -->
-            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='listings') -->
+            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listings') -->
             <!-- col55 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='largest_listing') -->
             <!-- col56 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_64), column_alias='smallest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- where = SqlStringExpression(node_id=str_0 sql_expr=listing__country_latest = 'us') -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
                 <!-- node_id = NodeId(id_str='ss_2') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__month') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='ds__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='ds__week') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='ds__month') -->
                 <!-- col3 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__quarter') -->
+                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__year') -->
                 <!-- col5 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__extract_year') -->
                 <!-- col6 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
                 <!--     column_alias='ds__extract_quarter',               -->
                 <!--   )                                                   -->
                 <!-- col7 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_month') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__extract_month') -->
                 <!-- col8 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_day') -->
                 <!-- col9 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_dow') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_dow') -->
                 <!-- col10 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__extract_doy') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_doy') -->
                 <!-- col11 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='created_at__day') -->
                 <!-- col12 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__week') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='created_at__week') -->
                 <!-- col13 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__month') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='created_at__month') -->
                 <!-- col14 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
                 <!--     column_alias='created_at__quarter',               -->
                 <!--   )                                                   -->
                 <!-- col15 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='created_at__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__year') -->
                 <!-- col16 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
                 <!--     column_alias='created_at__extract_year',          -->
                 <!--   )                                                   -->
                 <!-- col17 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
                 <!--     column_alias='created_at__extract_quarter',       -->
                 <!--   )                                                   -->
                 <!-- col18 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
                 <!--     column_alias='created_at__extract_month',         -->
                 <!--   )                                                   -->
                 <!-- col19 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
                 <!--     column_alias='created_at__extract_day',           -->
                 <!--   )                                                   -->
                 <!-- col20 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
                 <!--     column_alias='created_at__extract_dow',           -->
                 <!--   )                                                   -->
                 <!-- col21 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
                 <!--     column_alias='created_at__extract_doy',           -->
                 <!--   )                                                   -->
                 <!-- col22 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing__ds__day') -->
                 <!-- col23 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__week') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing__ds__week') -->
                 <!-- col24 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
                 <!--     column_alias='listing__ds__month',                -->
                 <!--   )                                                   -->
                 <!-- col25 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
                 <!--     column_alias='listing__ds__quarter',              -->
                 <!--   )                                                   -->
                 <!-- col26 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='listing__ds__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__year') -->
                 <!-- col27 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
                 <!--     column_alias='listing__ds__extract_year',         -->
                 <!--   )                                                   -->
                 <!-- col28 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
                 <!--     column_alias='listing__ds__extract_quarter',      -->
                 <!--   )                                                   -->
                 <!-- col29 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
                 <!--     column_alias='listing__ds__extract_month',        -->
                 <!--   )                                                   -->
                 <!-- col30 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
                 <!--     column_alias='listing__ds__extract_day',          -->
                 <!--   )                                                   -->
                 <!-- col31 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
                 <!--     column_alias='listing__ds__extract_dow',          -->
                 <!--   )                                                   -->
                 <!-- col32 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
                 <!--     column_alias='listing__ds__extract_doy',          -->
                 <!--   )                                                   -->
                 <!-- col33 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
                 <!--     column_alias='listing__created_at__day',          -->
                 <!--   )                                                   -->
                 <!-- col34 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
                 <!--     column_alias='listing__created_at__week',         -->
                 <!--   )                                                   -->
                 <!-- col35 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
                 <!--     column_alias='listing__created_at__month',        -->
                 <!--   )                                                   -->
                 <!-- col36 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
                 <!--     column_alias='listing__created_at__quarter',      -->
                 <!--   )                                                   -->
                 <!-- col37 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
                 <!--     column_alias='listing__created_at__year',         -->
                 <!--   )                                                   -->
                 <!-- col38 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
                 <!--     column_alias='listing__created_at__extract_year', -->
                 <!--   )                                                   -->
                 <!-- col39 =                                                  -->
                 <!--   SqlSelectColumn(                                       -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_74),    -->
                 <!--     column_alias='listing__created_at__extract_quarter', -->
                 <!--   )                                                      -->
                 <!-- col40 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54),  -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_75),  -->
                 <!--     column_alias='listing__created_at__extract_month', -->
                 <!--   )                                                    -->
                 <!-- col41 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
                 <!--     column_alias='listing__created_at__extract_day',  -->
                 <!--   )                                                   -->
                 <!-- col42 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
                 <!--     column_alias='listing__created_at__extract_dow',  -->
                 <!--   )                                                   -->
                 <!-- col43 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
                 <!--     column_alias='listing__created_at__extract_doy',  -->
                 <!--   )                                                   -->
-                <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing') -->
-                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='user') -->
+                <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='listing') -->
+                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='user') -->
                 <!-- col46 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__user') -->
-                <!-- col47 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='country_latest') -->
-                <!-- col48 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_lux_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__user') -->
+                <!-- col47 =                                                                                            -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='country_latest') -->
+                <!-- col48 =                                                                                           -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='is_lux_latest') -->
                 <!-- col49 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='capacity_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='capacity_latest') -->
                 <!-- col50 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
                 <!--     column_alias='listing__country_latest',           -->
                 <!--   )                                                   -->
                 <!-- col51 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
                 <!--     column_alias='listing__is_lux_latest',            -->
                 <!--   )                                                   -->
                 <!-- col52 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
                 <!--     column_alias='listing__capacity_latest',          -->
                 <!--   )                                                   -->
                 <!-- col53 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
                 <!--     column_alias='user__home_state_latest',           -->
                 <!--   )                                                   -->
-                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='listings') -->
-                <!-- col55 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
-                <!-- col56 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
+                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='listings') -->
+                <!-- col55 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='largest_listing') -->
+                <!-- col56 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='smallest_listing') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
@@ -657,12 +657,12 @@
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
                     <!-- node_id = NodeId(id_str='ss_1') -->
-                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='user') -->
-                    <!-- col1 =                                               -->
-                    <!--   SqlSelectColumn(                                   -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
-                    <!--     column_alias='home_state_latest',                -->
-                    <!--   )                                                  -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='user') -->
+                    <!-- col1 =                                                -->
+                    <!--   SqlSelectColumn(                                    -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
+                    <!--     column_alias='home_state_latest',                 -->
+                    <!--   )                                                   -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
                     <!-- where = None -->
                     <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
@@ -3,203 +3,204 @@
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
         <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 =                                                                                                     -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='user__home_state_latest') -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
         <!-- group_by0 =                                                                                                -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                 -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
             <!-- node_id = NodeId(id_str='ss_2') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__year') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='ds__extract_quarter') -->
             <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__extract_month') -->
             <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_day') -->
             <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='created_at__day') -->
             <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='created_at__week') -->
             <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='created_at__month') -->
             <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='created_at__quarter') -->
             <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='created_at__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__year') -->
             <!-- col16 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
             <!--     column_alias='created_at__extract_year',          -->
             <!--   )                                                   -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
             <!--     column_alias='created_at__extract_quarter',       -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
             <!--     column_alias='created_at__extract_month',         -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
             <!--     column_alias='created_at__extract_day',           -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
             <!--     column_alias='created_at__extract_dow',           -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
             <!--     column_alias='created_at__extract_doy',           -->
             <!--   )                                                   -->
             <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing__ds__day') -->
             <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing__ds__week') -->
             <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='listing__ds__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__ds__month') -->
             <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__ds__quarter') -->
             <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='listing__ds__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__year') -->
             <!-- col27 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
             <!--     column_alias='listing__ds__extract_year',         -->
             <!--   )                                                   -->
             <!-- col28 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
             <!--     column_alias='listing__ds__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col29 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
             <!--     column_alias='listing__ds__extract_month',        -->
             <!--   )                                                   -->
             <!-- col30 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
             <!--     column_alias='listing__ds__extract_day',          -->
             <!--   )                                                   -->
             <!-- col31 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
             <!--     column_alias='listing__ds__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col32 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
             <!--     column_alias='listing__ds__extract_doy',          -->
             <!--   )                                                   -->
             <!-- col33 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
             <!--     column_alias='listing__created_at__day',          -->
             <!--   )                                                   -->
             <!-- col34 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
             <!--     column_alias='listing__created_at__week',         -->
             <!--   )                                                   -->
             <!-- col35 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
             <!--     column_alias='listing__created_at__month',        -->
             <!--   )                                                   -->
             <!-- col36 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
             <!--     column_alias='listing__created_at__quarter',      -->
             <!--   )                                                   -->
             <!-- col37 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
             <!--     column_alias='listing__created_at__year',         -->
             <!--   )                                                   -->
             <!-- col38 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
             <!--     column_alias='listing__created_at__extract_year', -->
             <!--   )                                                   -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_74),    -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54),  -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_75),  -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
             <!--     column_alias='listing__created_at__extract_day',  -->
             <!--   )                                                   -->
             <!-- col42 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
             <!--     column_alias='listing__created_at__extract_dow',  -->
             <!--   )                                                   -->
             <!-- col43 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
             <!--     column_alias='listing__created_at__extract_doy',  -->
             <!--   )                                                   -->
-            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='user') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__user') -->
-            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='country_latest') -->
-            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_lux_latest') -->
+            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='listing') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='user') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__user') -->
+            <!-- col47 =                                                                                            -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='country_latest') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='is_lux_latest') -->
             <!-- col49 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='capacity_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='capacity_latest') -->
             <!-- col50 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
             <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
             <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
             <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
             <!--     column_alias='user__home_state_latest',           -->
             <!--   )                                                   -->
-            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='listings') -->
-            <!-- col55 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
-            <!-- col56 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
+            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='listings') -->
+            <!-- col55 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='largest_listing') -->
+            <!-- col56 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
@@ -418,9 +419,9 @@
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
                 <!-- node_id = NodeId(id_str='ss_1') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='user') -->
-                <!-- col1 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='home_state_latest') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='user') -->
+                <!-- col1 =                                                                                                -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='home_state_latest') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
                 <!-- where = None -->
                 <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
+++ b/metricflow/test/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
@@ -3,411 +3,411 @@
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
         <!-- node_id = NodeId(id_str='ss_4') -->
         <!-- col0 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_140), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                       -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_120), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_141), column_alias='user__home_state_latest') -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- group_by0 =                                                                                                 -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_140), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_120), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_141), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Output with WHERE' -->
             <!-- node_id = NodeId(id_str='ss_3') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_74), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_75), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_76), column_alias='ds__year') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_93), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_77), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_78), column_alias='ds__extract_quarter') -->
-            <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='ds__extract_month') -->
-            <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='ds__extract_day') -->
-            <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='ds__extract_dow') -->
-            <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='ds__extract_doy') -->
-            <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='created_at__day') -->
-            <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='created_at__week') -->
-            <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='created_at__month') -->
-            <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='created_at__quarter') -->
-            <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_87), column_alias='created_at__year') -->
-            <!-- col16 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
-            <!--     column_alias='created_at__extract_year',          -->
-            <!--   )                                                   -->
-            <!-- col17 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
-            <!--     column_alias='created_at__extract_quarter',       -->
-            <!--   )                                                   -->
-            <!-- col18 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
-            <!--     column_alias='created_at__extract_month',         -->
-            <!--   )                                                   -->
-            <!-- col19 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
-            <!--     column_alias='created_at__extract_day',           -->
-            <!--   )                                                   -->
-            <!-- col20 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
-            <!--     column_alias='created_at__extract_dow',           -->
-            <!--   )                                                   -->
-            <!-- col21 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
-            <!--     column_alias='created_at__extract_doy',           -->
-            <!--   )                                                   -->
-            <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='listing__ds__day') -->
-            <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='listing__ds__week') -->
-            <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='listing__ds__month') -->
-            <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='listing__ds__quarter') -->
-            <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='listing__ds__year') -->
-            <!-- col27 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
-            <!--     column_alias='listing__ds__extract_year',         -->
-            <!--   )                                                   -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_99), column_alias='ds__extract_quarter') -->
+            <!-- col7 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_100), column_alias='ds__extract_month') -->
+            <!-- col8 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_101), column_alias='ds__extract_day') -->
+            <!-- col9 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='ds__extract_dow') -->
+            <!-- col10 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='ds__extract_doy') -->
+            <!-- col11 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='created_at__day') -->
+            <!-- col12 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='created_at__week') -->
+            <!-- col13 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='created_at__month') -->
+            <!-- col14 =                                                                                                  -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='created_at__quarter') -->
+            <!-- col15 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='created_at__year') -->
+            <!-- col16 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
+            <!--     column_alias='created_at__extract_year',           -->
+            <!--   )                                                    -->
+            <!-- col17 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
+            <!--     column_alias='created_at__extract_quarter',        -->
+            <!--   )                                                    -->
+            <!-- col18 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
+            <!--     column_alias='created_at__extract_month',          -->
+            <!--   )                                                    -->
+            <!-- col19 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
+            <!--     column_alias='created_at__extract_day',            -->
+            <!--   )                                                    -->
+            <!-- col20 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
+            <!--     column_alias='created_at__extract_dow',            -->
+            <!--   )                                                    -->
+            <!-- col21 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
+            <!--     column_alias='created_at__extract_doy',            -->
+            <!--   )                                                    -->
+            <!-- col22 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_115), column_alias='listing__ds__day') -->
+            <!-- col23 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_116), column_alias='listing__ds__week') -->
+            <!-- col24 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_117), column_alias='listing__ds__month') -->
+            <!-- col25 =                                                                                                   -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__ds__quarter') -->
+            <!-- col26 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='listing__ds__year') -->
+            <!-- col27 =                                                -->
+            <!--   SqlSelectColumn(                                     -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
+            <!--     column_alias='listing__ds__extract_year',          -->
+            <!--   )                                                    -->
             <!-- col28 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
             <!--     column_alias='listing__ds__extract_quarter',       -->
             <!--   )                                                    -->
             <!-- col29 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
             <!--     column_alias='listing__ds__extract_month',         -->
             <!--   )                                                    -->
             <!-- col30 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
             <!--     column_alias='listing__ds__extract_day',           -->
             <!--   )                                                    -->
             <!-- col31 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
             <!--     column_alias='listing__ds__extract_dow',           -->
             <!--   )                                                    -->
             <!-- col32 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
             <!--     column_alias='listing__ds__extract_doy',           -->
             <!--   )                                                    -->
             <!-- col33 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
             <!--     column_alias='listing__created_at__day',           -->
             <!--   )                                                    -->
             <!-- col34 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
             <!--     column_alias='listing__created_at__week',          -->
             <!--   )                                                    -->
             <!-- col35 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
             <!--     column_alias='listing__created_at__month',         -->
             <!--   )                                                    -->
             <!-- col36 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
             <!--     column_alias='listing__created_at__quarter',       -->
             <!--   )                                                    -->
             <!-- col37 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
             <!--     column_alias='listing__created_at__year',          -->
             <!--   )                                                    -->
             <!-- col38 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
             <!--     column_alias='listing__created_at__extract_year',  -->
             <!--   )                                                    -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_111),   -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_132),   -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
             <!--     column_alias='listing__created_at__extract_day',   -->
             <!--   )                                                    -->
             <!-- col42 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
             <!--     column_alias='listing__created_at__extract_dow',   -->
             <!--   )                                                    -->
             <!-- col43 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_115), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
             <!--     column_alias='listing__created_at__extract_doy',   -->
             <!--   )                                                    -->
-            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_116), column_alias='listing') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_117), column_alias='user') -->
+            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_137), column_alias='listing') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_138), column_alias='user') -->
             <!-- col46 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__user') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_139), column_alias='listing__user') -->
             <!-- col47 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_65), column_alias='country_latest') -->
-            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_66), column_alias='is_lux_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='country_latest') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_87), column_alias='is_lux_latest') -->
             <!-- col49 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_67), column_alias='capacity_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_88), column_alias='capacity_latest') -->
             <!-- col50 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
             <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
             <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
             <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
             <!--     column_alias='user__home_state_latest',           -->
             <!--   )                                                   -->
-            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='listings') -->
+            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listings') -->
             <!-- col55 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='largest_listing') -->
             <!-- col56 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_64), column_alias='smallest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- where = SqlStringExpression(node_id=str_0 sql_expr=user__home_state_latest = 'us') -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
                 <!-- node_id = NodeId(id_str='ss_2') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__month') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='ds__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='ds__week') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='ds__month') -->
                 <!-- col3 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__quarter') -->
+                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__year') -->
                 <!-- col5 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__extract_year') -->
                 <!-- col6 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
                 <!--     column_alias='ds__extract_quarter',               -->
                 <!--   )                                                   -->
                 <!-- col7 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_month') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__extract_month') -->
                 <!-- col8 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_day') -->
                 <!-- col9 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_dow') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_dow') -->
                 <!-- col10 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__extract_doy') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_doy') -->
                 <!-- col11 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='created_at__day') -->
                 <!-- col12 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__week') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='created_at__week') -->
                 <!-- col13 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__month') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='created_at__month') -->
                 <!-- col14 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
                 <!--     column_alias='created_at__quarter',               -->
                 <!--   )                                                   -->
                 <!-- col15 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='created_at__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__year') -->
                 <!-- col16 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
                 <!--     column_alias='created_at__extract_year',          -->
                 <!--   )                                                   -->
                 <!-- col17 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
                 <!--     column_alias='created_at__extract_quarter',       -->
                 <!--   )                                                   -->
                 <!-- col18 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
                 <!--     column_alias='created_at__extract_month',         -->
                 <!--   )                                                   -->
                 <!-- col19 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
                 <!--     column_alias='created_at__extract_day',           -->
                 <!--   )                                                   -->
                 <!-- col20 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
                 <!--     column_alias='created_at__extract_dow',           -->
                 <!--   )                                                   -->
                 <!-- col21 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
                 <!--     column_alias='created_at__extract_doy',           -->
                 <!--   )                                                   -->
                 <!-- col22 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing__ds__day') -->
                 <!-- col23 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__week') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing__ds__week') -->
                 <!-- col24 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
                 <!--     column_alias='listing__ds__month',                -->
                 <!--   )                                                   -->
                 <!-- col25 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
                 <!--     column_alias='listing__ds__quarter',              -->
                 <!--   )                                                   -->
                 <!-- col26 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='listing__ds__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__year') -->
                 <!-- col27 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
                 <!--     column_alias='listing__ds__extract_year',         -->
                 <!--   )                                                   -->
                 <!-- col28 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
                 <!--     column_alias='listing__ds__extract_quarter',      -->
                 <!--   )                                                   -->
                 <!-- col29 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
                 <!--     column_alias='listing__ds__extract_month',        -->
                 <!--   )                                                   -->
                 <!-- col30 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
                 <!--     column_alias='listing__ds__extract_day',          -->
                 <!--   )                                                   -->
                 <!-- col31 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
                 <!--     column_alias='listing__ds__extract_dow',          -->
                 <!--   )                                                   -->
                 <!-- col32 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
                 <!--     column_alias='listing__ds__extract_doy',          -->
                 <!--   )                                                   -->
                 <!-- col33 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
                 <!--     column_alias='listing__created_at__day',          -->
                 <!--   )                                                   -->
                 <!-- col34 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
                 <!--     column_alias='listing__created_at__week',         -->
                 <!--   )                                                   -->
                 <!-- col35 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
                 <!--     column_alias='listing__created_at__month',        -->
                 <!--   )                                                   -->
                 <!-- col36 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
                 <!--     column_alias='listing__created_at__quarter',      -->
                 <!--   )                                                   -->
                 <!-- col37 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
                 <!--     column_alias='listing__created_at__year',         -->
                 <!--   )                                                   -->
                 <!-- col38 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
                 <!--     column_alias='listing__created_at__extract_year', -->
                 <!--   )                                                   -->
                 <!-- col39 =                                                  -->
                 <!--   SqlSelectColumn(                                       -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_74),    -->
                 <!--     column_alias='listing__created_at__extract_quarter', -->
                 <!--   )                                                      -->
                 <!-- col40 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54),  -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_75),  -->
                 <!--     column_alias='listing__created_at__extract_month', -->
                 <!--   )                                                    -->
                 <!-- col41 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
                 <!--     column_alias='listing__created_at__extract_day',  -->
                 <!--   )                                                   -->
                 <!-- col42 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
                 <!--     column_alias='listing__created_at__extract_dow',  -->
                 <!--   )                                                   -->
                 <!-- col43 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
                 <!--     column_alias='listing__created_at__extract_doy',  -->
                 <!--   )                                                   -->
-                <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing') -->
-                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='user') -->
+                <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='listing') -->
+                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='user') -->
                 <!-- col46 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__user') -->
-                <!-- col47 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='country_latest') -->
-                <!-- col48 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_lux_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__user') -->
+                <!-- col47 =                                                                                            -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='country_latest') -->
+                <!-- col48 =                                                                                           -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='is_lux_latest') -->
                 <!-- col49 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='capacity_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='capacity_latest') -->
                 <!-- col50 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
                 <!--     column_alias='listing__country_latest',           -->
                 <!--   )                                                   -->
                 <!-- col51 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
                 <!--     column_alias='listing__is_lux_latest',            -->
                 <!--   )                                                   -->
                 <!-- col52 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
                 <!--     column_alias='listing__capacity_latest',          -->
                 <!--   )                                                   -->
                 <!-- col53 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
                 <!--     column_alias='user__home_state_latest',           -->
                 <!--   )                                                   -->
-                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='listings') -->
-                <!-- col55 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
-                <!-- col56 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
+                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='listings') -->
+                <!-- col55 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='largest_listing') -->
+                <!-- col56 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='smallest_listing') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
@@ -661,12 +661,12 @@
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
                     <!-- node_id = NodeId(id_str='ss_1') -->
-                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='user') -->
-                    <!-- col1 =                                               -->
-                    <!--   SqlSelectColumn(                                   -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
-                    <!--     column_alias='home_state_latest',                -->
-                    <!--   )                                                  -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='user') -->
+                    <!-- col1 =                                                -->
+                    <!--   SqlSelectColumn(                                    -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
+                    <!--     column_alias='home_state_latest',                 -->
+                    <!--   )                                                   -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
                     <!-- where = None -->
                     <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
+++ b/metricflow/test/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
@@ -3,203 +3,204 @@
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
         <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 =                                                                                                     -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='user__home_state_latest') -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
         <!-- group_by0 =                                                                                                -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                 -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
             <!-- node_id = NodeId(id_str='ss_2') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__year') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='ds__extract_quarter') -->
             <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__extract_month') -->
             <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_day') -->
             <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='created_at__day') -->
             <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='created_at__week') -->
             <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='created_at__month') -->
             <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='created_at__quarter') -->
             <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='created_at__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__year') -->
             <!-- col16 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
             <!--     column_alias='created_at__extract_year',          -->
             <!--   )                                                   -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
             <!--     column_alias='created_at__extract_quarter',       -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
             <!--     column_alias='created_at__extract_month',         -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
             <!--     column_alias='created_at__extract_day',           -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
             <!--     column_alias='created_at__extract_dow',           -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
             <!--     column_alias='created_at__extract_doy',           -->
             <!--   )                                                   -->
             <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing__ds__day') -->
             <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing__ds__week') -->
             <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='listing__ds__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__ds__month') -->
             <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__ds__quarter') -->
             <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='listing__ds__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__year') -->
             <!-- col27 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
             <!--     column_alias='listing__ds__extract_year',         -->
             <!--   )                                                   -->
             <!-- col28 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
             <!--     column_alias='listing__ds__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col29 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
             <!--     column_alias='listing__ds__extract_month',        -->
             <!--   )                                                   -->
             <!-- col30 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
             <!--     column_alias='listing__ds__extract_day',          -->
             <!--   )                                                   -->
             <!-- col31 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
             <!--     column_alias='listing__ds__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col32 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
             <!--     column_alias='listing__ds__extract_doy',          -->
             <!--   )                                                   -->
             <!-- col33 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
             <!--     column_alias='listing__created_at__day',          -->
             <!--   )                                                   -->
             <!-- col34 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
             <!--     column_alias='listing__created_at__week',         -->
             <!--   )                                                   -->
             <!-- col35 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
             <!--     column_alias='listing__created_at__month',        -->
             <!--   )                                                   -->
             <!-- col36 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
             <!--     column_alias='listing__created_at__quarter',      -->
             <!--   )                                                   -->
             <!-- col37 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
             <!--     column_alias='listing__created_at__year',         -->
             <!--   )                                                   -->
             <!-- col38 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
             <!--     column_alias='listing__created_at__extract_year', -->
             <!--   )                                                   -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_74),    -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54),  -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_75),  -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
             <!--     column_alias='listing__created_at__extract_day',  -->
             <!--   )                                                   -->
             <!-- col42 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
             <!--     column_alias='listing__created_at__extract_dow',  -->
             <!--   )                                                   -->
             <!-- col43 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
             <!--     column_alias='listing__created_at__extract_doy',  -->
             <!--   )                                                   -->
-            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='user') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__user') -->
-            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='country_latest') -->
-            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_lux_latest') -->
+            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='listing') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='user') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__user') -->
+            <!-- col47 =                                                                                            -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='country_latest') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='is_lux_latest') -->
             <!-- col49 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='capacity_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='capacity_latest') -->
             <!-- col50 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
             <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
             <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
             <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
             <!--     column_alias='user__home_state_latest',           -->
             <!--   )                                                   -->
-            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='listings') -->
-            <!-- col55 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
-            <!-- col56 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
+            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='listings') -->
+            <!-- col55 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='largest_listing') -->
+            <!-- col56 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
@@ -418,9 +419,9 @@
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
                 <!-- node_id = NodeId(id_str='ss_1') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='user') -->
-                <!-- col1 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='home_state_latest') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='user') -->
+                <!-- col1 =                                                                                                -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='home_state_latest') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
                 <!-- where = None -->
                 <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
@@ -1,7 +1,7 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Combine Aggregated Outputs' -->
-        <!-- node_id = NodeId(id_str='ss_18') -->
+        <!-- node_id = NodeId(id_str='ss_17') -->
         <!-- col0 =                                                                         -->
         <!--   SqlSelectColumn(                                                             -->
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
@@ -17,10 +17,10 @@
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
         <!--     column_alias='booking_payments',                                      -->
         <!--   )                                                                       -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_17),  -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_16),  -->
         <!--     right_source_alias='subq_9',                         -->
         <!--     join_type=FULL_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -34,508 +34,508 @@
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_13') -->
+            <!-- node_id = NodeId(id_str='ss_12') -->
             <!-- col0 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_631), column_alias='metric_time__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_632), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_630), column_alias='metric_time__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_631), column_alias='bookings') -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_12') -->
+                <!-- node_id = NodeId(id_str='ss_11') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_630), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_629), column_alias='metric_time__day') -->
                 <!-- col1 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='bookings',                                              -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                 <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_630), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_629), column_alias='metric_time__day') -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_11') -->
+                    <!-- node_id = NodeId(id_str='ss_10') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
                     <!-- col1 =                                                                                        -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_627), column_alias='bookings') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_626), column_alias='bookings') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_10') -->
+                        <!-- node_id = NodeId(id_str='ss_9') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_544), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_543), column_alias='ds__day') -->
                         <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_545), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_544), column_alias='ds__week') -->
                         <!-- col2 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
                         <!--     column_alias='ds__month',                          -->
                         <!--   )                                                    -->
                         <!-- col3 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
                         <!--     column_alias='ds__quarter',                        -->
                         <!--   )                                                    -->
                         <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_548), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_547), column_alias='ds__year') -->
                         <!-- col5 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
                         <!--     column_alias='ds__extract_year',                   -->
                         <!--   )                                                    -->
                         <!-- col6 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
                         <!--     column_alias='ds__extract_quarter',                -->
                         <!--   )                                                    -->
                         <!-- col7 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
                         <!--     column_alias='ds__extract_month',                  -->
                         <!--   )                                                    -->
                         <!-- col8 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
                         <!--     column_alias='ds__extract_day',                    -->
                         <!--   )                                                    -->
                         <!-- col9 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
                         <!--     column_alias='ds__extract_dow',                    -->
                         <!--   )                                                    -->
                         <!-- col10 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
                         <!--     column_alias='ds__extract_doy',                    -->
                         <!--   )                                                    -->
                         <!-- col11 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
                         <!--     column_alias='ds_partitioned__day',                -->
                         <!--   )                                                    -->
                         <!-- col12 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
                         <!--     column_alias='ds_partitioned__week',               -->
                         <!--   )                                                    -->
                         <!-- col13 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
                         <!--     column_alias='ds_partitioned__month',              -->
                         <!--   )                                                    -->
                         <!-- col14 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
                         <!--     column_alias='ds_partitioned__quarter',            -->
                         <!--   )                                                    -->
                         <!-- col15 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
                         <!--     column_alias='ds_partitioned__year',               -->
                         <!--   )                                                    -->
                         <!-- col16 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
                         <!--     column_alias='ds_partitioned__extract_year',       -->
                         <!--   )                                                    -->
                         <!-- col17 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
                         <!--     column_alias='ds_partitioned__extract_quarter',    -->
                         <!--   )                                                    -->
                         <!-- col18 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
                         <!--     column_alias='ds_partitioned__extract_month',      -->
                         <!--   )                                                    -->
                         <!-- col19 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
                         <!--     column_alias='ds_partitioned__extract_day',        -->
                         <!--   )                                                    -->
                         <!-- col20 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
                         <!--     column_alias='ds_partitioned__extract_dow',        -->
                         <!--   )                                                    -->
                         <!-- col21 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
                         <!--     column_alias='ds_partitioned__extract_doy',        -->
                         <!--   )                                                    -->
                         <!-- col22 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_566), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
                         <!--     column_alias='paid_at__day',                       -->
                         <!--   )                                                    -->
                         <!-- col23 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_566), -->
                         <!--     column_alias='paid_at__week',                      -->
                         <!--   )                                                    -->
                         <!-- col24 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
                         <!--     column_alias='paid_at__month',                     -->
                         <!--   )                                                    -->
                         <!-- col25 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
                         <!--     column_alias='paid_at__quarter',                   -->
                         <!--   )                                                    -->
                         <!-- col26 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
                         <!--     column_alias='paid_at__year',                      -->
                         <!--   )                                                    -->
                         <!-- col27 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
                         <!--     column_alias='paid_at__extract_year',              -->
                         <!--   )                                                    -->
                         <!-- col28 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
                         <!--     column_alias='paid_at__extract_quarter',           -->
                         <!--   )                                                    -->
                         <!-- col29 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
                         <!--     column_alias='paid_at__extract_month',             -->
                         <!--   )                                                    -->
                         <!-- col30 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
                         <!--     column_alias='paid_at__extract_day',               -->
                         <!--   )                                                    -->
                         <!-- col31 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
                         <!--     column_alias='paid_at__extract_dow',               -->
                         <!--   )                                                    -->
                         <!-- col32 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
                         <!--     column_alias='paid_at__extract_doy',               -->
                         <!--   )                                                    -->
                         <!-- col33 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
                         <!--     column_alias='booking__ds__day',                   -->
                         <!--   )                                                    -->
                         <!-- col34 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
                         <!--     column_alias='booking__ds__week',                  -->
                         <!--   )                                                    -->
                         <!-- col35 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
                         <!--     column_alias='booking__ds__month',                 -->
                         <!--   )                                                    -->
                         <!-- col36 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
                         <!--     column_alias='booking__ds__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col37 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
                         <!--     column_alias='booking__ds__year',                  -->
                         <!--   )                                                    -->
                         <!-- col38 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
                         <!--     column_alias='booking__ds__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col39 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
                         <!--     column_alias='booking__ds__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col40 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
                         <!--     column_alias='booking__ds__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col41 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
                         <!--     column_alias='booking__ds__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col42 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
                         <!--     column_alias='booking__ds__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col43 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
                         <!--     column_alias='booking__ds__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col44 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
                         <!--     column_alias='booking__ds_partitioned__day',       -->
                         <!--   )                                                    -->
                         <!-- col45 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
                         <!--     column_alias='booking__ds_partitioned__week',      -->
                         <!--   )                                                    -->
                         <!-- col46 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
                         <!--     column_alias='booking__ds_partitioned__month',     -->
                         <!--   )                                                    -->
                         <!-- col47 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
                         <!--     column_alias='booking__ds_partitioned__quarter',   -->
                         <!--   )                                                    -->
                         <!-- col48 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
                         <!--     column_alias='booking__ds_partitioned__year',      -->
                         <!--   )                                                    -->
                         <!-- col49 =                                                   -->
                         <!--   SqlSelectColumn(                                        -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_593),    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_592),    -->
                         <!--     column_alias='booking__ds_partitioned__extract_year', -->
                         <!--   )                                                       -->
                         <!-- col50 =                                                      -->
                         <!--   SqlSelectColumn(                                           -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_594),       -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_593),       -->
                         <!--     column_alias='booking__ds_partitioned__extract_quarter', -->
                         <!--   )                                                          -->
                         <!-- col51 =                                                    -->
                         <!--   SqlSelectColumn(                                         -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_595),     -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_594),     -->
                         <!--     column_alias='booking__ds_partitioned__extract_month', -->
                         <!--   )                                                        -->
                         <!-- col52 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_596),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_595),   -->
                         <!--     column_alias='booking__ds_partitioned__extract_day', -->
                         <!--   )                                                      -->
                         <!-- col53 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_597),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_596),   -->
                         <!--     column_alias='booking__ds_partitioned__extract_dow', -->
                         <!--   )                                                      -->
                         <!-- col54 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_598),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_597),   -->
                         <!--     column_alias='booking__ds_partitioned__extract_doy', -->
                         <!--   )                                                      -->
                         <!-- col55 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
                         <!--     column_alias='booking__paid_at__day',              -->
                         <!--   )                                                    -->
                         <!-- col56 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
                         <!--     column_alias='booking__paid_at__week',             -->
                         <!--   )                                                    -->
                         <!-- col57 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
                         <!--     column_alias='booking__paid_at__month',            -->
                         <!--   )                                                    -->
                         <!-- col58 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
                         <!--     column_alias='booking__paid_at__quarter',          -->
                         <!--   )                                                    -->
                         <!-- col59 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
                         <!--     column_alias='booking__paid_at__year',             -->
                         <!--   )                                                    -->
                         <!-- col60 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
                         <!--     column_alias='booking__paid_at__extract_year',     -->
                         <!--   )                                                    -->
                         <!-- col61 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
                         <!--     column_alias='booking__paid_at__extract_quarter',  -->
                         <!--   )                                                    -->
                         <!-- col62 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
                         <!--     column_alias='booking__paid_at__extract_month',    -->
                         <!--   )                                                    -->
                         <!-- col63 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
                         <!--     column_alias='booking__paid_at__extract_day',      -->
                         <!--   )                                                    -->
                         <!-- col64 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
                         <!--     column_alias='booking__paid_at__extract_dow',      -->
                         <!--   )                                                    -->
                         <!-- col65 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
                         <!--     column_alias='booking__paid_at__extract_doy',      -->
                         <!--   )                                                    -->
                         <!-- col66 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col67 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
                         <!--     column_alias='metric_time__week',                  -->
                         <!--   )                                                    -->
                         <!-- col68 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
                         <!--     column_alias='metric_time__month',                 -->
                         <!--   )                                                    -->
                         <!-- col69 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
                         <!--     column_alias='metric_time__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col70 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
                         <!--     column_alias='metric_time__year',                  -->
                         <!--   )                                                    -->
                         <!-- col71 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
                         <!--     column_alias='metric_time__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col72 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
                         <!--     column_alias='metric_time__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col73 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
                         <!--     column_alias='metric_time__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col74 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
                         <!--     column_alias='metric_time__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col75 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
                         <!--     column_alias='metric_time__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col76 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
                         <!--     column_alias='metric_time__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col77 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_621), column_alias='listing') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_620), column_alias='listing') -->
                         <!-- col78 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_622), column_alias='guest') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_621), column_alias='guest') -->
                         <!-- col79 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_623), column_alias='host') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_622), column_alias='host') -->
                         <!-- col80 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
                         <!--     column_alias='booking__listing',                   -->
                         <!--   )                                                    -->
                         <!-- col81 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
                         <!--     column_alias='booking__guest',                     -->
                         <!--   )                                                    -->
                         <!-- col82 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
                         <!--     column_alias='booking__host',                      -->
                         <!--   )                                                    -->
                         <!-- col83 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
                         <!--     column_alias='is_instant',                         -->
                         <!--   )                                                    -->
                         <!-- col84 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
                         <!--     column_alias='booking__is_instant',                -->
                         <!--   )                                                    -->
                         <!-- col85 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='bookings') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='bookings') -->
                         <!-- col86 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_529), -->
                         <!--     column_alias='instant_bookings',                   -->
                         <!--   )                                                    -->
                         <!-- col87 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
                         <!--     column_alias='booking_value',                      -->
                         <!--   )                                                    -->
                         <!-- col88 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
                         <!--     column_alias='max_booking_value',                  -->
                         <!--   )                                                    -->
                         <!-- col89 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_533), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
                         <!--     column_alias='min_booking_value',                  -->
                         <!--   )                                                    -->
                         <!-- col90 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_534), column_alias='bookers') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='bookers') -->
                         <!-- col91 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
                         <!--     column_alias='average_booking_value',              -->
                         <!--   )                                                    -->
                         <!-- col92 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
                         <!--     column_alias='referred_bookings',                  -->
                         <!--   )                                                    -->
                         <!-- col93 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
                         <!--     column_alias='median_booking_value',               -->
                         <!--   )                                                    -->
                         <!-- col94 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
                         <!--     column_alias='booking_value_p99',                  -->
                         <!--   )                                                    -->
                         <!-- col95 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
                         <!--     column_alias='discrete_booking_value_p99',         -->
                         <!--   )                                                    -->
                         <!-- col96 =                                                      -->
                         <!--   SqlSelectColumn(                                           -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540),       -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539),       -->
                         <!--     column_alias='approximate_continuous_booking_value_p99', -->
                         <!--   )                                                          -->
                         <!-- col97 =                                                    -->
                         <!--   SqlSelectColumn(                                         -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541),     -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540),     -->
                         <!--     column_alias='approximate_discrete_booking_value_p99', -->
                         <!--   )                                                        -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
@@ -990,458 +990,458 @@
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_17') -->
+            <!-- node_id = NodeId(id_str='ss_16') -->
             <!-- col0 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_723), column_alias='metric_time__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_722), column_alias='metric_time__day') -->
             <!-- col1 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_724), column_alias='booking_payments') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_723), column_alias='booking_payments') -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_16') -->
+                <!-- node_id = NodeId(id_str='ss_15') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_722), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_721), column_alias='metric_time__day') -->
                 <!-- col1 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='booking_payments',                                      -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                 <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_722), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_721), column_alias='metric_time__day') -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['booking_payments', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_15') -->
+                    <!-- node_id = NodeId(id_str='ss_14') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_720), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_719), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_719), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_718), -->
                     <!--     column_alias='booking_payments',                   -->
                     <!--   )                                                    -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'paid_at'" -->
-                        <!-- node_id = NodeId(id_str='ss_14') -->
+                        <!-- node_id = NodeId(id_str='ss_13') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_636), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_635), column_alias='ds__day') -->
                         <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_637), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_636), column_alias='ds__week') -->
                         <!-- col2 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
                         <!--     column_alias='ds__month',                          -->
                         <!--   )                                                    -->
                         <!-- col3 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
                         <!--     column_alias='ds__quarter',                        -->
                         <!--   )                                                    -->
                         <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_640), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_639), column_alias='ds__year') -->
                         <!-- col5 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
                         <!--     column_alias='ds__extract_year',                   -->
                         <!--   )                                                    -->
                         <!-- col6 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
                         <!--     column_alias='ds__extract_quarter',                -->
                         <!--   )                                                    -->
                         <!-- col7 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
                         <!--     column_alias='ds__extract_month',                  -->
                         <!--   )                                                    -->
                         <!-- col8 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
                         <!--     column_alias='ds__extract_day',                    -->
                         <!--   )                                                    -->
                         <!-- col9 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
                         <!--     column_alias='ds__extract_dow',                    -->
                         <!--   )                                                    -->
                         <!-- col10 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
                         <!--     column_alias='ds__extract_doy',                    -->
                         <!--   )                                                    -->
                         <!-- col11 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
                         <!--     column_alias='ds_partitioned__day',                -->
                         <!--   )                                                    -->
                         <!-- col12 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
                         <!--     column_alias='ds_partitioned__week',               -->
                         <!--   )                                                    -->
                         <!-- col13 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
                         <!--     column_alias='ds_partitioned__month',              -->
                         <!--   )                                                    -->
                         <!-- col14 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
                         <!--     column_alias='ds_partitioned__quarter',            -->
                         <!--   )                                                    -->
                         <!-- col15 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
                         <!--     column_alias='ds_partitioned__year',               -->
                         <!--   )                                                    -->
                         <!-- col16 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
                         <!--     column_alias='ds_partitioned__extract_year',       -->
                         <!--   )                                                    -->
                         <!-- col17 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
                         <!--     column_alias='ds_partitioned__extract_quarter',    -->
                         <!--   )                                                    -->
                         <!-- col18 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
                         <!--     column_alias='ds_partitioned__extract_month',      -->
                         <!--   )                                                    -->
                         <!-- col19 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
                         <!--     column_alias='ds_partitioned__extract_day',        -->
                         <!--   )                                                    -->
                         <!-- col20 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
                         <!--     column_alias='ds_partitioned__extract_dow',        -->
                         <!--   )                                                    -->
                         <!-- col21 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
                         <!--     column_alias='ds_partitioned__extract_doy',        -->
                         <!--   )                                                    -->
                         <!-- col22 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
                         <!--     column_alias='paid_at__day',                       -->
                         <!--   )                                                    -->
                         <!-- col23 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
                         <!--     column_alias='paid_at__week',                      -->
                         <!--   )                                                    -->
                         <!-- col24 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
                         <!--     column_alias='paid_at__month',                     -->
                         <!--   )                                                    -->
                         <!-- col25 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
                         <!--     column_alias='paid_at__quarter',                   -->
                         <!--   )                                                    -->
                         <!-- col26 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
                         <!--     column_alias='paid_at__year',                      -->
                         <!--   )                                                    -->
                         <!-- col27 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
                         <!--     column_alias='paid_at__extract_year',              -->
                         <!--   )                                                    -->
                         <!-- col28 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
                         <!--     column_alias='paid_at__extract_quarter',           -->
                         <!--   )                                                    -->
                         <!-- col29 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
                         <!--     column_alias='paid_at__extract_month',             -->
                         <!--   )                                                    -->
                         <!-- col30 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
                         <!--     column_alias='paid_at__extract_day',               -->
                         <!--   )                                                    -->
                         <!-- col31 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
                         <!--     column_alias='paid_at__extract_dow',               -->
                         <!--   )                                                    -->
                         <!-- col32 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
                         <!--     column_alias='paid_at__extract_doy',               -->
                         <!--   )                                                    -->
                         <!-- col33 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
                         <!--     column_alias='booking__ds__day',                   -->
                         <!--   )                                                    -->
                         <!-- col34 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
                         <!--     column_alias='booking__ds__week',                  -->
                         <!--   )                                                    -->
                         <!-- col35 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
                         <!--     column_alias='booking__ds__month',                 -->
                         <!--   )                                                    -->
                         <!-- col36 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
                         <!--     column_alias='booking__ds__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col37 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
                         <!--     column_alias='booking__ds__year',                  -->
                         <!--   )                                                    -->
                         <!-- col38 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
                         <!--     column_alias='booking__ds__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col39 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
                         <!--     column_alias='booking__ds__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col40 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
                         <!--     column_alias='booking__ds__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col41 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
                         <!--     column_alias='booking__ds__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col42 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
                         <!--     column_alias='booking__ds__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col43 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
                         <!--     column_alias='booking__ds__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col44 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
                         <!--     column_alias='booking__ds_partitioned__day',       -->
                         <!--   )                                                    -->
                         <!-- col45 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
                         <!--     column_alias='booking__ds_partitioned__week',      -->
                         <!--   )                                                    -->
                         <!-- col46 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
                         <!--     column_alias='booking__ds_partitioned__month',     -->
                         <!--   )                                                    -->
                         <!-- col47 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
                         <!--     column_alias='booking__ds_partitioned__quarter',   -->
                         <!--   )                                                    -->
                         <!-- col48 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
                         <!--     column_alias='booking__ds_partitioned__year',      -->
                         <!--   )                                                    -->
                         <!-- col49 =                                                   -->
                         <!--   SqlSelectColumn(                                        -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_685),    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_684),    -->
                         <!--     column_alias='booking__ds_partitioned__extract_year', -->
                         <!--   )                                                       -->
                         <!-- col50 =                                                      -->
                         <!--   SqlSelectColumn(                                           -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_686),       -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_685),       -->
                         <!--     column_alias='booking__ds_partitioned__extract_quarter', -->
                         <!--   )                                                          -->
                         <!-- col51 =                                                    -->
                         <!--   SqlSelectColumn(                                         -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_687),     -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_686),     -->
                         <!--     column_alias='booking__ds_partitioned__extract_month', -->
                         <!--   )                                                        -->
                         <!-- col52 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_688),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_687),   -->
                         <!--     column_alias='booking__ds_partitioned__extract_day', -->
                         <!--   )                                                      -->
                         <!-- col53 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_689),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_688),   -->
                         <!--     column_alias='booking__ds_partitioned__extract_dow', -->
                         <!--   )                                                      -->
                         <!-- col54 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_690),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_689),   -->
                         <!--     column_alias='booking__ds_partitioned__extract_doy', -->
                         <!--   )                                                      -->
                         <!-- col55 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
                         <!--     column_alias='booking__paid_at__day',              -->
                         <!--   )                                                    -->
                         <!-- col56 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
                         <!--     column_alias='booking__paid_at__week',             -->
                         <!--   )                                                    -->
                         <!-- col57 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
                         <!--     column_alias='booking__paid_at__month',            -->
                         <!--   )                                                    -->
                         <!-- col58 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
                         <!--     column_alias='booking__paid_at__quarter',          -->
                         <!--   )                                                    -->
                         <!-- col59 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
                         <!--     column_alias='booking__paid_at__year',             -->
                         <!--   )                                                    -->
                         <!-- col60 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
                         <!--     column_alias='booking__paid_at__extract_year',     -->
                         <!--   )                                                    -->
                         <!-- col61 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
                         <!--     column_alias='booking__paid_at__extract_quarter',  -->
                         <!--   )                                                    -->
                         <!-- col62 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_698), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
                         <!--     column_alias='booking__paid_at__extract_month',    -->
                         <!--   )                                                    -->
                         <!-- col63 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_699), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_698), -->
                         <!--     column_alias='booking__paid_at__extract_day',      -->
                         <!--   )                                                    -->
                         <!-- col64 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_700), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_699), -->
                         <!--     column_alias='booking__paid_at__extract_dow',      -->
                         <!--   )                                                    -->
                         <!-- col65 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_701), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_700), -->
                         <!--     column_alias='booking__paid_at__extract_doy',      -->
                         <!--   )                                                    -->
                         <!-- col66 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_702), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_701), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col67 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_703), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_702), -->
                         <!--     column_alias='metric_time__week',                  -->
                         <!--   )                                                    -->
                         <!-- col68 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_704), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_703), -->
                         <!--     column_alias='metric_time__month',                 -->
                         <!--   )                                                    -->
                         <!-- col69 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_705), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_704), -->
                         <!--     column_alias='metric_time__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col70 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_706), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_705), -->
                         <!--     column_alias='metric_time__year',                  -->
                         <!--   )                                                    -->
                         <!-- col71 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_707), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_706), -->
                         <!--     column_alias='metric_time__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col72 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_708), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_707), -->
                         <!--     column_alias='metric_time__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col73 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_709), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_708), -->
                         <!--     column_alias='metric_time__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col74 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_710), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_709), -->
                         <!--     column_alias='metric_time__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col75 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_711), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_710), -->
                         <!--     column_alias='metric_time__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col76 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_712), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_711), -->
                         <!--     column_alias='metric_time__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col77 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_713), column_alias='listing') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_712), column_alias='listing') -->
                         <!-- col78 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_714), column_alias='guest') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_713), column_alias='guest') -->
                         <!-- col79 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_715), column_alias='host') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_714), column_alias='host') -->
                         <!-- col80 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_716), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_715), -->
                         <!--     column_alias='booking__listing',                   -->
                         <!--   )                                                    -->
                         <!-- col81 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_717), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_716), -->
                         <!--     column_alias='booking__guest',                     -->
                         <!--   )                                                    -->
                         <!-- col82 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_718), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_717), -->
                         <!--     column_alias='booking__host',                      -->
                         <!--   )                                                    -->
                         <!-- col83 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
                         <!--     column_alias='is_instant',                         -->
                         <!--   )                                                    -->
                         <!-- col84 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
                         <!--     column_alias='booking__is_instant',                -->
                         <!--   )                                                    -->
                         <!-- col85 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
                         <!--     column_alias='booking_payments',                   -->
                         <!--   )                                                    -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0.sql
@@ -218,18 +218,18 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC(time_spine_src_0.ds, day) AS ds__day
-            , DATE_TRUNC(time_spine_src_0.ds, isoweek) AS ds__week
-            , DATE_TRUNC(time_spine_src_0.ds, month) AS ds__month
-            , DATE_TRUNC(time_spine_src_0.ds, quarter) AS ds__quarter
-            , DATE_TRUNC(time_spine_src_0.ds, year) AS ds__year
-            , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-            , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-            , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-            , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-            , IF(EXTRACT(dayofweek FROM time_spine_src_0.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_0.ds) - 1) AS ds__extract_dow
-            , EXTRACT(dayofyear FROM time_spine_src_0.ds) AS ds__extract_doy
-          FROM ***************************.mf_time_spine time_spine_src_0
+            DATE_TRUNC(time_spine_src_28000.ds, day) AS ds__day
+            , DATE_TRUNC(time_spine_src_28000.ds, isoweek) AS ds__week
+            , DATE_TRUNC(time_spine_src_28000.ds, month) AS ds__month
+            , DATE_TRUNC(time_spine_src_28000.ds, quarter) AS ds__quarter
+            , DATE_TRUNC(time_spine_src_28000.ds, year) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+            , IF(EXTRACT(dayofweek FROM time_spine_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_28000.ds) - 1) AS ds__extract_dow
+            , EXTRACT(dayofyear FROM time_spine_src_28000.ds) AS ds__extract_doy
+          FROM ***************************.mf_time_spine time_spine_src_28000
         ) subq_1
       ) subq_2
     ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -2,17 +2,17 @@
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC(time_spine_src_0.ds, day) AS metric_time__day
+  DATE_TRUNC(time_spine_src_28000.ds, day) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
-WHERE DATE_TRUNC(time_spine_src_0.ds, day) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE DATE_TRUNC(time_spine_src_28000.ds, day) BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
   metric_time__day
   , listing__is_lux_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC(time_spine_src_0.ds, day) AS ds__day
-      , DATE_TRUNC(time_spine_src_0.ds, isoweek) AS ds__week
-      , DATE_TRUNC(time_spine_src_0.ds, month) AS ds__month
-      , DATE_TRUNC(time_spine_src_0.ds, quarter) AS ds__quarter
-      , DATE_TRUNC(time_spine_src_0.ds, year) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , IF(EXTRACT(dayofweek FROM time_spine_src_0.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_0.ds) - 1) AS ds__extract_dow
-      , EXTRACT(dayofyear FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC(time_spine_src_28000.ds, day) AS ds__day
+      , DATE_TRUNC(time_spine_src_28000.ds, isoweek) AS ds__week
+      , DATE_TRUNC(time_spine_src_28000.ds, month) AS ds__month
+      , DATE_TRUNC(time_spine_src_28000.ds, quarter) AS ds__quarter
+      , DATE_TRUNC(time_spine_src_28000.ds, year) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , IF(EXTRACT(dayofweek FROM time_spine_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_28000.ds) - 1) AS ds__extract_dow
+      , EXTRACT(dayofyear FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_only__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
   DATE_TRUNC(ds, day) AS metric_time__day
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   metric_time__day

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_quarter_alone__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_quarter_alone__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC(time_spine_src_0.ds, day) AS ds__day
-      , DATE_TRUNC(time_spine_src_0.ds, isoweek) AS ds__week
-      , DATE_TRUNC(time_spine_src_0.ds, month) AS ds__month
-      , DATE_TRUNC(time_spine_src_0.ds, quarter) AS ds__quarter
-      , DATE_TRUNC(time_spine_src_0.ds, year) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , IF(EXTRACT(dayofweek FROM time_spine_src_0.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_0.ds) - 1) AS ds__extract_dow
-      , EXTRACT(dayofyear FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC(time_spine_src_28000.ds, day) AS ds__day
+      , DATE_TRUNC(time_spine_src_28000.ds, isoweek) AS ds__week
+      , DATE_TRUNC(time_spine_src_28000.ds, month) AS ds__month
+      , DATE_TRUNC(time_spine_src_28000.ds, quarter) AS ds__quarter
+      , DATE_TRUNC(time_spine_src_28000.ds, year) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , IF(EXTRACT(dayofweek FROM time_spine_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_28000.ds) - 1) AS ds__extract_dow
+      , EXTRACT(dayofyear FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT
   DATE_TRUNC(ds, quarter) AS metric_time__quarter
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   metric_time__quarter

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0.sql
@@ -157,18 +157,18 @@ FROM (
       FROM (
         -- Time Spine
         SELECT
-          DATE_TRUNC(time_spine_src_0.ds, day) AS ds__day
-          , DATE_TRUNC(time_spine_src_0.ds, isoweek) AS ds__week
-          , DATE_TRUNC(time_spine_src_0.ds, month) AS ds__month
-          , DATE_TRUNC(time_spine_src_0.ds, quarter) AS ds__quarter
-          , DATE_TRUNC(time_spine_src_0.ds, year) AS ds__year
-          , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-          , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-          , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-          , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-          , IF(EXTRACT(dayofweek FROM time_spine_src_0.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_0.ds) - 1) AS ds__extract_dow
-          , EXTRACT(dayofyear FROM time_spine_src_0.ds) AS ds__extract_doy
-        FROM ***************************.mf_time_spine time_spine_src_0
+          DATE_TRUNC(time_spine_src_28000.ds, day) AS ds__day
+          , DATE_TRUNC(time_spine_src_28000.ds, isoweek) AS ds__week
+          , DATE_TRUNC(time_spine_src_28000.ds, month) AS ds__month
+          , DATE_TRUNC(time_spine_src_28000.ds, quarter) AS ds__quarter
+          , DATE_TRUNC(time_spine_src_28000.ds, year) AS ds__year
+          , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+          , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+          , IF(EXTRACT(dayofweek FROM time_spine_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_28000.ds) - 1) AS ds__extract_dow
+          , EXTRACT(dayofyear FROM time_spine_src_28000.ds) AS ds__extract_doy
+        FROM ***************************.mf_time_spine time_spine_src_28000
       ) subq_1
     ) subq_2
   ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -1,12 +1,12 @@
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC(time_spine_src_0.ds, day) AS metric_time__day
+  DATE_TRUNC(time_spine_src_28000.ds, day) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0.sql
@@ -218,18 +218,18 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-            , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-            , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-            , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-            , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-            , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-            , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-            , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-            , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-            , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_0.ds) AS ds__extract_dow
-            , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-          FROM ***************************.mf_time_spine time_spine_src_0
+            DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_28000.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+          FROM ***************************.mf_time_spine time_spine_src_28000
         ) subq_1
       ) subq_2
     ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -2,18 +2,18 @@
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
-WHERE DATE_TRUNC('day', time_spine_src_0.ds) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE DATE_TRUNC('day', time_spine_src_28000.ds) BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_0.ds) AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_28000.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_only__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
   DATE_TRUNC('day', ds) AS metric_time__day
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('day', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_quarter_alone__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_quarter_alone__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_0.ds) AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_28000.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('quarter', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0.sql
@@ -157,18 +157,18 @@ FROM (
       FROM (
         -- Time Spine
         SELECT
-          DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-          , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-          , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-          , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-          , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-          , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-          , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-          , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-          , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-          , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_0.ds) AS ds__extract_dow
-          , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-        FROM ***************************.mf_time_spine time_spine_src_0
+          DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+          , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+          , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+          , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+          , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+          , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+          , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+          , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_28000.ds) AS ds__extract_dow
+          , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+        FROM ***************************.mf_time_spine time_spine_src_28000
       ) subq_1
     ) subq_2
   ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -1,17 +1,17 @@
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0.sql
@@ -218,18 +218,18 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-            , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-            , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-            , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-            , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-            , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-            , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-            , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-            , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-            , EXTRACT(isodow FROM time_spine_src_0.ds) AS ds__extract_dow
-            , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-          FROM ***************************.mf_time_spine time_spine_src_0
+            DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+            , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+          FROM ***************************.mf_time_spine time_spine_src_28000
         ) subq_1
       ) subq_2
     ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -2,18 +2,18 @@
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
-WHERE DATE_TRUNC('day', time_spine_src_0.ds) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE DATE_TRUNC('day', time_spine_src_28000.ds) BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , EXTRACT(isodow FROM time_spine_src_0.ds) AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_only__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
   DATE_TRUNC('day', ds) AS metric_time__day
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('day', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_quarter_alone__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_quarter_alone__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , EXTRACT(isodow FROM time_spine_src_0.ds) AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('quarter', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0.sql
@@ -157,18 +157,18 @@ FROM (
       FROM (
         -- Time Spine
         SELECT
-          DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-          , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-          , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-          , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-          , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-          , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-          , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-          , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-          , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-          , EXTRACT(isodow FROM time_spine_src_0.ds) AS ds__extract_dow
-          , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-        FROM ***************************.mf_time_spine time_spine_src_0
+          DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+          , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+          , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+          , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+          , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+          , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+          , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+          , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+          , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+        FROM ***************************.mf_time_spine time_spine_src_28000
       ) subq_1
     ) subq_2
   ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -1,17 +1,17 @@
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0.sql
@@ -218,18 +218,18 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-            , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-            , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-            , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-            , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-            , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-            , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-            , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-            , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-            , EXTRACT(isodow FROM time_spine_src_0.ds) AS ds__extract_dow
-            , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-          FROM ***************************.mf_time_spine time_spine_src_0
+            DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+            , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+          FROM ***************************.mf_time_spine time_spine_src_28000
         ) subq_1
       ) subq_2
     ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -2,18 +2,18 @@
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
-WHERE DATE_TRUNC('day', time_spine_src_0.ds) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE DATE_TRUNC('day', time_spine_src_28000.ds) BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , EXTRACT(isodow FROM time_spine_src_0.ds) AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_only__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
   DATE_TRUNC('day', ds) AS metric_time__day
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('day', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_quarter_alone__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_quarter_alone__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , EXTRACT(isodow FROM time_spine_src_0.ds) AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('quarter', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0.sql
@@ -157,18 +157,18 @@ FROM (
       FROM (
         -- Time Spine
         SELECT
-          DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-          , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-          , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-          , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-          , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-          , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-          , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-          , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-          , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-          , EXTRACT(isodow FROM time_spine_src_0.ds) AS ds__extract_dow
-          , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-        FROM ***************************.mf_time_spine time_spine_src_0
+          DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+          , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+          , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+          , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+          , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+          , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+          , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+          , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+          , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+        FROM ***************************.mf_time_spine time_spine_src_28000
       ) subq_1
     ) subq_2
   ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -1,17 +1,17 @@
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0.sql
@@ -218,18 +218,18 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-            , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-            , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-            , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-            , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-            , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-            , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-            , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-            , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-            , CASE WHEN EXTRACT(dow FROM time_spine_src_0.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_0.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_0.ds) END AS ds__extract_dow
-            , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-          FROM ***************************.mf_time_spine time_spine_src_0
+            DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM time_spine_src_28000.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_28000.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_28000.ds) END AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+          FROM ***************************.mf_time_spine time_spine_src_28000
         ) subq_1
       ) subq_2
     ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -2,18 +2,18 @@
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
-WHERE DATE_TRUNC('day', time_spine_src_0.ds) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE DATE_TRUNC('day', time_spine_src_28000.ds) BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , CASE WHEN EXTRACT(dow FROM time_spine_src_0.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_0.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_0.ds) END AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , CASE WHEN EXTRACT(dow FROM time_spine_src_28000.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_28000.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_28000.ds) END AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_only__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
   DATE_TRUNC('day', ds) AS metric_time__day
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('day', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_quarter_alone__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_quarter_alone__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , CASE WHEN EXTRACT(dow FROM time_spine_src_0.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_0.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_0.ds) END AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , CASE WHEN EXTRACT(dow FROM time_spine_src_28000.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_28000.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_28000.ds) END AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('quarter', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0.sql
@@ -157,18 +157,18 @@ FROM (
       FROM (
         -- Time Spine
         SELECT
-          DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-          , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-          , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-          , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-          , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-          , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-          , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-          , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-          , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-          , CASE WHEN EXTRACT(dow FROM time_spine_src_0.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_0.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_0.ds) END AS ds__extract_dow
-          , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-        FROM ***************************.mf_time_spine time_spine_src_0
+          DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+          , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+          , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+          , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+          , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+          , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+          , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+          , CASE WHEN EXTRACT(dow FROM time_spine_src_28000.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_28000.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_28000.ds) END AS ds__extract_dow
+          , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+        FROM ***************************.mf_time_spine time_spine_src_28000
       ) subq_1
     ) subq_2
   ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -1,17 +1,17 @@
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0.sql
@@ -218,18 +218,18 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-            , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-            , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-            , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-            , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-            , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-            , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-            , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-            , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-            , EXTRACT(dayofweekiso FROM time_spine_src_0.ds) AS ds__extract_dow
-            , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-          FROM ***************************.mf_time_spine time_spine_src_0
+            DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+            , EXTRACT(dayofweekiso FROM time_spine_src_28000.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+          FROM ***************************.mf_time_spine time_spine_src_28000
         ) subq_1
       ) subq_2
     ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -2,18 +2,18 @@
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
-WHERE DATE_TRUNC('day', time_spine_src_0.ds) BETWEEN '2020-01-01' AND '2020-01-03'
+WHERE DATE_TRUNC('day', time_spine_src_28000.ds) BETWEEN '2020-01-01' AND '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , EXTRACT(dayofweekiso FROM time_spine_src_0.ds) AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , EXTRACT(dayofweekiso FROM time_spine_src_28000.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_only__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
   DATE_TRUNC('day', ds) AS metric_time__day
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('day', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_quarter_alone__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_quarter_alone__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , EXTRACT(dayofweekiso FROM time_spine_src_0.ds) AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , EXTRACT(dayofweekiso FROM time_spine_src_28000.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('quarter', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0.sql
@@ -157,18 +157,18 @@ FROM (
       FROM (
         -- Time Spine
         SELECT
-          DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-          , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-          , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-          , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-          , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-          , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-          , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-          , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-          , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-          , EXTRACT(dayofweekiso FROM time_spine_src_0.ds) AS ds__extract_dow
-          , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-        FROM ***************************.mf_time_spine time_spine_src_0
+          DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+          , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+          , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+          , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+          , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+          , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+          , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+          , EXTRACT(dayofweekiso FROM time_spine_src_28000.ds) AS ds__extract_dow
+          , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+        FROM ***************************.mf_time_spine time_spine_src_28000
       ) subq_1
     ) subq_2
   ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -1,17 +1,17 @@
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0.sql
@@ -218,18 +218,18 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-            , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-            , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-            , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-            , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-            , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-            , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-            , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-            , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-            , EXTRACT(DAY_OF_WEEK FROM time_spine_src_0.ds) AS ds__extract_dow
-            , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-          FROM ***************************.mf_time_spine time_spine_src_0
+            DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM time_spine_src_28000.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+          FROM ***************************.mf_time_spine time_spine_src_28000
         ) subq_1
       ) subq_2
     ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0_optimized.sql
@@ -2,18 +2,18 @@
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
-WHERE DATE_TRUNC('day', time_spine_src_0.ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-03'
+WHERE DATE_TRUNC('day', time_spine_src_28000.ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-03'
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , EXTRACT(DAY_OF_WEEK FROM time_spine_src_0.ds) AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , EXTRACT(DAY_OF_WEEK FROM time_spine_src_28000.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_only__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__day',]
 SELECT
   DATE_TRUNC('day', ds) AS metric_time__day
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('day', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_quarter_alone__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_quarter_alone__plan0.sql
@@ -29,18 +29,18 @@ FROM (
   FROM (
     -- Time Spine
     SELECT
-      DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-      , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-      , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-      , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-      , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-      , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-      , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-      , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-      , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-      , EXTRACT(DAY_OF_WEEK FROM time_spine_src_0.ds) AS ds__extract_dow
-      , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-    FROM ***************************.mf_time_spine time_spine_src_0
+      DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+      , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+      , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+      , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+      , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+      , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+      , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+      , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+      , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+      , EXTRACT(DAY_OF_WEEK FROM time_spine_src_28000.ds) AS ds__extract_dow
+      , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+    FROM ***************************.mf_time_spine time_spine_src_28000
   ) subq_0
 ) subq_1
 GROUP BY

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_quarter_alone__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_quarter_alone__plan0_optimized.sql
@@ -3,6 +3,6 @@
 -- Pass Only Elements: ['metric_time__quarter',]
 SELECT
   DATE_TRUNC('quarter', ds) AS metric_time__quarter
-FROM ***************************.mf_time_spine time_spine_src_0
+FROM ***************************.mf_time_spine time_spine_src_28000
 GROUP BY
   DATE_TRUNC('quarter', ds)

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0.sql
@@ -157,18 +157,18 @@ FROM (
       FROM (
         -- Time Spine
         SELECT
-          DATE_TRUNC('day', time_spine_src_0.ds) AS ds__day
-          , DATE_TRUNC('week', time_spine_src_0.ds) AS ds__week
-          , DATE_TRUNC('month', time_spine_src_0.ds) AS ds__month
-          , DATE_TRUNC('quarter', time_spine_src_0.ds) AS ds__quarter
-          , DATE_TRUNC('year', time_spine_src_0.ds) AS ds__year
-          , EXTRACT(year FROM time_spine_src_0.ds) AS ds__extract_year
-          , EXTRACT(quarter FROM time_spine_src_0.ds) AS ds__extract_quarter
-          , EXTRACT(month FROM time_spine_src_0.ds) AS ds__extract_month
-          , EXTRACT(day FROM time_spine_src_0.ds) AS ds__extract_day
-          , EXTRACT(DAY_OF_WEEK FROM time_spine_src_0.ds) AS ds__extract_dow
-          , EXTRACT(doy FROM time_spine_src_0.ds) AS ds__extract_doy
-        FROM ***************************.mf_time_spine time_spine_src_0
+          DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+          , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+          , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+          , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+          , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+          , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+          , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+          , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+          , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+          , EXTRACT(DAY_OF_WEEK FROM time_spine_src_28000.ds) AS ds__extract_dow
+          , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+        FROM ***************************.mf_time_spine time_spine_src_28000
       ) subq_1
     ) subq_2
   ) subq_3

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0_optimized.sql
@@ -1,17 +1,17 @@
 -- Join Standard Outputs
 -- Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']
 SELECT
-  DATE_TRUNC('day', time_spine_src_0.ds) AS metric_time__day
+  DATE_TRUNC('day', time_spine_src_28000.ds) AS metric_time__day
   , listings_latest_src_28005.is_lux AS listing__is_lux_latest
   , users_latest_src_28009.home_state_latest AS user__home_state_latest
 FROM ***************************.dim_listings_latest listings_latest_src_28005
 CROSS JOIN
-  ***************************.mf_time_spine time_spine_src_0
+  ***************************.mf_time_spine time_spine_src_28000
 FULL OUTER JOIN
   ***************************.dim_users_latest users_latest_src_28009
 ON
   listings_latest_src_28005.user_id = users_latest_src_28009.user_id
 GROUP BY
-  DATE_TRUNC('day', time_spine_src_0.ds)
+  DATE_TRUNC('day', time_spine_src_28000.ds)
   , listings_latest_src_28005.is_lux
   , users_latest_src_28009.home_state_latest

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
@@ -2,443 +2,443 @@
     <SqlSelectStatementNode>
         <!-- description =                                                                                     -->
         <!--   "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']" -->
-        <!-- node_id = NodeId(id_str='ss_9') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_214), column_alias='metric_time__day') -->
+        <!-- node_id = NodeId(id_str='ss_8') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_213), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_212), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_211), column_alias='listing__is_lux_latest') -->
         <!-- col2 =                                                                                                       -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_213), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_212), column_alias='user__home_state_latest') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
         <!-- group_by0 =                                                                                           -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_214), column_alias='metric_time__day') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_213), column_alias='metric_time__day') -->
         <!-- group_by1 =                                                                                                 -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_212), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_211), column_alias='listing__is_lux_latest') -->
         <!-- group_by2 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_213), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_212), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]' -->
-            <!-- node_id = NodeId(id_str='ss_8') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_164), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_165), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_166), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_167), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_168), column_alias='ds__year') -->
+            <!-- node_id = NodeId(id_str='ss_7') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_163), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_164), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_165), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_166), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_167), column_alias='ds__year') -->
             <!-- col5 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_169), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_168), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                   -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_170), column_alias='ds__extract_quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_169), column_alias='ds__extract_quarter') -->
             <!-- col7 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_171), column_alias='ds__extract_month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_170), column_alias='ds__extract_month') -->
             <!-- col8 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_172), column_alias='ds__extract_day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_171), column_alias='ds__extract_day') -->
             <!-- col9 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_173), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_172), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_174), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_173), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_175), column_alias='created_at__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_174), column_alias='created_at__day') -->
             <!-- col12 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_176), column_alias='created_at__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_175), column_alias='created_at__week') -->
             <!-- col13 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_177), column_alias='created_at__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_176), column_alias='created_at__month') -->
             <!-- col14 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_178), column_alias='created_at__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_177), column_alias='created_at__quarter') -->
             <!-- col15 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_179), column_alias='created_at__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_178), column_alias='created_at__year') -->
             <!-- col16 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_180), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_179), -->
             <!--     column_alias='created_at__extract_year',           -->
             <!--   )                                                    -->
             <!-- col17 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_181), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_180), -->
             <!--     column_alias='created_at__extract_quarter',        -->
             <!--   )                                                    -->
             <!-- col18 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_182), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_181), -->
             <!--     column_alias='created_at__extract_month',          -->
             <!--   )                                                    -->
             <!-- col19 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_183), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_182), -->
             <!--     column_alias='created_at__extract_day',            -->
             <!--   )                                                    -->
             <!-- col20 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_184), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_183), -->
             <!--     column_alias='created_at__extract_dow',            -->
             <!--   )                                                    -->
             <!-- col21 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_185), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_184), -->
             <!--     column_alias='created_at__extract_doy',            -->
             <!--   )                                                    -->
             <!-- col22 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_186), column_alias='listing__ds__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_185), column_alias='listing__ds__day') -->
             <!-- col23 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_187), column_alias='listing__ds__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_186), column_alias='listing__ds__week') -->
             <!-- col24 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_188), column_alias='listing__ds__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_187), column_alias='listing__ds__month') -->
             <!-- col25 =                                                                                                   -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_189), column_alias='listing__ds__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_188), column_alias='listing__ds__quarter') -->
             <!-- col26 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_190), column_alias='listing__ds__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_189), column_alias='listing__ds__year') -->
             <!-- col27 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_191), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_190), -->
             <!--     column_alias='listing__ds__extract_year',          -->
             <!--   )                                                    -->
             <!-- col28 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_192), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_191), -->
             <!--     column_alias='listing__ds__extract_quarter',       -->
             <!--   )                                                    -->
             <!-- col29 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_193), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_192), -->
             <!--     column_alias='listing__ds__extract_month',         -->
             <!--   )                                                    -->
             <!-- col30 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_194), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_193), -->
             <!--     column_alias='listing__ds__extract_day',           -->
             <!--   )                                                    -->
             <!-- col31 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_195), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_194), -->
             <!--     column_alias='listing__ds__extract_dow',           -->
             <!--   )                                                    -->
             <!-- col32 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_196), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_195), -->
             <!--     column_alias='listing__ds__extract_doy',           -->
             <!--   )                                                    -->
             <!-- col33 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_197), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_196), -->
             <!--     column_alias='listing__created_at__day',           -->
             <!--   )                                                    -->
             <!-- col34 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_198), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_197), -->
             <!--     column_alias='listing__created_at__week',          -->
             <!--   )                                                    -->
             <!-- col35 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_199), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_198), -->
             <!--     column_alias='listing__created_at__month',         -->
             <!--   )                                                    -->
             <!-- col36 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_200), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_199), -->
             <!--     column_alias='listing__created_at__quarter',       -->
             <!--   )                                                    -->
             <!-- col37 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_201), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_200), -->
             <!--     column_alias='listing__created_at__year',          -->
             <!--   )                                                    -->
             <!-- col38 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_202), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_201), -->
             <!--     column_alias='listing__created_at__extract_year',  -->
             <!--   )                                                    -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_203),   -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_202),   -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_204), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_203), -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_205), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_204), -->
             <!--     column_alias='listing__created_at__extract_day',   -->
             <!--   )                                                    -->
             <!-- col42 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_206), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_205), -->
             <!--     column_alias='listing__created_at__extract_dow',   -->
             <!--   )                                                    -->
             <!-- col43 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_207), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_206), -->
             <!--     column_alias='listing__created_at__extract_doy',   -->
             <!--   )                                                    -->
             <!-- col44 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_208), column_alias='metric_time__day') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_209), column_alias='listing') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_210), column_alias='user') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_207), column_alias='metric_time__day') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_208), column_alias='listing') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_209), column_alias='user') -->
             <!-- col47 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_211), column_alias='listing__user') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_210), column_alias='listing__user') -->
             <!-- col48 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_157), column_alias='country_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_156), column_alias='country_latest') -->
             <!-- col49 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_158), column_alias='is_lux_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_157), column_alias='is_lux_latest') -->
             <!-- col50 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_159), column_alias='capacity_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_158), column_alias='capacity_latest') -->
             <!-- col51 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_160), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_159), -->
             <!--     column_alias='listing__country_latest',            -->
             <!--   )                                                    -->
             <!-- col52 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_161), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_160), -->
             <!--     column_alias='listing__is_lux_latest',             -->
             <!--   )                                                    -->
             <!-- col53 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_161), -->
             <!--     column_alias='listing__capacity_latest',           -->
             <!--   )                                                    -->
             <!-- col54 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_163), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
             <!--     column_alias='user__home_state_latest',            -->
             <!--   )                                                    -->
-            <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_154), column_alias='listings') -->
+            <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_153), column_alias='listings') -->
             <!-- col56 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_155), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_154), column_alias='largest_listing') -->
             <!-- col57 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_156), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_155), column_alias='smallest_listing') -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
             <!-- where = SqlBetweenExpression(node_id=betw_1) -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_7') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='ds__month') -->
+                <!-- node_id = NodeId(id_str='ss_6') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='ds__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='ds__week') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='ds__month') -->
                 <!-- col3 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='ds__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='ds__quarter') -->
+                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='ds__year') -->
                 <!-- col5 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_109), column_alias='ds__extract_year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='ds__extract_year') -->
                 <!-- col6 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
                 <!--     column_alias='ds__extract_quarter',                -->
                 <!--   )                                                    -->
                 <!-- col7 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
                 <!--     column_alias='ds__extract_month',                  -->
                 <!--   )                                                    -->
                 <!-- col8 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_112), column_alias='ds__extract_day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_111), column_alias='ds__extract_day') -->
                 <!-- col9 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_113), column_alias='ds__extract_dow') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_112), column_alias='ds__extract_dow') -->
                 <!-- col10 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_114), column_alias='ds__extract_doy') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_113), column_alias='ds__extract_doy') -->
                 <!-- col11 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_115), column_alias='created_at__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_114), column_alias='created_at__day') -->
                 <!-- col12 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_116), column_alias='created_at__week') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_115), column_alias='created_at__week') -->
                 <!-- col13 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_116), -->
                 <!--     column_alias='created_at__month',                  -->
                 <!--   )                                                    -->
                 <!-- col14 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_118), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
                 <!--     column_alias='created_at__quarter',                -->
                 <!--   )                                                    -->
                 <!-- col15 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='created_at__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='created_at__year') -->
                 <!-- col16 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_119), -->
                 <!--     column_alias='created_at__extract_year',           -->
                 <!--   )                                                    -->
                 <!-- col17 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
                 <!--     column_alias='created_at__extract_quarter',        -->
                 <!--   )                                                    -->
                 <!-- col18 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
                 <!--     column_alias='created_at__extract_month',          -->
                 <!--   )                                                    -->
                 <!-- col19 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
                 <!--     column_alias='created_at__extract_day',            -->
                 <!--   )                                                    -->
                 <!-- col20 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
                 <!--     column_alias='created_at__extract_dow',            -->
                 <!--   )                                                    -->
                 <!-- col21 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
                 <!--     column_alias='created_at__extract_doy',            -->
                 <!--   )                                                    -->
                 <!-- col22 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_126), column_alias='listing__ds__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_125), column_alias='listing__ds__day') -->
                 <!-- col23 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
                 <!--     column_alias='listing__ds__week',                  -->
                 <!--   )                                                    -->
                 <!-- col24 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
                 <!--     column_alias='listing__ds__month',                 -->
                 <!--   )                                                    -->
                 <!-- col25 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
                 <!--     column_alias='listing__ds__quarter',               -->
                 <!--   )                                                    -->
                 <!-- col26 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
                 <!--     column_alias='listing__ds__year',                  -->
                 <!--   )                                                    -->
                 <!-- col27 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
                 <!--     column_alias='listing__ds__extract_year',          -->
                 <!--   )                                                    -->
                 <!-- col28 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_132), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
                 <!--     column_alias='listing__ds__extract_quarter',       -->
                 <!--   )                                                    -->
                 <!-- col29 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_132), -->
                 <!--     column_alias='listing__ds__extract_month',         -->
                 <!--   )                                                    -->
                 <!-- col30 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
                 <!--     column_alias='listing__ds__extract_day',           -->
                 <!--   )                                                    -->
                 <!-- col31 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
                 <!--     column_alias='listing__ds__extract_dow',           -->
                 <!--   )                                                    -->
                 <!-- col32 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
                 <!--     column_alias='listing__ds__extract_doy',           -->
                 <!--   )                                                    -->
                 <!-- col33 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
                 <!--     column_alias='listing__created_at__day',           -->
                 <!--   )                                                    -->
                 <!-- col34 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
                 <!--     column_alias='listing__created_at__week',          -->
                 <!--   )                                                    -->
                 <!-- col35 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
                 <!--     column_alias='listing__created_at__month',         -->
                 <!--   )                                                    -->
                 <!-- col36 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
                 <!--     column_alias='listing__created_at__quarter',       -->
                 <!--   )                                                    -->
                 <!-- col37 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_141), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
                 <!--     column_alias='listing__created_at__year',          -->
                 <!--   )                                                    -->
                 <!-- col38 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_142), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_141), -->
                 <!--     column_alias='listing__created_at__extract_year',  -->
                 <!--   )                                                    -->
                 <!-- col39 =                                                  -->
                 <!--   SqlSelectColumn(                                       -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_143),   -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_142),   -->
                 <!--     column_alias='listing__created_at__extract_quarter', -->
                 <!--   )                                                      -->
                 <!-- col40 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_144), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_143), -->
                 <!--     column_alias='listing__created_at__extract_month', -->
                 <!--   )                                                    -->
                 <!-- col41 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_144), -->
                 <!--     column_alias='listing__created_at__extract_day',   -->
                 <!--   )                                                    -->
                 <!-- col42 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
                 <!--     column_alias='listing__created_at__extract_dow',   -->
                 <!--   )                                                    -->
                 <!-- col43 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_147), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
                 <!--     column_alias='listing__created_at__extract_doy',   -->
                 <!--   )                                                    -->
                 <!-- col44 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_151), column_alias='metric_time__day') -->
-                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_148), column_alias='listing') -->
-                <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_149), column_alias='user') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_150), column_alias='metric_time__day') -->
+                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_147), column_alias='listing') -->
+                <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_148), column_alias='user') -->
                 <!-- col47 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_150), column_alias='listing__user') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_149), column_alias='listing__user') -->
                 <!-- col48 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='country_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='country_latest') -->
                 <!-- col49 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_99), column_alias='is_lux_latest') -->
-                <!-- col50 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_100), column_alias='capacity_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='is_lux_latest') -->
+                <!-- col50 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_99), column_alias='capacity_latest') -->
                 <!-- col51 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                 <!--     column_alias='listing__country_latest',            -->
                 <!--   )                                                    -->
                 <!-- col52 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
                 <!--     column_alias='listing__is_lux_latest',             -->
                 <!--   )                                                    -->
                 <!-- col53 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
                 <!--     column_alias='listing__capacity_latest',           -->
                 <!--   )                                                    -->
                 <!-- col54 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_152), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_151), -->
                 <!--     column_alias='user__home_state_latest',            -->
                 <!--   )                                                    -->
-                <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='listings') -->
+                <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='listings') -->
                 <!-- col56 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='largest_listing') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='largest_listing') -->
                 <!-- col57 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='smallest_listing') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='smallest_listing') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
                 <!-- join_0 =                                               -->
                 <!--   SqlJoinDescription(                                  -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_5), -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_4), -->
                 <!--     right_source_alias='subq_3',                       -->
                 <!--     join_type=CROSS_JOIN,                              -->
                 <!--   )                                                    -->
                 <!-- join_1 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_6),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_5),   -->
                 <!--     right_source_alias='subq_5',                         -->
                 <!--     join_type=FULL_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -687,168 +687,174 @@
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-                    <!-- node_id = NodeId(id_str='ss_5') -->
+                    <!-- node_id = NodeId(id_str='ss_4') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
                     <!--     column_alias='metric_time__day',                  -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_4') -->
+                        <!-- node_id = NodeId(id_str='ss_3') -->
                         <!-- col0 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_68), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_67), column_alias='ds__day') -->
                         <!-- col1 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_69), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_68), column_alias='ds__week') -->
                         <!-- col2 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_70), column_alias='ds__month') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_69), column_alias='ds__month') -->
                         <!-- col3 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
                         <!--     column_alias='ds__quarter',                       -->
                         <!--   )                                                   -->
                         <!-- col4 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='ds__year') -->
                         <!-- col5 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
                         <!--     column_alias='ds__extract_year',                  -->
                         <!--   )                                                   -->
                         <!-- col6 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
                         <!--     column_alias='ds__extract_quarter',               -->
                         <!--   )                                                   -->
                         <!-- col7 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
                         <!--     column_alias='ds__extract_month',                 -->
                         <!--   )                                                   -->
                         <!-- col8 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
                         <!--     column_alias='ds__extract_day',                   -->
                         <!--   )                                                   -->
                         <!-- col9 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
                         <!--     column_alias='ds__extract_dow',                   -->
                         <!--   )                                                   -->
                         <!-- col10 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
                         <!--     column_alias='ds__extract_doy',                   -->
                         <!--   )                                                   -->
                         <!-- col11 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
                         <!--     column_alias='metric_time__day',                  -->
                         <!--   )                                                   -->
                         <!-- col12 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
                         <!--     column_alias='metric_time__week',                 -->
                         <!--   )                                                   -->
                         <!-- col13 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
                         <!--     column_alias='metric_time__month',                -->
                         <!--   )                                                   -->
                         <!-- col14 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
                         <!--     column_alias='metric_time__quarter',              -->
                         <!--   )                                                   -->
                         <!-- col15 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_83), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
                         <!--     column_alias='metric_time__year',                 -->
                         <!--   )                                                   -->
                         <!-- col16 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_83), -->
                         <!--     column_alias='metric_time__extract_year',         -->
                         <!--   )                                                   -->
                         <!-- col17 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
                         <!--     column_alias='metric_time__extract_quarter',      -->
                         <!--   )                                                   -->
                         <!-- col18 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
                         <!--     column_alias='metric_time__extract_month',        -->
                         <!--   )                                                   -->
                         <!-- col19 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
                         <!--     column_alias='metric_time__extract_day',          -->
                         <!--   )                                                   -->
                         <!-- col20 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
                         <!--     column_alias='metric_time__extract_dow',          -->
                         <!--   )                                                   -->
                         <!-- col21 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
                         <!--     column_alias='metric_time__extract_doy',          -->
                         <!--   )                                                   -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28012) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Time Spine' -->
-                            <!-- node_id = NodeId(id_str='ss_0') -->
-                            <!-- col0 =                                                                               -->
-                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_0), column_alias='ds__day') -->
-                            <!-- col1 =                                                                                -->
-                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_1), column_alias='ds__week') -->
-                            <!-- col2 =                                                                                 -->
-                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_2), column_alias='ds__month') -->
-                            <!-- col3 =                                                                                   -->
-                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_3), column_alias='ds__quarter') -->
-                            <!-- col4 =                                                                                -->
-                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_4), column_alias='ds__year') -->
-                            <!-- col5 =                                       -->
-                            <!--   SqlSelectColumn(                           -->
-                            <!--     expr=SqlExtractExpression(node_id=ex_0), -->
-                            <!--     column_alias='ds__extract_year',         -->
-                            <!--   )                                          -->
-                            <!-- col6 =                                       -->
-                            <!--   SqlSelectColumn(                           -->
-                            <!--     expr=SqlExtractExpression(node_id=ex_1), -->
-                            <!--     column_alias='ds__extract_quarter',      -->
-                            <!--   )                                          -->
-                            <!-- col7 =                                       -->
-                            <!--   SqlSelectColumn(                           -->
-                            <!--     expr=SqlExtractExpression(node_id=ex_2), -->
-                            <!--     column_alias='ds__extract_month',        -->
-                            <!--   )                                          -->
-                            <!-- col8 =                                       -->
-                            <!--   SqlSelectColumn(                           -->
-                            <!--     expr=SqlExtractExpression(node_id=ex_3), -->
-                            <!--     column_alias='ds__extract_day',          -->
-                            <!--   )                                          -->
-                            <!-- col9 =                                       -->
-                            <!--   SqlSelectColumn(                           -->
-                            <!--     expr=SqlExtractExpression(node_id=ex_4), -->
-                            <!--     column_alias='ds__extract_dow',          -->
-                            <!--   )                                          -->
-                            <!-- col10 =                                      -->
-                            <!--   SqlSelectColumn(                           -->
-                            <!--     expr=SqlExtractExpression(node_id=ex_5), -->
-                            <!--     column_alias='ds__extract_doy',          -->
-                            <!--   )                                          -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+                            <!-- node_id = NodeId(id_str='ss_28012') -->
+                            <!-- col0 =                                                                                   -->
+                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28170), column_alias='ds__day') -->
+                            <!-- col1 =                                                                                    -->
+                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28171), column_alias='ds__week') -->
+                            <!-- col2 =                                             -->
+                            <!--   SqlSelectColumn(                                 -->
+                            <!--     expr=SqlDateTruncExpression(node_id=dt_28172), -->
+                            <!--     column_alias='ds__month',                      -->
+                            <!--   )                                                -->
+                            <!-- col3 =                                             -->
+                            <!--   SqlSelectColumn(                                 -->
+                            <!--     expr=SqlDateTruncExpression(node_id=dt_28173), -->
+                            <!--     column_alias='ds__quarter',                    -->
+                            <!--   )                                                -->
+                            <!-- col4 =                                                                                    -->
+                            <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28174), column_alias='ds__year') -->
+                            <!-- col5 =                                           -->
+                            <!--   SqlSelectColumn(                               -->
+                            <!--     expr=SqlExtractExpression(node_id=ex_28204), -->
+                            <!--     column_alias='ds__extract_year',             -->
+                            <!--   )                                              -->
+                            <!-- col6 =                                           -->
+                            <!--   SqlSelectColumn(                               -->
+                            <!--     expr=SqlExtractExpression(node_id=ex_28205), -->
+                            <!--     column_alias='ds__extract_quarter',          -->
+                            <!--   )                                              -->
+                            <!-- col7 =                                           -->
+                            <!--   SqlSelectColumn(                               -->
+                            <!--     expr=SqlExtractExpression(node_id=ex_28206), -->
+                            <!--     column_alias='ds__extract_month',            -->
+                            <!--   )                                              -->
+                            <!-- col8 =                                           -->
+                            <!--   SqlSelectColumn(                               -->
+                            <!--     expr=SqlExtractExpression(node_id=ex_28207), -->
+                            <!--     column_alias='ds__extract_day',              -->
+                            <!--   )                                              -->
+                            <!-- col9 =                                           -->
+                            <!--   SqlSelectColumn(                               -->
+                            <!--     expr=SqlExtractExpression(node_id=ex_28208), -->
+                            <!--     column_alias='ds__extract_dow',              -->
+                            <!--   )                                              -->
+                            <!-- col10 =                                          -->
+                            <!--   SqlSelectColumn(                               -->
+                            <!--     expr=SqlExtractExpression(node_id=ex_28209), -->
+                            <!--     column_alias='ds__extract_doy',              -->
+                            <!--   )                                              -->
+                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28012) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlTableFromClauseNode>
                                 <!-- description = 'Read from ***************************.mf_time_spine' -->
-                                <!-- node_id = NodeId(id_str='tfc_0') -->
+                                <!-- node_id = NodeId(id_str='tfc_28012') -->
                                 <!-- table_id = '***************************.mf_time_spine' -->
                             </SqlTableFromClauseNode>
                         </SqlSelectStatementNode>
@@ -856,11 +862,11 @@
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='ss_6') -->
-                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_92), column_alias='user') -->
+                    <!-- node_id = NodeId(id_str='ss_5') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_91), column_alias='user') -->
                     <!-- col1 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
                     <!--     column_alias='home_state_latest',                 -->
                     <!--   )                                                   -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
@@ -1,96 +1,100 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='metric_time__day') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='metric_time__day') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- group_by0 =                                                                                          -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='metric_time__day') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='metric_time__day') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Metric Time Dimension 'ds'" -->
-            <!-- node_id = NodeId(id_str='ss_2') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='ds__year') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='ds__extract_quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='ds__extract_quarter') -->
             <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='ds__extract_month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='ds__extract_month') -->
             <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='ds__extract_day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='ds__extract_day') -->
             <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_33), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_34), column_alias='metric_time__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_33), column_alias='metric_time__day') -->
             <!-- col12 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='metric_time__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_34), column_alias='metric_time__week') -->
             <!-- col13 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='metric_time__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='metric_time__month') -->
             <!-- col14 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='metric_time__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='metric_time__quarter') -->
             <!-- col15 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='metric_time__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='metric_time__year') -->
             <!-- col16 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
             <!--     column_alias='metric_time__extract_year',         -->
             <!--   )                                                   -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
             <!--     column_alias='metric_time__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
             <!--     column_alias='metric_time__extract_month',        -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
             <!--     column_alias='metric_time__extract_day',          -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
             <!--     column_alias='metric_time__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
             <!--     column_alias='metric_time__extract_doy',          -->
             <!--   )                                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_28012) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Time Spine' -->
-                <!-- node_id = NodeId(id_str='ss_0') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_0), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_1), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_2), column_alias='ds__month') -->
-                <!-- col3 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_3), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_4), column_alias='ds__year') -->
-                <!-- col5 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_0), column_alias='ds__extract_year') -->
-                <!-- col6 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_1), column_alias='ds__extract_quarter') -->
-                <!-- col7 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_2), column_alias='ds__extract_month') -->
-                <!-- col8 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_3), column_alias='ds__extract_day') -->
-                <!-- col9 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_4), column_alias='ds__extract_dow') -->
-                <!-- col10 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_5), column_alias='ds__extract_doy') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+                <!-- node_id = NodeId(id_str='ss_28012') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28170), column_alias='ds__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28171), column_alias='ds__week') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28172), column_alias='ds__month') -->
+                <!-- col3 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28173), column_alias='ds__quarter') -->
+                <!-- col4 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28174), column_alias='ds__year') -->
+                <!-- col5 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28204), column_alias='ds__extract_year') -->
+                <!-- col6 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28205), column_alias='ds__extract_quarter') -->
+                <!-- col7 =                                                                                           -->
+                <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28206), column_alias='ds__extract_month') -->
+                <!-- col8 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28207), column_alias='ds__extract_day') -->
+                <!-- col9 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28208), column_alias='ds__extract_dow') -->
+                <!-- col10 =                                                                                        -->
+                <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28209), column_alias='ds__extract_doy') -->
+                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28012) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableFromClauseNode>
                     <!-- description = 'Read from ***************************.mf_time_spine' -->
-                    <!-- node_id = NodeId(id_str='tfc_0') -->
+                    <!-- node_id = NodeId(id_str='tfc_28012') -->
                     <!-- table_id = '***************************.mf_time_spine' -->
                 </SqlTableFromClauseNode>
             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
@@ -1,97 +1,101 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['metric_time__quarter',]" -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 =                                                                                                   -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='metric_time__quarter') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='metric_time__quarter') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- group_by0 =                                                                                              -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='metric_time__quarter') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='metric_time__quarter') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Metric Time Dimension 'ds'" -->
-            <!-- node_id = NodeId(id_str='ss_2') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='ds__year') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='ds__extract_quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='ds__extract_quarter') -->
             <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='ds__extract_month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='ds__extract_month') -->
             <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='ds__extract_day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='ds__extract_day') -->
             <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_33), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_34), column_alias='metric_time__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_33), column_alias='metric_time__day') -->
             <!-- col12 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='metric_time__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_34), column_alias='metric_time__week') -->
             <!-- col13 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='metric_time__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='metric_time__month') -->
             <!-- col14 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='metric_time__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='metric_time__quarter') -->
             <!-- col15 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='metric_time__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='metric_time__year') -->
             <!-- col16 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
             <!--     column_alias='metric_time__extract_year',         -->
             <!--   )                                                   -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
             <!--     column_alias='metric_time__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
             <!--     column_alias='metric_time__extract_month',        -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
             <!--     column_alias='metric_time__extract_day',          -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
             <!--     column_alias='metric_time__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
             <!--     column_alias='metric_time__extract_doy',          -->
             <!--   )                                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_28012) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Time Spine' -->
-                <!-- node_id = NodeId(id_str='ss_0') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_0), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_1), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_2), column_alias='ds__month') -->
-                <!-- col3 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_3), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_4), column_alias='ds__year') -->
-                <!-- col5 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_0), column_alias='ds__extract_year') -->
-                <!-- col6 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_1), column_alias='ds__extract_quarter') -->
-                <!-- col7 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_2), column_alias='ds__extract_month') -->
-                <!-- col8 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_3), column_alias='ds__extract_day') -->
-                <!-- col9 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_4), column_alias='ds__extract_dow') -->
-                <!-- col10 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_5), column_alias='ds__extract_doy') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+                <!-- node_id = NodeId(id_str='ss_28012') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28170), column_alias='ds__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28171), column_alias='ds__week') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28172), column_alias='ds__month') -->
+                <!-- col3 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28173), column_alias='ds__quarter') -->
+                <!-- col4 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28174), column_alias='ds__year') -->
+                <!-- col5 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28204), column_alias='ds__extract_year') -->
+                <!-- col6 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28205), column_alias='ds__extract_quarter') -->
+                <!-- col7 =                                                                                           -->
+                <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28206), column_alias='ds__extract_month') -->
+                <!-- col8 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28207), column_alias='ds__extract_day') -->
+                <!-- col9 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28208), column_alias='ds__extract_dow') -->
+                <!-- col10 =                                                                                        -->
+                <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28209), column_alias='ds__extract_doy') -->
+                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28012) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlTableFromClauseNode>
                     <!-- description = 'Read from ***************************.mf_time_spine' -->
-                    <!-- node_id = NodeId(id_str='tfc_0') -->
+                    <!-- node_id = NodeId(id_str='tfc_28012') -->
                     <!-- table_id = '***************************.mf_time_spine' -->
                 </SqlTableFromClauseNode>
             </SqlSelectStatementNode>

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
@@ -2,222 +2,222 @@
     <SqlSelectStatementNode>
         <!-- description =                                                                                     -->
         <!--   "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']" -->
-        <!-- node_id = NodeId(id_str='ss_6') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_110), column_alias='metric_time__day') -->
+        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_109), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='listing__is_lux_latest') -->
         <!-- col2 =                                                                                                       -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_109), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='user__home_state_latest') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
         <!-- group_by0 =                                                                                           -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_110), column_alias='metric_time__day') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_109), column_alias='metric_time__day') -->
         <!-- group_by1 =                                                                                                 -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='listing__is_lux_latest') -->
         <!-- group_by2 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_109), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_5') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='ds__year') -->
+            <!-- node_id = NodeId(id_str='ss_4') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_64), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_65), column_alias='ds__extract_quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_64), column_alias='ds__extract_quarter') -->
             <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_66), column_alias='ds__extract_month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_65), column_alias='ds__extract_month') -->
             <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_67), column_alias='ds__extract_day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_66), column_alias='ds__extract_day') -->
             <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_68), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_67), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_69), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_68), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_70), column_alias='created_at__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_69), column_alias='created_at__day') -->
             <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='created_at__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_70), column_alias='created_at__week') -->
             <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='created_at__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='created_at__month') -->
             <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='created_at__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='created_at__quarter') -->
             <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_74), column_alias='created_at__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='created_at__year') -->
             <!-- col16 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
             <!--     column_alias='created_at__extract_year',          -->
             <!--   )                                                   -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
             <!--     column_alias='created_at__extract_quarter',       -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
             <!--     column_alias='created_at__extract_month',         -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
             <!--     column_alias='created_at__extract_day',           -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
             <!--     column_alias='created_at__extract_dow',           -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
             <!--     column_alias='created_at__extract_doy',           -->
             <!--   )                                                   -->
             <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__ds__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='listing__ds__day') -->
             <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='listing__ds__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__ds__week') -->
             <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__ds__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='listing__ds__month') -->
             <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='listing__ds__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__ds__quarter') -->
             <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='listing__ds__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='listing__ds__year') -->
             <!-- col27 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
             <!--     column_alias='listing__ds__extract_year',         -->
             <!--   )                                                   -->
             <!-- col28 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
             <!--     column_alias='listing__ds__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col29 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
             <!--     column_alias='listing__ds__extract_month',        -->
             <!--   )                                                   -->
             <!-- col30 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
             <!--     column_alias='listing__ds__extract_day',          -->
             <!--   )                                                   -->
             <!-- col31 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
             <!--     column_alias='listing__ds__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col32 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
             <!--     column_alias='listing__ds__extract_doy',          -->
             <!--   )                                                   -->
             <!-- col33 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
             <!--     column_alias='listing__created_at__day',          -->
             <!--   )                                                   -->
             <!-- col34 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
             <!--     column_alias='listing__created_at__week',         -->
             <!--   )                                                   -->
             <!-- col35 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
             <!--     column_alias='listing__created_at__month',        -->
             <!--   )                                                   -->
             <!-- col36 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
             <!--     column_alias='listing__created_at__quarter',      -->
             <!--   )                                                   -->
             <!-- col37 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
             <!--     column_alias='listing__created_at__year',         -->
             <!--   )                                                   -->
             <!-- col38 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_97), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
             <!--     column_alias='listing__created_at__extract_year', -->
             <!--   )                                                   -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_98),    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_97),    -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_99),  -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_98),  -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
-            <!-- col41 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
-            <!--     column_alias='listing__created_at__extract_day',   -->
-            <!--   )                                                    -->
+            <!-- col41 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+            <!--     column_alias='listing__created_at__extract_day',  -->
+            <!--   )                                                   -->
             <!-- col42 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
             <!--     column_alias='listing__created_at__extract_dow',   -->
             <!--   )                                                    -->
             <!-- col43 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
             <!--     column_alias='listing__created_at__extract_doy',   -->
             <!--   )                                                    -->
             <!-- col44 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='metric_time__day') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='listing') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='user') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='metric_time__day') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='listing') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='user') -->
             <!-- col47 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='listing__user') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='listing__user') -->
             <!-- col48 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_53), column_alias='country_latest') -->
-            <!-- col49 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_54), column_alias='is_lux_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_52), column_alias='country_latest') -->
+            <!-- col49 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_53), column_alias='is_lux_latest') -->
             <!-- col50 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_55), column_alias='capacity_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_54), column_alias='capacity_latest') -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
             <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
             <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
             <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
             <!-- col54 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
             <!--     column_alias='user__home_state_latest',            -->
             <!--   )                                                    -->
-            <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='listings') -->
+            <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='listings') -->
             <!-- col56 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_51), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='largest_listing') -->
             <!-- col57 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_52), column_alias='smallest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_51), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
             <!-- join_0 =                                               -->
             <!--   SqlJoinDescription(                                  -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_3), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_2), -->
             <!--     right_source_alias='subq_3',                       -->
             <!--     join_type=CROSS_JOIN,                              -->
             <!--   )                                                    -->
             <!-- join_1 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_4),   -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
             <!--     right_source_alias='subq_5',                         -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -431,143 +431,162 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-                <!-- node_id = NodeId(id_str='ss_3') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='metric_time__day') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='metric_time__day') -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Metric Time Dimension 'ds'" -->
-                    <!-- node_id = NodeId(id_str='ss_2') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__day') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__day') -->
                     <!-- col1 =                                                                                       -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__week') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__week') -->
                     <!-- col2 =                                                                                        -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='ds__month') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__month') -->
                     <!-- col3 =                                                                                          -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='ds__quarter') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='ds__quarter') -->
                     <!-- col4 =                                                                                       -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='ds__year') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='ds__year') -->
                     <!-- col5 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
                     <!--     column_alias='ds__extract_year',                  -->
                     <!--   )                                                   -->
                     <!-- col6 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
                     <!--     column_alias='ds__extract_quarter',               -->
                     <!--   )                                                   -->
                     <!-- col7 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
                     <!--     column_alias='ds__extract_month',                 -->
                     <!--   )                                                   -->
                     <!-- col8 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
                     <!--     column_alias='ds__extract_day',                   -->
                     <!--   )                                                   -->
                     <!-- col9 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
                     <!--     column_alias='ds__extract_dow',                   -->
                     <!--   )                                                   -->
                     <!-- col10 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
                     <!--     column_alias='ds__extract_doy',                   -->
                     <!--   )                                                   -->
                     <!-- col11 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
                     <!--     column_alias='metric_time__day',                  -->
                     <!--   )                                                   -->
                     <!-- col12 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
                     <!--     column_alias='metric_time__week',                 -->
                     <!--   )                                                   -->
                     <!-- col13 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
                     <!--     column_alias='metric_time__month',                -->
                     <!--   )                                                   -->
                     <!-- col14 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
                     <!--     column_alias='metric_time__quarter',              -->
                     <!--   )                                                   -->
                     <!-- col15 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
                     <!--     column_alias='metric_time__year',                 -->
                     <!--   )                                                   -->
                     <!-- col16 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
                     <!--     column_alias='metric_time__extract_year',         -->
                     <!--   )                                                   -->
                     <!-- col17 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
                     <!--     column_alias='metric_time__extract_quarter',      -->
                     <!--   )                                                   -->
                     <!-- col18 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
                     <!--     column_alias='metric_time__extract_month',        -->
                     <!--   )                                                   -->
                     <!-- col19 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
                     <!--     column_alias='metric_time__extract_day',          -->
                     <!--   )                                                   -->
                     <!-- col20 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
                     <!--     column_alias='metric_time__extract_dow',          -->
                     <!--   )                                                   -->
                     <!-- col21 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
                     <!--     column_alias='metric_time__extract_doy',          -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28012) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Time Spine' -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
-                        <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_0), column_alias='ds__day') -->
-                        <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_1), column_alias='ds__week') -->
-                        <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_2), column_alias='ds__month') -->
-                        <!-- col3 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_3), column_alias='ds__quarter') -->
-                        <!-- col4 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_4), column_alias='ds__year') -->
-                        <!-- col5 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_0), column_alias='ds__extract_year') -->
-                        <!-- col6 =                                       -->
-                        <!--   SqlSelectColumn(                           -->
-                        <!--     expr=SqlExtractExpression(node_id=ex_1), -->
-                        <!--     column_alias='ds__extract_quarter',      -->
-                        <!--   )                                          -->
-                        <!-- col7 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_2), column_alias='ds__extract_month') -->
-                        <!-- col8 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_3), column_alias='ds__extract_day') -->
-                        <!-- col9 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_4), column_alias='ds__extract_dow') -->
-                        <!-- col10 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_5), column_alias='ds__extract_doy') -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+                        <!-- node_id = NodeId(id_str='ss_28012') -->
+                        <!-- col0 =                                                                                   -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28170), column_alias='ds__day') -->
+                        <!-- col1 =                                                                                    -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28171), column_alias='ds__week') -->
+                        <!-- col2 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28172), column_alias='ds__month') -->
+                        <!-- col3 =                                                                                       -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28173), column_alias='ds__quarter') -->
+                        <!-- col4 =                                                                                    -->
+                        <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28174), column_alias='ds__year') -->
+                        <!-- col5 =                                           -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28204), -->
+                        <!--     column_alias='ds__extract_year',             -->
+                        <!--   )                                              -->
+                        <!-- col6 =                                           -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28205), -->
+                        <!--     column_alias='ds__extract_quarter',          -->
+                        <!--   )                                              -->
+                        <!-- col7 =                                           -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28206), -->
+                        <!--     column_alias='ds__extract_month',            -->
+                        <!--   )                                              -->
+                        <!-- col8 =                                           -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28207), -->
+                        <!--     column_alias='ds__extract_day',              -->
+                        <!--   )                                              -->
+                        <!-- col9 =                                           -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28208), -->
+                        <!--     column_alias='ds__extract_dow',              -->
+                        <!--   )                                              -->
+                        <!-- col10 =                                          -->
+                        <!--   SqlSelectColumn(                               -->
+                        <!--     expr=SqlExtractExpression(node_id=ex_28209), -->
+                        <!--     column_alias='ds__extract_doy',              -->
+                        <!--   )                                              -->
+                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28012) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlTableFromClauseNode>
                             <!-- description = 'Read from ***************************.mf_time_spine' -->
-                            <!-- node_id = NodeId(id_str='tfc_0') -->
+                            <!-- node_id = NodeId(id_str='tfc_28012') -->
                             <!-- table_id = '***************************.mf_time_spine' -->
                         </SqlTableFromClauseNode>
                     </SqlSelectStatementNode>
@@ -575,10 +594,10 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                <!-- node_id = NodeId(id_str='ss_4') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='user') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='user') -->
                 <!-- col1 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='home_state_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='home_state_latest') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
                 <!-- where = None -->
                 <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfp_0.xml
@@ -42,11 +42,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -59,11 +59,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_5') -->
+                                    <!-- node_id = NodeId(id_str='sma_28006') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                        <!-- node_id = NodeId(id_str='rss_5') -->
+                                        <!-- node_id = NodeId(id_str='rss_28018') -->
                                         <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -110,11 +110,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -127,11 +127,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_5') -->
+                                    <!-- node_id = NodeId(id_str='sma_28006') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                        <!-- node_id = NodeId(id_str='rss_5') -->
+                                        <!-- node_id = NodeId(id_str='rss_28018') -->
                                         <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
@@ -44,11 +44,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_14') -->
+                                <!-- node_id = NodeId(id_str='sma_4') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_17') -->
+                                    <!-- node_id = NodeId(id_str='rss_4') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
@@ -61,11 +61,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_15') -->
+                                <!-- node_id = NodeId(id_str='sma_5') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                    <!-- node_id = NodeId(id_str='rss_18') -->
+                                    <!-- node_id = NodeId(id_str='rss_5') -->
                                     <!-- data_set = SemanticModelDataSet('listings_latest') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_semantic_models__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_semantic_models__dfp_0.xml
@@ -20,11 +20,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28002') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28014') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -46,11 +46,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_5') -->
+                            <!-- node_id = NodeId(id_str='sma_28006') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                <!-- node_id = NodeId(id_str='rss_5') -->
+                                <!-- node_id = NodeId(id_str='rss_28018') -->
                                 <!-- data_set = SemanticModelDataSet('listings_latest') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_semantic_models__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_semantic_models__dfpo_0.xml
@@ -20,11 +20,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_10') -->
+                            <!-- node_id = NodeId(id_str='sma_0') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_13') -->
+                                <!-- node_id = NodeId(id_str='rss_0') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -46,11 +46,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_11') -->
+                            <!-- node_id = NodeId(id_str='sma_1') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                <!-- node_id = NodeId(id_str='rss_14') -->
+                                <!-- node_id = NodeId(id_str='rss_1') -->
                                 <!-- data_set = SemanticModelDataSet('listings_latest') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfp_0.xml
@@ -27,11 +27,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -53,11 +53,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -88,11 +88,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -114,11 +114,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfpo_0.xml
@@ -27,11 +27,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_16') -->
+                            <!-- node_id = NodeId(id_str='sma_6') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_19') -->
+                                <!-- node_id = NodeId(id_str='rss_6') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_semantic_models__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_semantic_models__dfp_0.xml
@@ -20,11 +20,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28002') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28014') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -46,11 +46,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28002') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28014') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -72,11 +72,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_5') -->
+                            <!-- node_id = NodeId(id_str='sma_28006') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                <!-- node_id = NodeId(id_str='rss_5') -->
+                                <!-- node_id = NodeId(id_str='rss_28018') -->
                                 <!-- data_set = SemanticModelDataSet('listings_latest') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_semantic_models__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_semantic_models__dfpo_0.xml
@@ -22,11 +22,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_13') -->
+                            <!-- node_id = NodeId(id_str='sma_3') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_16') -->
+                                <!-- node_id = NodeId(id_str='rss_3') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -48,11 +48,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_12') -->
+                            <!-- node_id = NodeId(id_str='sma_2') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                <!-- node_id = NodeId(id_str='rss_15') -->
+                                <!-- node_id = NodeId(id_str='rss_2') -->
                                 <!-- data_set = SemanticModelDataSet('listings_latest') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -20,11 +20,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28002') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28014') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -78,11 +78,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -20,11 +20,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_10') -->
+                            <!-- node_id = NodeId(id_str='sma_0') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_13') -->
+                                <!-- node_id = NodeId(id_str='rss_0') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -78,11 +78,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_11') -->
+                                    <!-- node_id = NodeId(id_str='sma_1') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_14') -->
+                                        <!-- node_id = NodeId(id_str='rss_1') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfp_0.xml
@@ -24,11 +24,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
@@ -50,11 +50,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfpo_0.xml
@@ -23,11 +23,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_12') -->
+                            <!-- node_id = NodeId(id_str='sma_2') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_15') -->
+                                <!-- node_id = NodeId(id_str='rss_2') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfp_0.xml
@@ -20,11 +20,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_1') -->
+                            <!-- node_id = NodeId(id_str='sma_28002') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                <!-- node_id = NodeId(id_str='rss_28014') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -53,11 +53,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -79,11 +79,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfpo_0.xml
@@ -20,11 +20,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_10') -->
+                            <!-- node_id = NodeId(id_str='sma_0') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_13') -->
+                                <!-- node_id = NodeId(id_str='rss_0') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>
@@ -53,11 +53,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_13') -->
+                                <!-- node_id = NodeId(id_str='sma_3') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_16') -->
+                                    <!-- node_id = NodeId(id_str='rss_3') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfp_0.xml
@@ -24,11 +24,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
@@ -55,11 +55,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfpo_0.xml
@@ -22,11 +22,11 @@
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='sma_12') -->
+                            <!-- node_id = NodeId(id_str='sma_2') -->
                             <!-- aggregation_time_dimension = 'ds' -->
                             <ReadSqlSourceNode>
                                 <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                <!-- node_id = NodeId(id_str='rss_15') -->
+                                <!-- node_id = NodeId(id_str='rss_2') -->
                                 <!-- data_set = SemanticModelDataSet('bookings_source') -->
                             </ReadSqlSourceNode>
                         </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfp_0.xml
@@ -32,11 +32,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
+                                        <!-- node_id = NodeId(id_str='sma_28002') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
+                                            <!-- node_id = NodeId(id_str='rss_28014') -->
                                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
@@ -59,11 +59,11 @@
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
+                                        <!-- node_id = NodeId(id_str='sma_28002') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
                                             <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
+                                            <!-- node_id = NodeId(id_str='rss_28014') -->
                                             <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
@@ -87,11 +87,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>
@@ -113,11 +113,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                <!-- node_id = NodeId(id_str='sma_28002') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                    <!-- node_id = NodeId(id_str='rss_28014') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>

--- a/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
+++ b/metricflow/test/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
@@ -31,11 +31,11 @@
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='sma_12') -->
+                                    <!-- node_id = NodeId(id_str='sma_2') -->
                                     <!-- aggregation_time_dimension = 'ds' -->
                                     <ReadSqlSourceNode>
                                         <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                        <!-- node_id = NodeId(id_str='rss_15') -->
+                                        <!-- node_id = NodeId(id_str='rss_2') -->
                                         <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                     </ReadSqlSourceNode>
                                 </MetricTimeDimensionTransformNode>
@@ -61,11 +61,11 @@
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='sma_15') -->
+                                <!-- node_id = NodeId(id_str='sma_5') -->
                                 <!-- aggregation_time_dimension = 'ds' -->
                                 <ReadSqlSourceNode>
                                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                    <!-- node_id = NodeId(id_str='rss_18') -->
+                                    <!-- node_id = NodeId(id_str='rss_5') -->
                                     <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                 </ReadSqlSourceNode>
                             </MetricTimeDimensionTransformNode>


### PR DESCRIPTION
### Description

This PR encapsulates the nodes used by the `DataflowPlanBuilder` into `SourceNodeSet` so that there's a single place where those nodes are generated and can be passed around. This will later be important for generating consistent SQL queries as the queries contain sequentially generated IDs. 

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
