### PR TITLE
Precompute / Cache Outputs for Nodes in `SourceNodeSet`

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -61,7 +61,6 @@ from metricflow.mf_logging.formatting import indent
 from metricflow.mf_logging.pretty_print import mf_pformat
 from metricflow.mf_logging.runtime import log_runtime
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow.plan_conversion.column_resolver import DunderColumnAssociationResolver
 from metricflow.plan_conversion.node_processor import PreJoinNodeProcessor
 from metricflow.query.group_by_item.filter_spec_resolution.filter_location import WhereFilterLocation
 from metricflow.query.group_by_item.filter_spec_resolution.filter_spec_lookup import FilterSpecResolutionLookUp
@@ -122,30 +121,15 @@ class DataflowPlanBuilder:
         self,
         source_node_set: SourceNodeSet,
         semantic_manifest_lookup: SemanticManifestLookup,
-        node_output_resolver: Optional[DataflowPlanNodeOutputDataSetResolver] = None,
-        column_association_resolver: Optional[ColumnAssociationResolver] = None,
+        node_output_resolver: DataflowPlanNodeOutputDataSetResolver,
+        column_association_resolver: ColumnAssociationResolver,
     ) -> None:
         self._semantic_model_lookup = semantic_manifest_lookup.semantic_model_lookup
         self._metric_lookup = semantic_manifest_lookup.metric_lookup
         self._metric_time_dimension_reference = DataSet.metric_time_dimension_reference()
         self._source_node_set = source_node_set
-        self._column_association_resolver = (
-            DunderColumnAssociationResolver(semantic_manifest_lookup)
-            if not column_association_resolver
-            else column_association_resolver
-        )
-        self._node_data_set_resolver = (
-            DataflowPlanNodeOutputDataSetResolver(
-                column_association_resolver=(
-                    DunderColumnAssociationResolver(semantic_manifest_lookup)
-                    if not column_association_resolver
-                    else column_association_resolver
-                ),
-                semantic_manifest_lookup=semantic_manifest_lookup,
-            )
-            if not node_output_resolver
-            else node_output_resolver
-        )
+        self._column_association_resolver = column_association_resolver
+        self._node_data_set_resolver = node_output_resolver
 
     def build_plan(
         self,

--- a/metricflow/dataflow/builder/node_data_set.py
+++ b/metricflow/dataflow/builder/node_data_set.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Sequence
 
 from metricflow.dataflow.dataflow_plan import (
     DataflowPlanNode,
 )
 from metricflow.dataset.sql_dataset import SqlDataSet
+from metricflow.mf_logging.runtime import log_block_runtime
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.specs.column_assoc import ColumnAssociationResolver
@@ -66,8 +67,17 @@ class DataflowPlanNodeOutputDataSetResolver(DataflowToSqlQueryPlanConverter):
         )
 
     def get_output_data_set(self, node: DataflowPlanNode) -> SqlDataSet:  # noqa: D
-        """Cached since this will be called repeatedly during the computation of multiple metrics."""
+        """Cached since this will be called repeatedly during the computation of multiple metrics.
+
+        # TODO: The cache needs to be pruned, but has not yet been an issue.
+        """
         if node not in self._node_to_output_data_set:
             self._node_to_output_data_set[node] = node.accept(self)
 
         return self._node_to_output_data_set[node]
+
+    def cache_output_data_sets(self, nodes: Sequence[DataflowPlanNode]) -> None:
+        """Cache the output of the given nodes for consistent retrieval with `get_output_data_set`."""
+        with log_block_runtime(f"cache_output_data_sets for {len(nodes)} nodes"):
+            for node in nodes:
+                self.get_output_data_set(node)

--- a/metricflow/dataflow/builder/node_data_set.py
+++ b/metricflow/dataflow/builder/node_data_set.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Sequence
+from typing import Dict, Optional, Sequence
 
 from metricflow.dataflow.dataflow_plan import (
     DataflowPlanNode,
@@ -59,8 +59,9 @@ class DataflowPlanNodeOutputDataSetResolver(DataflowToSqlQueryPlanConverter):
         self,
         column_association_resolver: ColumnAssociationResolver,
         semantic_manifest_lookup: SemanticManifestLookup,
+        _node_to_output_data_set: Optional[Dict[DataflowPlanNode, SqlDataSet]] = None,
     ) -> None:
-        self._node_to_output_data_set: Dict[DataflowPlanNode, SqlDataSet] = {}
+        self._node_to_output_data_set: Dict[DataflowPlanNode, SqlDataSet] = _node_to_output_data_set or {}
         super().__init__(
             column_association_resolver=column_association_resolver,
             semantic_manifest_lookup=semantic_manifest_lookup,
@@ -81,3 +82,11 @@ class DataflowPlanNodeOutputDataSetResolver(DataflowToSqlQueryPlanConverter):
         with log_block_runtime(f"cache_output_data_sets for {len(nodes)} nodes"):
             for node in nodes:
                 self.get_output_data_set(node)
+
+    def copy(self) -> DataflowPlanNodeOutputDataSetResolver:
+        """Return a copy of this with the same nodes cached."""
+        return DataflowPlanNodeOutputDataSetResolver(
+            column_association_resolver=self.column_association_resolver,
+            semantic_manifest_lookup=self._semantic_manifest_lookup,
+            _node_to_output_data_set=dict(self._node_to_output_data_set),
+        )

--- a/metricflow/dataflow/builder/source_node.py
+++ b/metricflow/dataflow/builder/source_node.py
@@ -31,11 +31,17 @@ class SourceNodeSet:
     source_nodes_for_metric_queries: Tuple[BaseOutput, ...]
 
     # Semantic models are 1:1 mapped to a ReadSqlSourceNode. The tuple also contains the same `time_spine_node` as
-    # below.
+    # below. See usage in `DataflowPlanBuilder`.
     source_nodes_for_group_by_item_queries: Tuple[BaseOutput, ...]
 
     # Provides the time spine.
     time_spine_node: MetricTimeDimensionTransformNode
+
+    @property
+    def all_nodes(self) -> Sequence[BaseOutput]:  # noqa: D
+        return (
+            self.source_nodes_for_metric_queries + self.source_nodes_for_group_by_item_queries + (self.time_spine_node,)
+        )
 
 
 class SourceNodeBuilder:

--- a/metricflow/mf_logging/runtime.py
+++ b/metricflow/mf_logging/runtime.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import functools
 import logging
 import time
-from typing import Callable, TypeVar
+from contextlib import contextmanager
+from typing import Callable, Iterator, TypeVar
 
 from typing_extensions import ParamSpec
 
@@ -14,7 +15,7 @@ ParametersType = ParamSpec("ParametersType")
 
 
 def log_runtime(
-    runtime_warning_threshold: float = 3.0,
+    runtime_warning_threshold: float = 5.0,
 ) -> Callable[[Callable[ParametersType, ReturnType]], Callable[ParametersType, ReturnType]]:
     """Logs how long a function took to run.
 
@@ -43,3 +44,18 @@ def log_runtime(
         return _inner
 
     return decorator
+
+
+@contextmanager
+def log_block_runtime(code_block_name: str, runtime_warning_threshold: float = 5.0) -> Iterator[None]:
+    """Logs the runtime of the enclosed code block."""
+    start_time = time.time()
+    description = f"code_block_name={repr(code_block_name)}"
+    logger.info(f"Starting {description}")
+
+    yield
+
+    runtime = time.time() - start_time
+    logger.info(f"Finished {description} in {runtime:.1f}s")
+    if runtime > runtime_warning_threshold:
+        logger.warning(f"{description} is slow with a runtime of {runtime:.1f}s")

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -163,6 +163,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             semantic_manifest_lookup: Self-explanatory.
         """
         self._column_association_resolver = column_association_resolver
+        self._semantic_manifest_lookup = semantic_manifest_lookup
         self._metric_lookup = semantic_manifest_lookup.metric_lookup
         self._semantic_model_lookup = semantic_manifest_lookup.semantic_model_lookup
         self._time_spine_source = semantic_manifest_lookup.time_spine_source

--- a/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_count_with_no_group_by__plan0.xml
+++ b/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_count_with_no_group_by__plan0.xml
@@ -1,15 +1,15 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_21') -->
+        <!-- node_id = NodeId(id_str='ss_12') -->
         <!-- col0 =                                                                                                     -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_725), column_alias='visit_buy_conversions') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_197), column_alias='visit_buy_conversions') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_20') -->
+            <!-- node_id = NodeId(id_str='ss_11') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX), -->
@@ -20,10 +20,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
             <!--     column_alias='buys',                                                       -->
             <!--   )                                                                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_19), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_10), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=CROSS_JOIN,                               -->
             <!--   )                                                     -->
@@ -31,210 +31,206 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_11') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits',]" -->
-                    <!-- node_id = NodeId(id_str='ss_10') -->
-                    <!-- col0 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_569), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_9') -->
-                        <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_532), column_alias='ds__day') -->
-                        <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__week') -->
-                        <!-- col2 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
-                        <!--     column_alias='ds__month',                          -->
-                        <!--   )                                                    -->
-                        <!-- col3 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
-                        <!--     column_alias='ds__quarter',                        -->
-                        <!--   )                                                    -->
-                        <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_536), column_alias='ds__year') -->
-                        <!-- col5 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
-                        <!--     column_alias='ds__extract_year',                   -->
-                        <!--   )                                                    -->
-                        <!-- col6 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
-                        <!--     column_alias='ds__extract_quarter',                -->
-                        <!--   )                                                    -->
-                        <!-- col7 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
-                        <!--     column_alias='ds__extract_month',                  -->
-                        <!--   )                                                    -->
-                        <!-- col8 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
-                        <!--     column_alias='ds__extract_day',                    -->
-                        <!--   )                                                    -->
-                        <!-- col9 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
-                        <!--     column_alias='ds__extract_dow',                    -->
-                        <!--   )                                                    -->
-                        <!-- col10 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
-                        <!--     column_alias='ds__extract_doy',                    -->
-                        <!--   )                                                    -->
-                        <!-- col11 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
-                        <!--     column_alias='visit__ds__day',                     -->
-                        <!--   )                                                    -->
-                        <!-- col12 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
-                        <!--     column_alias='visit__ds__week',                    -->
-                        <!--   )                                                    -->
-                        <!-- col13 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
-                        <!--     column_alias='visit__ds__month',                   -->
-                        <!--   )                                                    -->
-                        <!-- col14 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
-                        <!--     column_alias='visit__ds__quarter',                 -->
-                        <!--   )                                                    -->
-                        <!-- col15 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
-                        <!--     column_alias='visit__ds__year',                    -->
-                        <!--   )                                                    -->
-                        <!-- col16 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
-                        <!--     column_alias='visit__ds__extract_year',            -->
-                        <!--   )                                                    -->
-                        <!-- col17 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
-                        <!--     column_alias='visit__ds__extract_quarter',         -->
-                        <!--   )                                                    -->
-                        <!-- col18 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
-                        <!--     column_alias='visit__ds__extract_month',           -->
-                        <!--   )                                                    -->
-                        <!-- col19 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
-                        <!--     column_alias='visit__ds__extract_day',             -->
-                        <!--   )                                                    -->
-                        <!-- col20 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
-                        <!--     column_alias='visit__ds__extract_dow',             -->
-                        <!--   )                                                    -->
-                        <!-- col21 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
-                        <!--     column_alias='visit__ds__extract_doy',             -->
-                        <!--   )                                                    -->
-                        <!-- col22 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
-                        <!--     column_alias='metric_time__day',                   -->
-                        <!--   )                                                    -->
-                        <!-- col23 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
-                        <!--     column_alias='metric_time__week',                  -->
-                        <!--   )                                                    -->
-                        <!-- col24 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
-                        <!--     column_alias='metric_time__month',                 -->
-                        <!--   )                                                    -->
-                        <!-- col25 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
-                        <!--     column_alias='metric_time__quarter',               -->
-                        <!--   )                                                    -->
-                        <!-- col26 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
-                        <!--     column_alias='metric_time__year',                  -->
-                        <!--   )                                                    -->
-                        <!-- col27 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
-                        <!--     column_alias='metric_time__extract_year',          -->
-                        <!--   )                                                    -->
-                        <!-- col28 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
-                        <!--     column_alias='metric_time__extract_quarter',       -->
-                        <!--   )                                                    -->
-                        <!-- col29 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
-                        <!--     column_alias='metric_time__extract_month',         -->
-                        <!--   )                                                    -->
-                        <!-- col30 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
-                        <!--     column_alias='metric_time__extract_day',           -->
-                        <!--   )                                                    -->
-                        <!-- col31 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
-                        <!--     column_alias='metric_time__extract_dow',           -->
-                        <!--   )                                                    -->
-                        <!-- col32 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
-                        <!--     column_alias='metric_time__extract_doy',           -->
-                        <!--   )                                                    -->
-                        <!-- col33 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_565), column_alias='user') -->
-                        <!-- col34 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='session') -->
-                        <!-- col35 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
-                        <!--     column_alias='visit__user',                        -->
-                        <!--   )                                                    -->
-                        <!-- col36 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
-                        <!--     column_alias='visit__session',                     -->
-                        <!--   )                                                    -->
-                        <!-- col37 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
-                        <!--     column_alias='referrer_id',                        -->
-                        <!--   )                                                    -->
-                        <!-- col38 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
-                        <!--     column_alias='visit__referrer_id',                 -->
-                        <!--   )                                                    -->
-                        <!-- col39 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='visits') -->
-                        <!-- col40 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visitors') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- col0 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
+                        <!-- col1 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__week') -->
+                        <!-- col2 =                                                                                       -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='ds__month') -->
+                        <!-- col3 =                                               -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
+                        <!--     column_alias='ds__quarter',                      -->
+                        <!--   )                                                  -->
+                        <!-- col4 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='ds__year') -->
+                        <!-- col5 =                                               -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_9), -->
+                        <!--     column_alias='ds__extract_year',                 -->
+                        <!--   )                                                  -->
+                        <!-- col6 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
+                        <!--     column_alias='ds__extract_quarter',               -->
+                        <!--   )                                                   -->
+                        <!-- col7 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
+                        <!--     column_alias='ds__extract_month',                 -->
+                        <!--   )                                                   -->
+                        <!-- col8 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
+                        <!--     column_alias='ds__extract_day',                   -->
+                        <!--   )                                                   -->
+                        <!-- col9 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                        <!--     column_alias='ds__extract_dow',                   -->
+                        <!--   )                                                   -->
+                        <!-- col10 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_14), -->
+                        <!--     column_alias='ds__extract_doy',                   -->
+                        <!--   )                                                   -->
+                        <!-- col11 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_15), -->
+                        <!--     column_alias='visit__ds__day',                    -->
+                        <!--   )                                                   -->
+                        <!-- col12 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_16), -->
+                        <!--     column_alias='visit__ds__week',                   -->
+                        <!--   )                                                   -->
+                        <!-- col13 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_17), -->
+                        <!--     column_alias='visit__ds__month',                  -->
+                        <!--   )                                                   -->
+                        <!-- col14 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_18), -->
+                        <!--     column_alias='visit__ds__quarter',                -->
+                        <!--   )                                                   -->
+                        <!-- col15 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
+                        <!--     column_alias='visit__ds__year',                   -->
+                        <!--   )                                                   -->
+                        <!-- col16 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
+                        <!--     column_alias='visit__ds__extract_year',           -->
+                        <!--   )                                                   -->
+                        <!-- col17 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_21), -->
+                        <!--     column_alias='visit__ds__extract_quarter',        -->
+                        <!--   )                                                   -->
+                        <!-- col18 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
+                        <!--     column_alias='visit__ds__extract_month',          -->
+                        <!--   )                                                   -->
+                        <!-- col19 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
+                        <!--     column_alias='visit__ds__extract_day',            -->
+                        <!--   )                                                   -->
+                        <!-- col20 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_24), -->
+                        <!--     column_alias='visit__ds__extract_dow',            -->
+                        <!--   )                                                   -->
+                        <!-- col21 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_25), -->
+                        <!--     column_alias='visit__ds__extract_doy',            -->
+                        <!--   )                                                   -->
+                        <!-- col22 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_26), -->
+                        <!--     column_alias='metric_time__day',                  -->
+                        <!--   )                                                   -->
+                        <!-- col23 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
+                        <!--     column_alias='metric_time__week',                 -->
+                        <!--   )                                                   -->
+                        <!-- col24 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
+                        <!--     column_alias='metric_time__month',                -->
+                        <!--   )                                                   -->
+                        <!-- col25 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
+                        <!--     column_alias='metric_time__quarter',              -->
+                        <!--   )                                                   -->
+                        <!-- col26 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+                        <!--     column_alias='metric_time__year',                 -->
+                        <!--   )                                                   -->
+                        <!-- col27 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+                        <!--     column_alias='metric_time__extract_year',         -->
+                        <!--   )                                                   -->
+                        <!-- col28 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                        <!--     column_alias='metric_time__extract_quarter',      -->
+                        <!--   )                                                   -->
+                        <!-- col29 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                        <!--     column_alias='metric_time__extract_month',        -->
+                        <!--   )                                                   -->
+                        <!-- col30 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                        <!--     column_alias='metric_time__extract_day',          -->
+                        <!--   )                                                   -->
+                        <!-- col31 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                        <!--     column_alias='metric_time__extract_dow',          -->
+                        <!--   )                                                   -->
+                        <!-- col32 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
+                        <!--     column_alias='metric_time__extract_doy',          -->
+                        <!--   )                                                   -->
+                        <!-- col33 =                                                                                  -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='user') -->
+                        <!-- col34 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='session') -->
+                        <!-- col35 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                        <!--     column_alias='visit__user',                       -->
+                        <!--   )                                                   -->
+                        <!-- col36 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+                        <!--     column_alias='visit__session',                    -->
+                        <!--   )                                                   -->
+                        <!-- col37 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
+                        <!--     column_alias='referrer_id',                      -->
+                        <!--   )                                                  -->
+                        <!-- col38 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_3), -->
+                        <!--     column_alias='visit__referrer_id',               -->
+                        <!--   )                                                  -->
+                        <!-- col39 =                                                                                   -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
+                        <!-- col40 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
@@ -396,39 +392,39 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_19') -->
+                <!-- node_id = NodeId(id_str='ss_10') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys',]" -->
-                    <!-- node_id = NodeId(id_str='ss_18') -->
-                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_721), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                    <!-- node_id = NodeId(id_str='ss_9') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_193), column_alias='buys') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_17') -->
+                        <!-- node_id = NodeId(id_str='ss_8') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_719), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_191), column_alias='ds__day') -->
                         <!-- col1 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_720), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_192), column_alias='user') -->
                         <!-- col2 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_717), column_alias='buys') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_189), column_alias='buys') -->
                         <!-- col3 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_718), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_190), column_alias='visits') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_16') -->
+                            <!-- node_id = NodeId(id_str='ss_7') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -446,250 +442,250 @@
                             <!--   )                                                                             -->
                             <!-- col3 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_715), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_187), -->
                             <!--     column_alias='mf_internal_uuid',                   -->
                             <!--   )                                                    -->
                             <!-- col4 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_716), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
-                            <!-- join_0 =                                                -->
-                            <!--   SqlJoinDescription(                                   -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
-                            <!--     right_source_alias='subq_9',                        -->
-                            <!--     join_type=INNER,                                    -->
-                            <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
-                            <!--   )                                                     -->
+                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_188), column_alias='buys') -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- join_0 =                                               -->
+                            <!--   SqlJoinDescription(                                  -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_6), -->
+                            <!--     right_source_alias='subq_9',                       -->
+                            <!--     join_type=INNER,                                   -->
+                            <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
+                            <!--   )                                                    -->
                             <!-- where = None -->
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['visits', 'ds__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_13') -->
-                                <!-- col0 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
-                                <!--     column_alias='ds__day',                            -->
-                                <!--   )                                                    -->
-                                <!-- col1 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
-                                <!--     column_alias='user',                               -->
-                                <!--   )                                                    -->
-                                <!-- col2 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
-                                <!--     column_alias='visits',                             -->
-                                <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+                                <!-- node_id = NodeId(id_str='ss_4') -->
+                                <!-- col0 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
+                                <!--     column_alias='ds__day',                           -->
+                                <!--   )                                                   -->
+                                <!-- col1 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+                                <!--     column_alias='user',                              -->
+                                <!--   )                                                   -->
+                                <!-- col2 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
+                                <!--     column_alias='visits',                            -->
+                                <!--   )                                                   -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_12') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col4 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
-                                    <!--     column_alias='ds__year',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col5 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
-                                    <!--     column_alias='ds__extract_year',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col6 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
-                                    <!--     column_alias='ds__extract_quarter',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col7 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
-                                    <!--     column_alias='ds__extract_month',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col8 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
-                                    <!--     column_alias='ds__extract_day',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col9 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
-                                    <!--     column_alias='ds__extract_dow',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col10 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
-                                    <!--     column_alias='ds__extract_doy',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col11 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
-                                    <!--     column_alias='visit__ds__day',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col12 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
-                                    <!--     column_alias='visit__ds__week',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col13 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
-                                    <!--     column_alias='visit__ds__month',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col14 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
-                                    <!--     column_alias='visit__ds__quarter',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col15 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
-                                    <!--     column_alias='visit__ds__year',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col16 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
-                                    <!--     column_alias='visit__ds__extract_year',            -->
-                                    <!--   )                                                    -->
-                                    <!-- col17 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
-                                    <!--     column_alias='visit__ds__extract_quarter',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col18 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
-                                    <!--     column_alias='visit__ds__extract_month',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col19 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
-                                    <!--     column_alias='visit__ds__extract_day',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col20 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
-                                    <!--     column_alias='visit__ds__extract_dow',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col21 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
-                                    <!--     column_alias='visit__ds__extract_doy',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col22 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
-                                    <!--     column_alias='metric_time__day',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col23 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
-                                    <!--     column_alias='metric_time__week',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col24 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
-                                    <!--     column_alias='metric_time__month',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col25 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
-                                    <!--     column_alias='metric_time__quarter',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col26 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
-                                    <!--     column_alias='metric_time__year',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col27 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
-                                    <!--     column_alias='metric_time__extract_year',          -->
-                                    <!--   )                                                    -->
-                                    <!-- col28 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
-                                    <!--     column_alias='metric_time__extract_quarter',       -->
-                                    <!--   )                                                    -->
-                                    <!-- col29 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
-                                    <!--     column_alias='metric_time__extract_month',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col30 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
-                                    <!--     column_alias='metric_time__extract_day',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col31 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
-                                    <!--     column_alias='metric_time__extract_dow',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col32 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
-                                    <!--     column_alias='metric_time__extract_doy',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col33 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
-                                    <!--     column_alias='user',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col34 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
-                                    <!--     column_alias='session',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col35 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
-                                    <!--     column_alias='visit__user',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col36 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
-                                    <!--     column_alias='visit__session',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
-                                    <!--     column_alias='referrer_id',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
-                                    <!--     column_alias='visit__referrer_id',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col39 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
-                                    <!--     column_alias='visits',                             -->
-                                    <!--   )                                                    -->
-                                    <!-- col40 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
-                                    <!--     column_alias='visitors',                           -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_3') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col4 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                                    <!--     column_alias='ds__year',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col5 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                                    <!--     column_alias='ds__extract_year',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col6 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+                                    <!--     column_alias='ds__extract_quarter',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col7 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+                                    <!--     column_alias='ds__extract_month',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col8 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                                    <!--     column_alias='ds__extract_day',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col9 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                                    <!--     column_alias='ds__extract_dow',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col10 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+                                    <!--     column_alias='ds__extract_doy',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col11 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
+                                    <!--     column_alias='visit__ds__day',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col12 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+                                    <!--     column_alias='visit__ds__week',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col13 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
+                                    <!--     column_alias='visit__ds__month',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col14 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+                                    <!--     column_alias='visit__ds__quarter',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col15 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+                                    <!--     column_alias='visit__ds__year',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col16 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+                                    <!--     column_alias='visit__ds__extract_year',           -->
+                                    <!--   )                                                   -->
+                                    <!-- col17 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
+                                    <!--     column_alias='visit__ds__extract_quarter',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col18 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
+                                    <!--     column_alias='visit__ds__extract_month',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col19 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
+                                    <!--     column_alias='visit__ds__extract_day',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col20 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
+                                    <!--     column_alias='visit__ds__extract_dow',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col21 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+                                    <!--     column_alias='visit__ds__extract_doy',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col22 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+                                    <!--     column_alias='metric_time__day',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col23 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+                                    <!--     column_alias='metric_time__week',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col24 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+                                    <!--     column_alias='metric_time__month',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col25 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+                                    <!--     column_alias='metric_time__quarter',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col26 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                                    <!--     column_alias='metric_time__year',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
+                                    <!--     column_alias='metric_time__extract_year',         -->
+                                    <!--   )                                                   -->
+                                    <!-- col28 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+                                    <!--     column_alias='metric_time__extract_quarter',      -->
+                                    <!--   )                                                   -->
+                                    <!-- col29 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                                    <!--     column_alias='metric_time__extract_month',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col30 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                                    <!--     column_alias='metric_time__extract_day',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col31 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                                    <!--     column_alias='metric_time__extract_dow',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col32 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+                                    <!--     column_alias='metric_time__extract_doy',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col33 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+                                    <!--     column_alias='user',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col34 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+                                    <!--     column_alias='session',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col35 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                                    <!--     column_alias='visit__user',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col36 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_83), -->
+                                    <!--     column_alias='visit__session',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                                    <!--     column_alias='referrer_id',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
+                                    <!--     column_alias='visit__referrer_id',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col39 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+                                    <!--     column_alias='visits',                            -->
+                                    <!--   )                                                   -->
+                                    <!-- col40 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+                                    <!--     column_alias='visitors',                          -->
+                                    <!--   )                                                   -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
@@ -859,200 +855,200 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_15') -->
+                                <!-- node_id = NodeId(id_str='ss_6') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
                                 <!--     column_alias='ds__week',                           -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
                                 <!--     column_alias='ds__month',                          -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
                                 <!--     column_alias='ds__quarter',                        -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_132), -->
                                 <!--     column_alias='ds__year',                           -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
                                 <!--     column_alias='ds__extract_year',                   -->
                                 <!--   )                                                    -->
                                 <!-- col6 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
                                 <!--     column_alias='ds__extract_quarter',                -->
                                 <!--   )                                                    -->
                                 <!-- col7 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
                                 <!--     column_alias='ds__extract_month',                  -->
                                 <!--   )                                                    -->
                                 <!-- col8 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
                                 <!--     column_alias='ds__extract_day',                    -->
                                 <!--   )                                                    -->
                                 <!-- col9 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
                                 <!--     column_alias='ds__extract_dow',                    -->
                                 <!--   )                                                    -->
                                 <!-- col10 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
                                 <!--     column_alias='ds__extract_doy',                    -->
                                 <!--   )                                                    -->
                                 <!-- col11 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
                                 <!--     column_alias='buy__ds__day',                       -->
                                 <!--   )                                                    -->
                                 <!-- col12 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
                                 <!--     column_alias='buy__ds__week',                      -->
                                 <!--   )                                                    -->
                                 <!-- col13 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_141), -->
                                 <!--     column_alias='buy__ds__month',                     -->
                                 <!--   )                                                    -->
                                 <!-- col14 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_142), -->
                                 <!--     column_alias='buy__ds__quarter',                   -->
                                 <!--   )                                                    -->
                                 <!-- col15 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_143), -->
                                 <!--     column_alias='buy__ds__year',                      -->
                                 <!--   )                                                    -->
                                 <!-- col16 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_144), -->
                                 <!--     column_alias='buy__ds__extract_year',              -->
                                 <!--   )                                                    -->
                                 <!-- col17 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
                                 <!--     column_alias='buy__ds__extract_quarter',           -->
                                 <!--   )                                                    -->
                                 <!-- col18 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
                                 <!--     column_alias='buy__ds__extract_month',             -->
                                 <!--   )                                                    -->
                                 <!-- col19 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_147), -->
                                 <!--     column_alias='buy__ds__extract_day',               -->
                                 <!--   )                                                    -->
                                 <!-- col20 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_148), -->
                                 <!--     column_alias='buy__ds__extract_dow',               -->
                                 <!--   )                                                    -->
                                 <!-- col21 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_149), -->
                                 <!--     column_alias='buy__ds__extract_doy',               -->
                                 <!--   )                                                    -->
                                 <!-- col22 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_150), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col23 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_151), -->
                                 <!--     column_alias='metric_time__week',                  -->
                                 <!--   )                                                    -->
                                 <!-- col24 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_152), -->
                                 <!--     column_alias='metric_time__month',                 -->
                                 <!--   )                                                    -->
                                 <!-- col25 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_153), -->
                                 <!--     column_alias='metric_time__quarter',               -->
                                 <!--   )                                                    -->
                                 <!-- col26 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_154), -->
                                 <!--     column_alias='metric_time__year',                  -->
                                 <!--   )                                                    -->
                                 <!-- col27 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_155), -->
                                 <!--     column_alias='metric_time__extract_year',          -->
                                 <!--   )                                                    -->
                                 <!-- col28 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_156), -->
                                 <!--     column_alias='metric_time__extract_quarter',       -->
                                 <!--   )                                                    -->
                                 <!-- col29 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_157), -->
                                 <!--     column_alias='metric_time__extract_month',         -->
                                 <!--   )                                                    -->
                                 <!-- col30 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_158), -->
                                 <!--     column_alias='metric_time__extract_day',           -->
                                 <!--   )                                                    -->
                                 <!-- col31 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_159), -->
                                 <!--     column_alias='metric_time__extract_dow',           -->
                                 <!--   )                                                    -->
                                 <!-- col32 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_160), -->
                                 <!--     column_alias='metric_time__extract_doy',           -->
                                 <!--   )                                                    -->
                                 <!-- col33 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_161), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col34 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
                                 <!--     column_alias='session_id',                         -->
                                 <!--   )                                                    -->
                                 <!-- col35 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_163), -->
                                 <!--     column_alias='buy__user',                          -->
                                 <!--   )                                                    -->
                                 <!-- col36 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_164), -->
                                 <!--     column_alias='buy__session_id',                    -->
                                 <!--   )                                                    -->
                                 <!-- col37 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
                                 <!-- col38 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
                                 <!--     column_alias='buyers',                             -->
                                 <!--   )                                                    -->
                                 <!-- col39 =                                             -->
@@ -1060,207 +1056,207 @@
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_14') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col4 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
-                                    <!--     column_alias='ds__year',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col5 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
-                                    <!--     column_alias='ds__extract_year',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col6 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
-                                    <!--     column_alias='ds__extract_quarter',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col7 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
-                                    <!--     column_alias='ds__extract_month',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col8 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
-                                    <!--     column_alias='ds__extract_day',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col9 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
-                                    <!--     column_alias='ds__extract_dow',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col10 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
-                                    <!--     column_alias='ds__extract_doy',                    -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_5') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col4 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
+                                    <!--     column_alias='ds__year',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col5 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
+                                    <!--     column_alias='ds__extract_year',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col6 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
+                                    <!--     column_alias='ds__extract_quarter',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col7 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
+                                    <!--     column_alias='ds__extract_month',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col8 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_97), -->
+                                    <!--     column_alias='ds__extract_day',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col9 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_98), -->
+                                    <!--     column_alias='ds__extract_dow',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col10 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+                                    <!--     column_alias='ds__extract_doy',                   -->
+                                    <!--   )                                                   -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                                     <!--     column_alias='buy__ds__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
                                     <!--     column_alias='buy__ds__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
                                     <!--     column_alias='buy__ds__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
                                     <!--     column_alias='buy__ds__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
                                     <!--     column_alias='buy__ds__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
                                     <!--     column_alias='buy__ds__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
                                     <!--     column_alias='buy__ds__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
                                     <!--     column_alias='buy__ds__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
                                     <!--     column_alias='buy__ds__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
                                     <!--     column_alias='buy__ds__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
                                     <!--     column_alias='buy__ds__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_115), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_116), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_118), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_119), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
                                     <!--     column_alias='session_id',                         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
                                     <!--     column_alias='buy__user',                          -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
                                     <!--     column_alias='buy__session_id',                    -->
                                     <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
-                                    <!--     column_alias='buys',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
-                                    <!--     column_alias='buyers',                             -->
-                                    <!--   )                                                    -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+                                    <!--     column_alias='buys',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+                                    <!--     column_alias='buyers',                            -->
+                                    <!--   )                                                   -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate__plan0.xml
+++ b/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate__plan0.xml
@@ -1,17 +1,17 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_21') -->
+        <!-- node_id = NodeId(id_str='ss_12') -->
         <!-- col0 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_741), column_alias='visit__referrer_id') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_213), column_alias='visit__referrer_id') -->
         <!-- col1 =                                                                                                        -->
         <!--   SqlSelectColumn(expr=SqlRatioComputationExpression(node_id=rc_0), column_alias='visit_buy_conversion_rate') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_20') -->
+            <!-- node_id = NodeId(id_str='ss_11') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
@@ -27,10 +27,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_19),  -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_10),  -->
             <!--     right_source_alias='subq_13',                        -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_2), -->
@@ -44,225 +44,221 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_11') -->
-                <!-- col0 =                                                 -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
-                <!--     column_alias='visit__referrer_id',                 -->
-                <!--   )                                                    -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- col0 =                                                -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+                <!--     column_alias='visit__referrer_id',                -->
+                <!--   )                                                   -->
                 <!-- col1 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-                <!-- group_by0 =                                            -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
-                <!--     column_alias='visit__referrer_id',                 -->
-                <!--   )                                                    -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- group_by0 =                                           -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+                <!--     column_alias='visit__referrer_id',                -->
+                <!--   )                                                   -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id']" -->
-                    <!-- node_id = NodeId(id_str='ss_10') -->
-                    <!-- col0 =                                                 -->
-                    <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
-                    <!--     column_alias='visit__referrer_id',                 -->
-                    <!--   )                                                    -->
-                    <!-- col1 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_569), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- col0 =                                                -->
+                    <!--   SqlSelectColumn(                                    -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+                    <!--     column_alias='visit__referrer_id',                -->
+                    <!--   )                                                   -->
+                    <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_9') -->
-                        <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_532), column_alias='ds__day') -->
-                        <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__week') -->
-                        <!-- col2 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
-                        <!--     column_alias='ds__month',                          -->
-                        <!--   )                                                    -->
-                        <!-- col3 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
-                        <!--     column_alias='ds__quarter',                        -->
-                        <!--   )                                                    -->
-                        <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_536), column_alias='ds__year') -->
-                        <!-- col5 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
-                        <!--     column_alias='ds__extract_year',                   -->
-                        <!--   )                                                    -->
-                        <!-- col6 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
-                        <!--     column_alias='ds__extract_quarter',                -->
-                        <!--   )                                                    -->
-                        <!-- col7 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
-                        <!--     column_alias='ds__extract_month',                  -->
-                        <!--   )                                                    -->
-                        <!-- col8 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
-                        <!--     column_alias='ds__extract_day',                    -->
-                        <!--   )                                                    -->
-                        <!-- col9 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
-                        <!--     column_alias='ds__extract_dow',                    -->
-                        <!--   )                                                    -->
-                        <!-- col10 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
-                        <!--     column_alias='ds__extract_doy',                    -->
-                        <!--   )                                                    -->
-                        <!-- col11 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
-                        <!--     column_alias='visit__ds__day',                     -->
-                        <!--   )                                                    -->
-                        <!-- col12 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
-                        <!--     column_alias='visit__ds__week',                    -->
-                        <!--   )                                                    -->
-                        <!-- col13 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
-                        <!--     column_alias='visit__ds__month',                   -->
-                        <!--   )                                                    -->
-                        <!-- col14 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
-                        <!--     column_alias='visit__ds__quarter',                 -->
-                        <!--   )                                                    -->
-                        <!-- col15 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
-                        <!--     column_alias='visit__ds__year',                    -->
-                        <!--   )                                                    -->
-                        <!-- col16 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
-                        <!--     column_alias='visit__ds__extract_year',            -->
-                        <!--   )                                                    -->
-                        <!-- col17 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
-                        <!--     column_alias='visit__ds__extract_quarter',         -->
-                        <!--   )                                                    -->
-                        <!-- col18 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
-                        <!--     column_alias='visit__ds__extract_month',           -->
-                        <!--   )                                                    -->
-                        <!-- col19 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
-                        <!--     column_alias='visit__ds__extract_day',             -->
-                        <!--   )                                                    -->
-                        <!-- col20 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
-                        <!--     column_alias='visit__ds__extract_dow',             -->
-                        <!--   )                                                    -->
-                        <!-- col21 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
-                        <!--     column_alias='visit__ds__extract_doy',             -->
-                        <!--   )                                                    -->
-                        <!-- col22 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
-                        <!--     column_alias='metric_time__day',                   -->
-                        <!--   )                                                    -->
-                        <!-- col23 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
-                        <!--     column_alias='metric_time__week',                  -->
-                        <!--   )                                                    -->
-                        <!-- col24 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
-                        <!--     column_alias='metric_time__month',                 -->
-                        <!--   )                                                    -->
-                        <!-- col25 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
-                        <!--     column_alias='metric_time__quarter',               -->
-                        <!--   )                                                    -->
-                        <!-- col26 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
-                        <!--     column_alias='metric_time__year',                  -->
-                        <!--   )                                                    -->
-                        <!-- col27 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
-                        <!--     column_alias='metric_time__extract_year',          -->
-                        <!--   )                                                    -->
-                        <!-- col28 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
-                        <!--     column_alias='metric_time__extract_quarter',       -->
-                        <!--   )                                                    -->
-                        <!-- col29 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
-                        <!--     column_alias='metric_time__extract_month',         -->
-                        <!--   )                                                    -->
-                        <!-- col30 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
-                        <!--     column_alias='metric_time__extract_day',           -->
-                        <!--   )                                                    -->
-                        <!-- col31 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
-                        <!--     column_alias='metric_time__extract_dow',           -->
-                        <!--   )                                                    -->
-                        <!-- col32 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
-                        <!--     column_alias='metric_time__extract_doy',           -->
-                        <!--   )                                                    -->
-                        <!-- col33 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_565), column_alias='user') -->
-                        <!-- col34 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='session') -->
-                        <!-- col35 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
-                        <!--     column_alias='visit__user',                        -->
-                        <!--   )                                                    -->
-                        <!-- col36 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
-                        <!--     column_alias='visit__session',                     -->
-                        <!--   )                                                    -->
-                        <!-- col37 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
-                        <!--     column_alias='referrer_id',                        -->
-                        <!--   )                                                    -->
-                        <!-- col38 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
-                        <!--     column_alias='visit__referrer_id',                 -->
-                        <!--   )                                                    -->
-                        <!-- col39 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='visits') -->
-                        <!-- col40 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visitors') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- col0 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
+                        <!-- col1 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__week') -->
+                        <!-- col2 =                                                                                       -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='ds__month') -->
+                        <!-- col3 =                                               -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
+                        <!--     column_alias='ds__quarter',                      -->
+                        <!--   )                                                  -->
+                        <!-- col4 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='ds__year') -->
+                        <!-- col5 =                                               -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_9), -->
+                        <!--     column_alias='ds__extract_year',                 -->
+                        <!--   )                                                  -->
+                        <!-- col6 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
+                        <!--     column_alias='ds__extract_quarter',               -->
+                        <!--   )                                                   -->
+                        <!-- col7 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
+                        <!--     column_alias='ds__extract_month',                 -->
+                        <!--   )                                                   -->
+                        <!-- col8 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
+                        <!--     column_alias='ds__extract_day',                   -->
+                        <!--   )                                                   -->
+                        <!-- col9 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                        <!--     column_alias='ds__extract_dow',                   -->
+                        <!--   )                                                   -->
+                        <!-- col10 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_14), -->
+                        <!--     column_alias='ds__extract_doy',                   -->
+                        <!--   )                                                   -->
+                        <!-- col11 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_15), -->
+                        <!--     column_alias='visit__ds__day',                    -->
+                        <!--   )                                                   -->
+                        <!-- col12 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_16), -->
+                        <!--     column_alias='visit__ds__week',                   -->
+                        <!--   )                                                   -->
+                        <!-- col13 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_17), -->
+                        <!--     column_alias='visit__ds__month',                  -->
+                        <!--   )                                                   -->
+                        <!-- col14 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_18), -->
+                        <!--     column_alias='visit__ds__quarter',                -->
+                        <!--   )                                                   -->
+                        <!-- col15 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
+                        <!--     column_alias='visit__ds__year',                   -->
+                        <!--   )                                                   -->
+                        <!-- col16 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
+                        <!--     column_alias='visit__ds__extract_year',           -->
+                        <!--   )                                                   -->
+                        <!-- col17 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_21), -->
+                        <!--     column_alias='visit__ds__extract_quarter',        -->
+                        <!--   )                                                   -->
+                        <!-- col18 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
+                        <!--     column_alias='visit__ds__extract_month',          -->
+                        <!--   )                                                   -->
+                        <!-- col19 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
+                        <!--     column_alias='visit__ds__extract_day',            -->
+                        <!--   )                                                   -->
+                        <!-- col20 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_24), -->
+                        <!--     column_alias='visit__ds__extract_dow',            -->
+                        <!--   )                                                   -->
+                        <!-- col21 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_25), -->
+                        <!--     column_alias='visit__ds__extract_doy',            -->
+                        <!--   )                                                   -->
+                        <!-- col22 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_26), -->
+                        <!--     column_alias='metric_time__day',                  -->
+                        <!--   )                                                   -->
+                        <!-- col23 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
+                        <!--     column_alias='metric_time__week',                 -->
+                        <!--   )                                                   -->
+                        <!-- col24 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
+                        <!--     column_alias='metric_time__month',                -->
+                        <!--   )                                                   -->
+                        <!-- col25 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
+                        <!--     column_alias='metric_time__quarter',              -->
+                        <!--   )                                                   -->
+                        <!-- col26 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+                        <!--     column_alias='metric_time__year',                 -->
+                        <!--   )                                                   -->
+                        <!-- col27 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+                        <!--     column_alias='metric_time__extract_year',         -->
+                        <!--   )                                                   -->
+                        <!-- col28 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                        <!--     column_alias='metric_time__extract_quarter',      -->
+                        <!--   )                                                   -->
+                        <!-- col29 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                        <!--     column_alias='metric_time__extract_month',        -->
+                        <!--   )                                                   -->
+                        <!-- col30 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                        <!--     column_alias='metric_time__extract_day',          -->
+                        <!--   )                                                   -->
+                        <!-- col31 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                        <!--     column_alias='metric_time__extract_dow',          -->
+                        <!--   )                                                   -->
+                        <!-- col32 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
+                        <!--     column_alias='metric_time__extract_doy',          -->
+                        <!--   )                                                   -->
+                        <!-- col33 =                                                                                  -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='user') -->
+                        <!-- col34 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='session') -->
+                        <!-- col35 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                        <!--     column_alias='visit__user',                       -->
+                        <!--   )                                                   -->
+                        <!-- col36 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+                        <!--     column_alias='visit__session',                    -->
+                        <!--   )                                                   -->
+                        <!-- col37 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
+                        <!--     column_alias='referrer_id',                      -->
+                        <!--   )                                                  -->
+                        <!-- col38 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_3), -->
+                        <!--     column_alias='visit__referrer_id',               -->
+                        <!--   )                                                  -->
+                        <!-- col39 =                                                                                   -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
+                        <!-- col40 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
@@ -424,10 +420,10 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_19') -->
+                <!-- node_id = NodeId(id_str='ss_10') -->
                 <!-- col0 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_734), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_206), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- col1 =                                                                    -->
@@ -435,48 +431,48 @@
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- group_by0 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_734), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_206), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id']" -->
-                    <!-- node_id = NodeId(id_str='ss_18') -->
+                    <!-- node_id = NodeId(id_str='ss_9') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_732), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_204), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
-                    <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_731), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                    <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_203), column_alias='buys') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of INF' -->
-                        <!-- node_id = NodeId(id_str='ss_17') -->
+                        <!-- node_id = NodeId(id_str='ss_8') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_729), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_201), column_alias='ds__day') -->
                         <!-- col1 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_730), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_202), column_alias='user') -->
                         <!-- col2 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_728), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_200), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col3 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_726), column_alias='buys') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_198), column_alias='buys') -->
                         <!-- col4 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_727), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_199), column_alias='visits') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_16') -->
+                            <!-- node_id = NodeId(id_str='ss_7') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -499,256 +495,256 @@
                             <!--   )                                                                             -->
                             <!-- col4 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_724), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_196), -->
                             <!--     column_alias='mf_internal_uuid',                   -->
                             <!--   )                                                    -->
                             <!-- col5 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_725), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
-                            <!-- join_0 =                                                -->
-                            <!--   SqlJoinDescription(                                   -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
-                            <!--     right_source_alias='subq_9',                        -->
-                            <!--     join_type=INNER,                                    -->
-                            <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
-                            <!--   )                                                     -->
+                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_197), column_alias='buys') -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- join_0 =                                               -->
+                            <!--   SqlJoinDescription(                                  -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_6), -->
+                            <!--     right_source_alias='subq_9',                       -->
+                            <!--     join_type=INNER,                                   -->
+                            <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
+                            <!--   )                                                    -->
                             <!-- where = None -->
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description =                                                               -->
                                 <!--   "Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_13') -->
-                                <!-- col0 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
-                                <!--     column_alias='ds__day',                            -->
-                                <!--   )                                                    -->
-                                <!-- col1 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
-                                <!--     column_alias='user',                               -->
-                                <!--   )                                                    -->
-                                <!-- col2 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
-                                <!--     column_alias='visit__referrer_id',                 -->
-                                <!--   )                                                    -->
-                                <!-- col3 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
-                                <!--     column_alias='visits',                             -->
-                                <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+                                <!-- node_id = NodeId(id_str='ss_4') -->
+                                <!-- col0 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+                                <!--     column_alias='ds__day',                           -->
+                                <!--   )                                                   -->
+                                <!-- col1 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+                                <!--     column_alias='user',                              -->
+                                <!--   )                                                   -->
+                                <!-- col2 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+                                <!--     column_alias='visit__referrer_id',                -->
+                                <!--   )                                                   -->
+                                <!-- col3 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+                                <!--     column_alias='visits',                            -->
+                                <!--   )                                                   -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_12') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col4 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
-                                    <!--     column_alias='ds__year',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col5 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
-                                    <!--     column_alias='ds__extract_year',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col6 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
-                                    <!--     column_alias='ds__extract_quarter',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col7 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
-                                    <!--     column_alias='ds__extract_month',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col8 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
-                                    <!--     column_alias='ds__extract_day',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col9 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
-                                    <!--     column_alias='ds__extract_dow',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col10 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
-                                    <!--     column_alias='ds__extract_doy',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col11 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
-                                    <!--     column_alias='visit__ds__day',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col12 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
-                                    <!--     column_alias='visit__ds__week',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col13 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
-                                    <!--     column_alias='visit__ds__month',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col14 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
-                                    <!--     column_alias='visit__ds__quarter',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col15 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
-                                    <!--     column_alias='visit__ds__year',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col16 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
-                                    <!--     column_alias='visit__ds__extract_year',            -->
-                                    <!--   )                                                    -->
-                                    <!-- col17 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
-                                    <!--     column_alias='visit__ds__extract_quarter',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col18 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
-                                    <!--     column_alias='visit__ds__extract_month',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col19 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
-                                    <!--     column_alias='visit__ds__extract_day',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col20 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
-                                    <!--     column_alias='visit__ds__extract_dow',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col21 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
-                                    <!--     column_alias='visit__ds__extract_doy',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col22 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
-                                    <!--     column_alias='metric_time__day',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col23 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
-                                    <!--     column_alias='metric_time__week',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col24 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
-                                    <!--     column_alias='metric_time__month',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col25 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
-                                    <!--     column_alias='metric_time__quarter',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col26 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
-                                    <!--     column_alias='metric_time__year',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col27 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
-                                    <!--     column_alias='metric_time__extract_year',          -->
-                                    <!--   )                                                    -->
-                                    <!-- col28 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
-                                    <!--     column_alias='metric_time__extract_quarter',       -->
-                                    <!--   )                                                    -->
-                                    <!-- col29 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
-                                    <!--     column_alias='metric_time__extract_month',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col30 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
-                                    <!--     column_alias='metric_time__extract_day',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col31 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
-                                    <!--     column_alias='metric_time__extract_dow',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col32 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
-                                    <!--     column_alias='metric_time__extract_doy',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col33 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
-                                    <!--     column_alias='user',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col34 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
-                                    <!--     column_alias='session',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col35 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
-                                    <!--     column_alias='visit__user',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col36 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
-                                    <!--     column_alias='visit__session',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
-                                    <!--     column_alias='referrer_id',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
-                                    <!--     column_alias='visit__referrer_id',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col39 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
-                                    <!--     column_alias='visits',                             -->
-                                    <!--   )                                                    -->
-                                    <!-- col40 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
-                                    <!--     column_alias='visitors',                           -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_3') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col4 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+                                    <!--     column_alias='ds__year',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col5 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+                                    <!--     column_alias='ds__extract_year',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col6 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                                    <!--     column_alias='ds__extract_quarter',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col7 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                                    <!--     column_alias='ds__extract_month',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col8 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+                                    <!--     column_alias='ds__extract_day',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col9 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
+                                    <!--     column_alias='ds__extract_dow',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col10 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+                                    <!--     column_alias='ds__extract_doy',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col11 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
+                                    <!--     column_alias='visit__ds__day',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col12 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+                                    <!--     column_alias='visit__ds__week',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col13 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+                                    <!--     column_alias='visit__ds__month',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col14 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+                                    <!--     column_alias='visit__ds__quarter',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col15 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
+                                    <!--     column_alias='visit__ds__year',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col16 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
+                                    <!--     column_alias='visit__ds__extract_year',           -->
+                                    <!--   )                                                   -->
+                                    <!-- col17 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
+                                    <!--     column_alias='visit__ds__extract_quarter',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col18 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
+                                    <!--     column_alias='visit__ds__extract_month',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col19 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+                                    <!--     column_alias='visit__ds__extract_day',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col20 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+                                    <!--     column_alias='visit__ds__extract_dow',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col21 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+                                    <!--     column_alias='visit__ds__extract_doy',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col22 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+                                    <!--     column_alias='metric_time__day',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col23 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+                                    <!--     column_alias='metric_time__week',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col24 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                                    <!--     column_alias='metric_time__month',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col25 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
+                                    <!--     column_alias='metric_time__quarter',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col26 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+                                    <!--     column_alias='metric_time__year',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                                    <!--     column_alias='metric_time__extract_year',         -->
+                                    <!--   )                                                   -->
+                                    <!-- col28 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                                    <!--     column_alias='metric_time__extract_quarter',      -->
+                                    <!--   )                                                   -->
+                                    <!-- col29 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                                    <!--     column_alias='metric_time__extract_month',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col30 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+                                    <!--     column_alias='metric_time__extract_day',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col31 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+                                    <!--     column_alias='metric_time__extract_dow',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col32 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+                                    <!--     column_alias='metric_time__extract_doy',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col33 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                                    <!--     column_alias='user',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col34 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_83), -->
+                                    <!--     column_alias='session',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col35 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
+                                    <!--     column_alias='visit__user',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col36 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
+                                    <!--     column_alias='visit__session',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+                                    <!--     column_alias='referrer_id',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+                                    <!--     column_alias='visit__referrer_id',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col39 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                                    <!--     column_alias='visits',                            -->
+                                    <!--   )                                                   -->
+                                    <!-- col40 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
+                                    <!--     column_alias='visitors',                          -->
+                                    <!--   )                                                   -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
@@ -918,200 +914,200 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_15') -->
+                                <!-- node_id = NodeId(id_str='ss_6') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_132), -->
                                 <!--     column_alias='ds__week',                           -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
                                 <!--     column_alias='ds__month',                          -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
                                 <!--     column_alias='ds__quarter',                        -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
                                 <!--     column_alias='ds__year',                           -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
                                 <!--     column_alias='ds__extract_year',                   -->
                                 <!--   )                                                    -->
                                 <!-- col6 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
                                 <!--     column_alias='ds__extract_quarter',                -->
                                 <!--   )                                                    -->
                                 <!-- col7 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
                                 <!--     column_alias='ds__extract_month',                  -->
                                 <!--   )                                                    -->
                                 <!-- col8 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
                                 <!--     column_alias='ds__extract_day',                    -->
                                 <!--   )                                                    -->
                                 <!-- col9 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
                                 <!--     column_alias='ds__extract_dow',                    -->
                                 <!--   )                                                    -->
                                 <!-- col10 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_141), -->
                                 <!--     column_alias='ds__extract_doy',                    -->
                                 <!--   )                                                    -->
                                 <!-- col11 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_142), -->
                                 <!--     column_alias='buy__ds__day',                       -->
                                 <!--   )                                                    -->
                                 <!-- col12 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_143), -->
                                 <!--     column_alias='buy__ds__week',                      -->
                                 <!--   )                                                    -->
                                 <!-- col13 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_144), -->
                                 <!--     column_alias='buy__ds__month',                     -->
                                 <!--   )                                                    -->
                                 <!-- col14 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
                                 <!--     column_alias='buy__ds__quarter',                   -->
                                 <!--   )                                                    -->
                                 <!-- col15 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
                                 <!--     column_alias='buy__ds__year',                      -->
                                 <!--   )                                                    -->
                                 <!-- col16 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_147), -->
                                 <!--     column_alias='buy__ds__extract_year',              -->
                                 <!--   )                                                    -->
                                 <!-- col17 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_148), -->
                                 <!--     column_alias='buy__ds__extract_quarter',           -->
                                 <!--   )                                                    -->
                                 <!-- col18 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_149), -->
                                 <!--     column_alias='buy__ds__extract_month',             -->
                                 <!--   )                                                    -->
                                 <!-- col19 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_150), -->
                                 <!--     column_alias='buy__ds__extract_day',               -->
                                 <!--   )                                                    -->
                                 <!-- col20 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_151), -->
                                 <!--     column_alias='buy__ds__extract_dow',               -->
                                 <!--   )                                                    -->
                                 <!-- col21 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_152), -->
                                 <!--     column_alias='buy__ds__extract_doy',               -->
                                 <!--   )                                                    -->
                                 <!-- col22 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_153), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col23 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_154), -->
                                 <!--     column_alias='metric_time__week',                  -->
                                 <!--   )                                                    -->
                                 <!-- col24 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_155), -->
                                 <!--     column_alias='metric_time__month',                 -->
                                 <!--   )                                                    -->
                                 <!-- col25 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_156), -->
                                 <!--     column_alias='metric_time__quarter',               -->
                                 <!--   )                                                    -->
                                 <!-- col26 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_157), -->
                                 <!--     column_alias='metric_time__year',                  -->
                                 <!--   )                                                    -->
                                 <!-- col27 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_158), -->
                                 <!--     column_alias='metric_time__extract_year',          -->
                                 <!--   )                                                    -->
                                 <!-- col28 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_159), -->
                                 <!--     column_alias='metric_time__extract_quarter',       -->
                                 <!--   )                                                    -->
                                 <!-- col29 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_160), -->
                                 <!--     column_alias='metric_time__extract_month',         -->
                                 <!--   )                                                    -->
                                 <!-- col30 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_161), -->
                                 <!--     column_alias='metric_time__extract_day',           -->
                                 <!--   )                                                    -->
                                 <!-- col31 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
                                 <!--     column_alias='metric_time__extract_dow',           -->
                                 <!--   )                                                    -->
                                 <!-- col32 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_163), -->
                                 <!--     column_alias='metric_time__extract_doy',           -->
                                 <!--   )                                                    -->
                                 <!-- col33 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_164), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col34 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_165), -->
                                 <!--     column_alias='session_id',                         -->
                                 <!--   )                                                    -->
                                 <!-- col35 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_166), -->
                                 <!--     column_alias='buy__user',                          -->
                                 <!--   )                                                    -->
                                 <!-- col36 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_167), -->
                                 <!--     column_alias='buy__session_id',                    -->
                                 <!--   )                                                    -->
                                 <!-- col37 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
                                 <!-- col38 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
                                 <!--     column_alias='buyers',                             -->
                                 <!--   )                                                    -->
                                 <!-- col39 =                                             -->
@@ -1119,207 +1115,207 @@
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_14') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col4 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
-                                    <!--     column_alias='ds__year',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col5 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
-                                    <!--     column_alias='ds__extract_year',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col6 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
-                                    <!--     column_alias='ds__extract_quarter',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col7 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
-                                    <!--     column_alias='ds__extract_month',                  -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_5') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col4 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
+                                    <!--     column_alias='ds__year',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col5 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_97), -->
+                                    <!--     column_alias='ds__extract_year',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col6 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_98), -->
+                                    <!--     column_alias='ds__extract_quarter',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col7 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+                                    <!--     column_alias='ds__extract_month',                 -->
+                                    <!--   )                                                   -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
                                     <!--     column_alias='buy__ds__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
                                     <!--     column_alias='buy__ds__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
                                     <!--     column_alias='buy__ds__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
                                     <!--     column_alias='buy__ds__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
                                     <!--     column_alias='buy__ds__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
                                     <!--     column_alias='buy__ds__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
                                     <!--     column_alias='buy__ds__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
                                     <!--     column_alias='buy__ds__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
                                     <!--     column_alias='buy__ds__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
                                     <!--     column_alias='buy__ds__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
                                     <!--     column_alias='buy__ds__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_115), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_116), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_118), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_119), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
                                     <!--     column_alias='session_id',                         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
                                     <!--     column_alias='buy__user',                          -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
                                     <!--     column_alias='buy__session_id',                    -->
                                     <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
-                                    <!--     column_alias='buys',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
-                                    <!--     column_alias='buyers',                             -->
-                                    <!--   )                                                    -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+                                    <!--     column_alias='buys',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+                                    <!--     column_alias='buyers',                            -->
+                                    <!--   )                                                   -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_constant_properties__plan0.xml
+++ b/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_constant_properties__plan0.xml
@@ -1,21 +1,21 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_21') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_774), column_alias='metric_time__day') -->
+        <!-- node_id = NodeId(id_str='ss_12') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_246), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_773), column_alias='visit__referrer_id') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_245), column_alias='visit__referrer_id') -->
         <!-- col2 =                                                   -->
         <!--   SqlSelectColumn(                                       -->
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0),    -->
         <!--     column_alias='visit_buy_conversion_rate_by_session', -->
         <!--   )                                                      -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_20') -->
+            <!-- node_id = NodeId(id_str='ss_11') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -36,10 +36,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_19), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_10), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=FULL_OUTER,                               -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_2),    -->
@@ -58,234 +58,230 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_11') -->
-                <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_574), column_alias='metric_time__day') -->
-                <!-- col1 =                                                 -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
-                <!--     column_alias='visit__referrer_id',                 -->
-                <!--   )                                                    -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- col0 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
+                <!-- col1 =                                                -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                <!--     column_alias='visit__referrer_id',                -->
+                <!--   )                                                   -->
                 <!-- col2 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-                <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_574), column_alias='metric_time__day') -->
-                <!-- group_by1 =                                            -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
-                <!--     column_alias='visit__referrer_id',                 -->
-                <!--   )                                                    -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- group_by0 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
+                <!-- group_by1 =                                           -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                <!--     column_alias='visit__referrer_id',                -->
+                <!--   )                                                   -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_10') -->
-                    <!-- col0 =                                                 -->
-                    <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
-                    <!--     column_alias='metric_time__day',                   -->
-                    <!--   )                                                    -->
-                    <!-- col1 =                                                 -->
-                    <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
-                    <!--     column_alias='visit__referrer_id',                 -->
-                    <!--   )                                                    -->
-                    <!-- col2 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_569), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- col0 =                                                -->
+                    <!--   SqlSelectColumn(                                    -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+                    <!--     column_alias='metric_time__day',                  -->
+                    <!--   )                                                   -->
+                    <!-- col1 =                                                -->
+                    <!--   SqlSelectColumn(                                    -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+                    <!--     column_alias='visit__referrer_id',                -->
+                    <!--   )                                                   -->
+                    <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_9') -->
-                        <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_532), column_alias='ds__day') -->
-                        <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__week') -->
-                        <!-- col2 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
-                        <!--     column_alias='ds__month',                          -->
-                        <!--   )                                                    -->
-                        <!-- col3 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
-                        <!--     column_alias='ds__quarter',                        -->
-                        <!--   )                                                    -->
-                        <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_536), column_alias='ds__year') -->
-                        <!-- col5 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
-                        <!--     column_alias='ds__extract_year',                   -->
-                        <!--   )                                                    -->
-                        <!-- col6 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
-                        <!--     column_alias='ds__extract_quarter',                -->
-                        <!--   )                                                    -->
-                        <!-- col7 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
-                        <!--     column_alias='ds__extract_month',                  -->
-                        <!--   )                                                    -->
-                        <!-- col8 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
-                        <!--     column_alias='ds__extract_day',                    -->
-                        <!--   )                                                    -->
-                        <!-- col9 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
-                        <!--     column_alias='ds__extract_dow',                    -->
-                        <!--   )                                                    -->
-                        <!-- col10 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
-                        <!--     column_alias='ds__extract_doy',                    -->
-                        <!--   )                                                    -->
-                        <!-- col11 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
-                        <!--     column_alias='visit__ds__day',                     -->
-                        <!--   )                                                    -->
-                        <!-- col12 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
-                        <!--     column_alias='visit__ds__week',                    -->
-                        <!--   )                                                    -->
-                        <!-- col13 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
-                        <!--     column_alias='visit__ds__month',                   -->
-                        <!--   )                                                    -->
-                        <!-- col14 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
-                        <!--     column_alias='visit__ds__quarter',                 -->
-                        <!--   )                                                    -->
-                        <!-- col15 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
-                        <!--     column_alias='visit__ds__year',                    -->
-                        <!--   )                                                    -->
-                        <!-- col16 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
-                        <!--     column_alias='visit__ds__extract_year',            -->
-                        <!--   )                                                    -->
-                        <!-- col17 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
-                        <!--     column_alias='visit__ds__extract_quarter',         -->
-                        <!--   )                                                    -->
-                        <!-- col18 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
-                        <!--     column_alias='visit__ds__extract_month',           -->
-                        <!--   )                                                    -->
-                        <!-- col19 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
-                        <!--     column_alias='visit__ds__extract_day',             -->
-                        <!--   )                                                    -->
-                        <!-- col20 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
-                        <!--     column_alias='visit__ds__extract_dow',             -->
-                        <!--   )                                                    -->
-                        <!-- col21 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
-                        <!--     column_alias='visit__ds__extract_doy',             -->
-                        <!--   )                                                    -->
-                        <!-- col22 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
-                        <!--     column_alias='metric_time__day',                   -->
-                        <!--   )                                                    -->
-                        <!-- col23 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
-                        <!--     column_alias='metric_time__week',                  -->
-                        <!--   )                                                    -->
-                        <!-- col24 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
-                        <!--     column_alias='metric_time__month',                 -->
-                        <!--   )                                                    -->
-                        <!-- col25 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
-                        <!--     column_alias='metric_time__quarter',               -->
-                        <!--   )                                                    -->
-                        <!-- col26 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
-                        <!--     column_alias='metric_time__year',                  -->
-                        <!--   )                                                    -->
-                        <!-- col27 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
-                        <!--     column_alias='metric_time__extract_year',          -->
-                        <!--   )                                                    -->
-                        <!-- col28 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
-                        <!--     column_alias='metric_time__extract_quarter',       -->
-                        <!--   )                                                    -->
-                        <!-- col29 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
-                        <!--     column_alias='metric_time__extract_month',         -->
-                        <!--   )                                                    -->
-                        <!-- col30 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
-                        <!--     column_alias='metric_time__extract_day',           -->
-                        <!--   )                                                    -->
-                        <!-- col31 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
-                        <!--     column_alias='metric_time__extract_dow',           -->
-                        <!--   )                                                    -->
-                        <!-- col32 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
-                        <!--     column_alias='metric_time__extract_doy',           -->
-                        <!--   )                                                    -->
-                        <!-- col33 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_565), column_alias='user') -->
-                        <!-- col34 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='session') -->
-                        <!-- col35 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
-                        <!--     column_alias='visit__user',                        -->
-                        <!--   )                                                    -->
-                        <!-- col36 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
-                        <!--     column_alias='visit__session',                     -->
-                        <!--   )                                                    -->
-                        <!-- col37 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
-                        <!--     column_alias='referrer_id',                        -->
-                        <!--   )                                                    -->
-                        <!-- col38 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
-                        <!--     column_alias='visit__referrer_id',                 -->
-                        <!--   )                                                    -->
-                        <!-- col39 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='visits') -->
-                        <!-- col40 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visitors') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- col0 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
+                        <!-- col1 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__week') -->
+                        <!-- col2 =                                                                                       -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='ds__month') -->
+                        <!-- col3 =                                               -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
+                        <!--     column_alias='ds__quarter',                      -->
+                        <!--   )                                                  -->
+                        <!-- col4 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='ds__year') -->
+                        <!-- col5 =                                               -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_9), -->
+                        <!--     column_alias='ds__extract_year',                 -->
+                        <!--   )                                                  -->
+                        <!-- col6 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
+                        <!--     column_alias='ds__extract_quarter',               -->
+                        <!--   )                                                   -->
+                        <!-- col7 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
+                        <!--     column_alias='ds__extract_month',                 -->
+                        <!--   )                                                   -->
+                        <!-- col8 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
+                        <!--     column_alias='ds__extract_day',                   -->
+                        <!--   )                                                   -->
+                        <!-- col9 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                        <!--     column_alias='ds__extract_dow',                   -->
+                        <!--   )                                                   -->
+                        <!-- col10 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_14), -->
+                        <!--     column_alias='ds__extract_doy',                   -->
+                        <!--   )                                                   -->
+                        <!-- col11 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_15), -->
+                        <!--     column_alias='visit__ds__day',                    -->
+                        <!--   )                                                   -->
+                        <!-- col12 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_16), -->
+                        <!--     column_alias='visit__ds__week',                   -->
+                        <!--   )                                                   -->
+                        <!-- col13 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_17), -->
+                        <!--     column_alias='visit__ds__month',                  -->
+                        <!--   )                                                   -->
+                        <!-- col14 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_18), -->
+                        <!--     column_alias='visit__ds__quarter',                -->
+                        <!--   )                                                   -->
+                        <!-- col15 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
+                        <!--     column_alias='visit__ds__year',                   -->
+                        <!--   )                                                   -->
+                        <!-- col16 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
+                        <!--     column_alias='visit__ds__extract_year',           -->
+                        <!--   )                                                   -->
+                        <!-- col17 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_21), -->
+                        <!--     column_alias='visit__ds__extract_quarter',        -->
+                        <!--   )                                                   -->
+                        <!-- col18 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
+                        <!--     column_alias='visit__ds__extract_month',          -->
+                        <!--   )                                                   -->
+                        <!-- col19 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
+                        <!--     column_alias='visit__ds__extract_day',            -->
+                        <!--   )                                                   -->
+                        <!-- col20 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_24), -->
+                        <!--     column_alias='visit__ds__extract_dow',            -->
+                        <!--   )                                                   -->
+                        <!-- col21 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_25), -->
+                        <!--     column_alias='visit__ds__extract_doy',            -->
+                        <!--   )                                                   -->
+                        <!-- col22 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_26), -->
+                        <!--     column_alias='metric_time__day',                  -->
+                        <!--   )                                                   -->
+                        <!-- col23 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
+                        <!--     column_alias='metric_time__week',                 -->
+                        <!--   )                                                   -->
+                        <!-- col24 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
+                        <!--     column_alias='metric_time__month',                -->
+                        <!--   )                                                   -->
+                        <!-- col25 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
+                        <!--     column_alias='metric_time__quarter',              -->
+                        <!--   )                                                   -->
+                        <!-- col26 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+                        <!--     column_alias='metric_time__year',                 -->
+                        <!--   )                                                   -->
+                        <!-- col27 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+                        <!--     column_alias='metric_time__extract_year',         -->
+                        <!--   )                                                   -->
+                        <!-- col28 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                        <!--     column_alias='metric_time__extract_quarter',      -->
+                        <!--   )                                                   -->
+                        <!-- col29 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                        <!--     column_alias='metric_time__extract_month',        -->
+                        <!--   )                                                   -->
+                        <!-- col30 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                        <!--     column_alias='metric_time__extract_day',          -->
+                        <!--   )                                                   -->
+                        <!-- col31 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                        <!--     column_alias='metric_time__extract_dow',          -->
+                        <!--   )                                                   -->
+                        <!-- col32 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
+                        <!--     column_alias='metric_time__extract_doy',          -->
+                        <!--   )                                                   -->
+                        <!-- col33 =                                                                                  -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='user') -->
+                        <!-- col34 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='session') -->
+                        <!-- col35 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                        <!--     column_alias='visit__user',                       -->
+                        <!--   )                                                   -->
+                        <!-- col36 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+                        <!--     column_alias='visit__session',                    -->
+                        <!--   )                                                   -->
+                        <!-- col37 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
+                        <!--     column_alias='referrer_id',                      -->
+                        <!--   )                                                  -->
+                        <!-- col38 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_3), -->
+                        <!--     column_alias='visit__referrer_id',               -->
+                        <!--   )                                                  -->
+                        <!-- col39 =                                                                                   -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
+                        <!-- col40 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
@@ -447,12 +443,12 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_19') -->
+                <!-- node_id = NodeId(id_str='ss_10') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_762), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_234), column_alias='metric_time__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_761), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_233), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- col2 =                                                                    -->
@@ -460,62 +456,62 @@
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_762), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_234), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_761), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_233), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_18') -->
+                    <!-- node_id = NodeId(id_str='ss_9') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_759), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_231), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_758), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_230), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
-                    <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_757), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                    <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_229), column_alias='buys') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_17') -->
+                        <!-- node_id = NodeId(id_str='ss_8') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_753), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_225), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_754), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_226), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_755), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_227), column_alias='user') -->
                         <!-- col3 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_756), column_alias='session') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_228), column_alias='session') -->
                         <!-- col4 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_752), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_224), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col5 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_750), column_alias='buys') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_222), column_alias='buys') -->
                         <!-- col6 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_751), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_223), column_alias='visits') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_16') -->
+                            <!-- node_id = NodeId(id_str='ss_7') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -548,267 +544,267 @@
                             <!--   )                                                                             -->
                             <!-- col6 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_748), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_220), -->
                             <!--     column_alias='mf_internal_uuid',                   -->
                             <!--   )                                                    -->
                             <!-- col7 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_749), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
-                            <!-- join_0 =                                                -->
-                            <!--   SqlJoinDescription(                                   -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
-                            <!--     right_source_alias='subq_9',                        -->
-                            <!--     join_type=INNER,                                    -->
-                            <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
-                            <!--   )                                                     -->
+                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_221), column_alias='buys') -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- join_0 =                                               -->
+                            <!--   SqlJoinDescription(                                  -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_6), -->
+                            <!--     right_source_alias='subq_9',                       -->
+                            <!--     join_type=INNER,                                   -->
+                            <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
+                            <!--   )                                                    -->
                             <!-- where = None -->
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description =                                                         -->
                                 <!--   ("Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', " -->
                                 <!--    "'metric_time__day', 'user', 'session']")                          -->
-                                <!-- node_id = NodeId(id_str='ss_13') -->
-                                <!-- col0 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
-                                <!--     column_alias='ds__day',                            -->
-                                <!--   )                                                    -->
-                                <!-- col1 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
-                                <!--     column_alias='metric_time__day',                   -->
-                                <!--   )                                                    -->
-                                <!-- col2 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
-                                <!--     column_alias='user',                               -->
-                                <!--   )                                                    -->
-                                <!-- col3 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
-                                <!--     column_alias='session',                            -->
-                                <!--   )                                                    -->
-                                <!-- col4 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
-                                <!--     column_alias='visit__referrer_id',                 -->
-                                <!--   )                                                    -->
-                                <!-- col5 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
-                                <!--     column_alias='visits',                             -->
-                                <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+                                <!-- node_id = NodeId(id_str='ss_4') -->
+                                <!-- col0 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+                                <!--     column_alias='ds__day',                           -->
+                                <!--   )                                                   -->
+                                <!-- col1 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+                                <!--     column_alias='metric_time__day',                  -->
+                                <!--   )                                                   -->
+                                <!-- col2 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+                                <!--     column_alias='user',                              -->
+                                <!--   )                                                   -->
+                                <!-- col3 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
+                                <!--     column_alias='session',                           -->
+                                <!--   )                                                   -->
+                                <!-- col4 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+                                <!--     column_alias='visit__referrer_id',                -->
+                                <!--   )                                                   -->
+                                <!-- col5 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+                                <!--     column_alias='visits',                            -->
+                                <!--   )                                                   -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_12') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col4 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
-                                    <!--     column_alias='ds__year',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col5 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
-                                    <!--     column_alias='ds__extract_year',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col6 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
-                                    <!--     column_alias='ds__extract_quarter',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col7 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
-                                    <!--     column_alias='ds__extract_month',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col8 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
-                                    <!--     column_alias='ds__extract_day',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col9 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
-                                    <!--     column_alias='ds__extract_dow',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col10 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
-                                    <!--     column_alias='ds__extract_doy',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col11 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
-                                    <!--     column_alias='visit__ds__day',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col12 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
-                                    <!--     column_alias='visit__ds__week',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col13 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
-                                    <!--     column_alias='visit__ds__month',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col14 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
-                                    <!--     column_alias='visit__ds__quarter',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col15 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
-                                    <!--     column_alias='visit__ds__year',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col16 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
-                                    <!--     column_alias='visit__ds__extract_year',            -->
-                                    <!--   )                                                    -->
-                                    <!-- col17 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
-                                    <!--     column_alias='visit__ds__extract_quarter',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col18 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
-                                    <!--     column_alias='visit__ds__extract_month',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col19 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
-                                    <!--     column_alias='visit__ds__extract_day',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col20 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
-                                    <!--     column_alias='visit__ds__extract_dow',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col21 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
-                                    <!--     column_alias='visit__ds__extract_doy',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col22 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
-                                    <!--     column_alias='metric_time__day',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col23 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
-                                    <!--     column_alias='metric_time__week',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col24 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
-                                    <!--     column_alias='metric_time__month',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col25 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
-                                    <!--     column_alias='metric_time__quarter',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col26 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
-                                    <!--     column_alias='metric_time__year',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col27 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
-                                    <!--     column_alias='metric_time__extract_year',          -->
-                                    <!--   )                                                    -->
-                                    <!-- col28 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
-                                    <!--     column_alias='metric_time__extract_quarter',       -->
-                                    <!--   )                                                    -->
-                                    <!-- col29 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
-                                    <!--     column_alias='metric_time__extract_month',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col30 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
-                                    <!--     column_alias='metric_time__extract_day',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col31 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
-                                    <!--     column_alias='metric_time__extract_dow',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col32 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
-                                    <!--     column_alias='metric_time__extract_doy',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col33 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
-                                    <!--     column_alias='user',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col34 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
-                                    <!--     column_alias='session',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col35 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
-                                    <!--     column_alias='visit__user',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col36 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
-                                    <!--     column_alias='visit__session',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
-                                    <!--     column_alias='referrer_id',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
-                                    <!--     column_alias='visit__referrer_id',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col39 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
-                                    <!--     column_alias='visits',                             -->
-                                    <!--   )                                                    -->
-                                    <!-- col40 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
-                                    <!--     column_alias='visitors',                           -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_3') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col4 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                                    <!--     column_alias='ds__year',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col5 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                                    <!--     column_alias='ds__extract_year',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col6 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+                                    <!--     column_alias='ds__extract_quarter',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col7 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
+                                    <!--     column_alias='ds__extract_month',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col8 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+                                    <!--     column_alias='ds__extract_day',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col9 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
+                                    <!--     column_alias='ds__extract_dow',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col10 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+                                    <!--     column_alias='ds__extract_doy',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col11 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+                                    <!--     column_alias='visit__ds__day',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col12 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+                                    <!--     column_alias='visit__ds__week',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col13 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
+                                    <!--     column_alias='visit__ds__month',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col14 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
+                                    <!--     column_alias='visit__ds__quarter',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col15 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
+                                    <!--     column_alias='visit__ds__year',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col16 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
+                                    <!--     column_alias='visit__ds__extract_year',           -->
+                                    <!--   )                                                   -->
+                                    <!-- col17 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+                                    <!--     column_alias='visit__ds__extract_quarter',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col18 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+                                    <!--     column_alias='visit__ds__extract_month',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col19 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+                                    <!--     column_alias='visit__ds__extract_day',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col20 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+                                    <!--     column_alias='visit__ds__extract_dow',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col21 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+                                    <!--     column_alias='visit__ds__extract_doy',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col22 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                                    <!--     column_alias='metric_time__day',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col23 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
+                                    <!--     column_alias='metric_time__week',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col24 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+                                    <!--     column_alias='metric_time__month',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col25 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                                    <!--     column_alias='metric_time__quarter',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col26 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                                    <!--     column_alias='metric_time__year',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                                    <!--     column_alias='metric_time__extract_year',         -->
+                                    <!--   )                                                   -->
+                                    <!-- col28 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+                                    <!--     column_alias='metric_time__extract_quarter',      -->
+                                    <!--   )                                                   -->
+                                    <!-- col29 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+                                    <!--     column_alias='metric_time__extract_month',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col30 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+                                    <!--     column_alias='metric_time__extract_day',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col31 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                                    <!--     column_alias='metric_time__extract_dow',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col32 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_83), -->
+                                    <!--     column_alias='metric_time__extract_doy',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col33 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
+                                    <!--     column_alias='user',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col34 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
+                                    <!--     column_alias='session',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col35 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+                                    <!--     column_alias='visit__user',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col36 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+                                    <!--     column_alias='visit__session',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                                    <!--     column_alias='referrer_id',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+                                    <!--     column_alias='visit__referrer_id',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col39 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+                                    <!--     column_alias='visits',                            -->
+                                    <!--   )                                                   -->
+                                    <!-- col40 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+                                    <!--     column_alias='visitors',                          -->
+                                    <!--   )                                                   -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
@@ -978,200 +974,200 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_15') -->
+                                <!-- node_id = NodeId(id_str='ss_6') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
                                 <!--     column_alias='ds__week',                           -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
                                 <!--     column_alias='ds__month',                          -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
                                 <!--     column_alias='ds__quarter',                        -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
                                 <!--     column_alias='ds__year',                           -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
                                 <!--     column_alias='ds__extract_year',                   -->
                                 <!--   )                                                    -->
                                 <!-- col6 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_141), -->
                                 <!--     column_alias='ds__extract_quarter',                -->
                                 <!--   )                                                    -->
                                 <!-- col7 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_142), -->
                                 <!--     column_alias='ds__extract_month',                  -->
                                 <!--   )                                                    -->
                                 <!-- col8 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_143), -->
                                 <!--     column_alias='ds__extract_day',                    -->
                                 <!--   )                                                    -->
                                 <!-- col9 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_144), -->
                                 <!--     column_alias='ds__extract_dow',                    -->
                                 <!--   )                                                    -->
                                 <!-- col10 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
                                 <!--     column_alias='ds__extract_doy',                    -->
                                 <!--   )                                                    -->
                                 <!-- col11 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
                                 <!--     column_alias='buy__ds__day',                       -->
                                 <!--   )                                                    -->
                                 <!-- col12 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_147), -->
                                 <!--     column_alias='buy__ds__week',                      -->
                                 <!--   )                                                    -->
                                 <!-- col13 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_148), -->
                                 <!--     column_alias='buy__ds__month',                     -->
                                 <!--   )                                                    -->
                                 <!-- col14 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_149), -->
                                 <!--     column_alias='buy__ds__quarter',                   -->
                                 <!--   )                                                    -->
                                 <!-- col15 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_150), -->
                                 <!--     column_alias='buy__ds__year',                      -->
                                 <!--   )                                                    -->
                                 <!-- col16 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_151), -->
                                 <!--     column_alias='buy__ds__extract_year',              -->
                                 <!--   )                                                    -->
                                 <!-- col17 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_152), -->
                                 <!--     column_alias='buy__ds__extract_quarter',           -->
                                 <!--   )                                                    -->
                                 <!-- col18 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_153), -->
                                 <!--     column_alias='buy__ds__extract_month',             -->
                                 <!--   )                                                    -->
                                 <!-- col19 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_154), -->
                                 <!--     column_alias='buy__ds__extract_day',               -->
                                 <!--   )                                                    -->
                                 <!-- col20 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_155), -->
                                 <!--     column_alias='buy__ds__extract_dow',               -->
                                 <!--   )                                                    -->
                                 <!-- col21 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_156), -->
                                 <!--     column_alias='buy__ds__extract_doy',               -->
                                 <!--   )                                                    -->
                                 <!-- col22 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_157), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col23 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_158), -->
                                 <!--     column_alias='metric_time__week',                  -->
                                 <!--   )                                                    -->
                                 <!-- col24 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_159), -->
                                 <!--     column_alias='metric_time__month',                 -->
                                 <!--   )                                                    -->
                                 <!-- col25 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_160), -->
                                 <!--     column_alias='metric_time__quarter',               -->
                                 <!--   )                                                    -->
                                 <!-- col26 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_161), -->
                                 <!--     column_alias='metric_time__year',                  -->
                                 <!--   )                                                    -->
                                 <!-- col27 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
                                 <!--     column_alias='metric_time__extract_year',          -->
                                 <!--   )                                                    -->
                                 <!-- col28 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_163), -->
                                 <!--     column_alias='metric_time__extract_quarter',       -->
                                 <!--   )                                                    -->
                                 <!-- col29 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_164), -->
                                 <!--     column_alias='metric_time__extract_month',         -->
                                 <!--   )                                                    -->
                                 <!-- col30 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_165), -->
                                 <!--     column_alias='metric_time__extract_day',           -->
                                 <!--   )                                                    -->
                                 <!-- col31 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_166), -->
                                 <!--     column_alias='metric_time__extract_dow',           -->
                                 <!--   )                                                    -->
                                 <!-- col32 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_167), -->
                                 <!--     column_alias='metric_time__extract_doy',           -->
                                 <!--   )                                                    -->
                                 <!-- col33 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_168), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col34 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_169), -->
                                 <!--     column_alias='session_id',                         -->
                                 <!--   )                                                    -->
                                 <!-- col35 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_698), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_170), -->
                                 <!--     column_alias='buy__user',                          -->
                                 <!--   )                                                    -->
                                 <!-- col36 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_699), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_171), -->
                                 <!--     column_alias='buy__session_id',                    -->
                                 <!--   )                                                    -->
                                 <!-- col37 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
                                 <!-- col38 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
                                 <!--     column_alias='buyers',                             -->
                                 <!--   )                                                    -->
                                 <!-- col39 =                                             -->
@@ -1179,207 +1175,207 @@
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_14') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_5') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_97), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_98), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
                                     <!--     column_alias='buy__ds__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
                                     <!--     column_alias='buy__ds__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
                                     <!--     column_alias='buy__ds__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
                                     <!--     column_alias='buy__ds__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
                                     <!--     column_alias='buy__ds__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
                                     <!--     column_alias='buy__ds__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
                                     <!--     column_alias='buy__ds__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
                                     <!--     column_alias='buy__ds__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_115), -->
                                     <!--     column_alias='buy__ds__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_116), -->
                                     <!--     column_alias='buy__ds__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
                                     <!--     column_alias='buy__ds__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_118), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_119), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
                                     <!--     column_alias='session_id',                         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
                                     <!--     column_alias='buy__user',                          -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_132), -->
                                     <!--     column_alias='buy__session_id',                    -->
                                     <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
-                                    <!--     column_alias='buys',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
-                                    <!--     column_alias='buyers',                             -->
-                                    <!--   )                                                    -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
+                                    <!--     column_alias='buys',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
+                                    <!--     column_alias='buyers',                            -->
+                                    <!--   )                                                   -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_no_group_by__plan0.xml
+++ b/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_no_group_by__plan0.xml
@@ -1,18 +1,18 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_21') -->
+        <!-- node_id = NodeId(id_str='ss_12') -->
         <!-- col0 =                                                -->
         <!--   SqlSelectColumn(                                    -->
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0), -->
         <!--     column_alias='visit_buy_conversion_rate_7days',   -->
         <!--   )                                                   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_20') -->
+            <!-- node_id = NodeId(id_str='ss_11') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX), -->
@@ -23,10 +23,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_19), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_10), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=CROSS_JOIN,                               -->
             <!--   )                                                     -->
@@ -34,210 +34,206 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_11') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits',]" -->
-                    <!-- node_id = NodeId(id_str='ss_10') -->
-                    <!-- col0 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_569), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_9') -->
-                        <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_532), column_alias='ds__day') -->
-                        <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__week') -->
-                        <!-- col2 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
-                        <!--     column_alias='ds__month',                          -->
-                        <!--   )                                                    -->
-                        <!-- col3 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
-                        <!--     column_alias='ds__quarter',                        -->
-                        <!--   )                                                    -->
-                        <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_536), column_alias='ds__year') -->
-                        <!-- col5 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
-                        <!--     column_alias='ds__extract_year',                   -->
-                        <!--   )                                                    -->
-                        <!-- col6 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
-                        <!--     column_alias='ds__extract_quarter',                -->
-                        <!--   )                                                    -->
-                        <!-- col7 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
-                        <!--     column_alias='ds__extract_month',                  -->
-                        <!--   )                                                    -->
-                        <!-- col8 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
-                        <!--     column_alias='ds__extract_day',                    -->
-                        <!--   )                                                    -->
-                        <!-- col9 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
-                        <!--     column_alias='ds__extract_dow',                    -->
-                        <!--   )                                                    -->
-                        <!-- col10 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
-                        <!--     column_alias='ds__extract_doy',                    -->
-                        <!--   )                                                    -->
-                        <!-- col11 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
-                        <!--     column_alias='visit__ds__day',                     -->
-                        <!--   )                                                    -->
-                        <!-- col12 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
-                        <!--     column_alias='visit__ds__week',                    -->
-                        <!--   )                                                    -->
-                        <!-- col13 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
-                        <!--     column_alias='visit__ds__month',                   -->
-                        <!--   )                                                    -->
-                        <!-- col14 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
-                        <!--     column_alias='visit__ds__quarter',                 -->
-                        <!--   )                                                    -->
-                        <!-- col15 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
-                        <!--     column_alias='visit__ds__year',                    -->
-                        <!--   )                                                    -->
-                        <!-- col16 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
-                        <!--     column_alias='visit__ds__extract_year',            -->
-                        <!--   )                                                    -->
-                        <!-- col17 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
-                        <!--     column_alias='visit__ds__extract_quarter',         -->
-                        <!--   )                                                    -->
-                        <!-- col18 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
-                        <!--     column_alias='visit__ds__extract_month',           -->
-                        <!--   )                                                    -->
-                        <!-- col19 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
-                        <!--     column_alias='visit__ds__extract_day',             -->
-                        <!--   )                                                    -->
-                        <!-- col20 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
-                        <!--     column_alias='visit__ds__extract_dow',             -->
-                        <!--   )                                                    -->
-                        <!-- col21 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
-                        <!--     column_alias='visit__ds__extract_doy',             -->
-                        <!--   )                                                    -->
-                        <!-- col22 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
-                        <!--     column_alias='metric_time__day',                   -->
-                        <!--   )                                                    -->
-                        <!-- col23 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
-                        <!--     column_alias='metric_time__week',                  -->
-                        <!--   )                                                    -->
-                        <!-- col24 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
-                        <!--     column_alias='metric_time__month',                 -->
-                        <!--   )                                                    -->
-                        <!-- col25 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
-                        <!--     column_alias='metric_time__quarter',               -->
-                        <!--   )                                                    -->
-                        <!-- col26 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
-                        <!--     column_alias='metric_time__year',                  -->
-                        <!--   )                                                    -->
-                        <!-- col27 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
-                        <!--     column_alias='metric_time__extract_year',          -->
-                        <!--   )                                                    -->
-                        <!-- col28 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
-                        <!--     column_alias='metric_time__extract_quarter',       -->
-                        <!--   )                                                    -->
-                        <!-- col29 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
-                        <!--     column_alias='metric_time__extract_month',         -->
-                        <!--   )                                                    -->
-                        <!-- col30 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
-                        <!--     column_alias='metric_time__extract_day',           -->
-                        <!--   )                                                    -->
-                        <!-- col31 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
-                        <!--     column_alias='metric_time__extract_dow',           -->
-                        <!--   )                                                    -->
-                        <!-- col32 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
-                        <!--     column_alias='metric_time__extract_doy',           -->
-                        <!--   )                                                    -->
-                        <!-- col33 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_565), column_alias='user') -->
-                        <!-- col34 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='session') -->
-                        <!-- col35 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
-                        <!--     column_alias='visit__user',                        -->
-                        <!--   )                                                    -->
-                        <!-- col36 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
-                        <!--     column_alias='visit__session',                     -->
-                        <!--   )                                                    -->
-                        <!-- col37 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
-                        <!--     column_alias='referrer_id',                        -->
-                        <!--   )                                                    -->
-                        <!-- col38 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
-                        <!--     column_alias='visit__referrer_id',                 -->
-                        <!--   )                                                    -->
-                        <!-- col39 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='visits') -->
-                        <!-- col40 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visitors') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- col0 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
+                        <!-- col1 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__week') -->
+                        <!-- col2 =                                                                                       -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='ds__month') -->
+                        <!-- col3 =                                               -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
+                        <!--     column_alias='ds__quarter',                      -->
+                        <!--   )                                                  -->
+                        <!-- col4 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='ds__year') -->
+                        <!-- col5 =                                               -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_9), -->
+                        <!--     column_alias='ds__extract_year',                 -->
+                        <!--   )                                                  -->
+                        <!-- col6 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
+                        <!--     column_alias='ds__extract_quarter',               -->
+                        <!--   )                                                   -->
+                        <!-- col7 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
+                        <!--     column_alias='ds__extract_month',                 -->
+                        <!--   )                                                   -->
+                        <!-- col8 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
+                        <!--     column_alias='ds__extract_day',                   -->
+                        <!--   )                                                   -->
+                        <!-- col9 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                        <!--     column_alias='ds__extract_dow',                   -->
+                        <!--   )                                                   -->
+                        <!-- col10 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_14), -->
+                        <!--     column_alias='ds__extract_doy',                   -->
+                        <!--   )                                                   -->
+                        <!-- col11 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_15), -->
+                        <!--     column_alias='visit__ds__day',                    -->
+                        <!--   )                                                   -->
+                        <!-- col12 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_16), -->
+                        <!--     column_alias='visit__ds__week',                   -->
+                        <!--   )                                                   -->
+                        <!-- col13 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_17), -->
+                        <!--     column_alias='visit__ds__month',                  -->
+                        <!--   )                                                   -->
+                        <!-- col14 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_18), -->
+                        <!--     column_alias='visit__ds__quarter',                -->
+                        <!--   )                                                   -->
+                        <!-- col15 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
+                        <!--     column_alias='visit__ds__year',                   -->
+                        <!--   )                                                   -->
+                        <!-- col16 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
+                        <!--     column_alias='visit__ds__extract_year',           -->
+                        <!--   )                                                   -->
+                        <!-- col17 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_21), -->
+                        <!--     column_alias='visit__ds__extract_quarter',        -->
+                        <!--   )                                                   -->
+                        <!-- col18 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
+                        <!--     column_alias='visit__ds__extract_month',          -->
+                        <!--   )                                                   -->
+                        <!-- col19 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
+                        <!--     column_alias='visit__ds__extract_day',            -->
+                        <!--   )                                                   -->
+                        <!-- col20 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_24), -->
+                        <!--     column_alias='visit__ds__extract_dow',            -->
+                        <!--   )                                                   -->
+                        <!-- col21 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_25), -->
+                        <!--     column_alias='visit__ds__extract_doy',            -->
+                        <!--   )                                                   -->
+                        <!-- col22 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_26), -->
+                        <!--     column_alias='metric_time__day',                  -->
+                        <!--   )                                                   -->
+                        <!-- col23 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
+                        <!--     column_alias='metric_time__week',                 -->
+                        <!--   )                                                   -->
+                        <!-- col24 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
+                        <!--     column_alias='metric_time__month',                -->
+                        <!--   )                                                   -->
+                        <!-- col25 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
+                        <!--     column_alias='metric_time__quarter',              -->
+                        <!--   )                                                   -->
+                        <!-- col26 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+                        <!--     column_alias='metric_time__year',                 -->
+                        <!--   )                                                   -->
+                        <!-- col27 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+                        <!--     column_alias='metric_time__extract_year',         -->
+                        <!--   )                                                   -->
+                        <!-- col28 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                        <!--     column_alias='metric_time__extract_quarter',      -->
+                        <!--   )                                                   -->
+                        <!-- col29 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                        <!--     column_alias='metric_time__extract_month',        -->
+                        <!--   )                                                   -->
+                        <!-- col30 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                        <!--     column_alias='metric_time__extract_day',          -->
+                        <!--   )                                                   -->
+                        <!-- col31 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                        <!--     column_alias='metric_time__extract_dow',          -->
+                        <!--   )                                                   -->
+                        <!-- col32 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
+                        <!--     column_alias='metric_time__extract_doy',          -->
+                        <!--   )                                                   -->
+                        <!-- col33 =                                                                                  -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='user') -->
+                        <!-- col34 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='session') -->
+                        <!-- col35 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                        <!--     column_alias='visit__user',                       -->
+                        <!--   )                                                   -->
+                        <!-- col36 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+                        <!--     column_alias='visit__session',                    -->
+                        <!--   )                                                   -->
+                        <!-- col37 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
+                        <!--     column_alias='referrer_id',                      -->
+                        <!--   )                                                  -->
+                        <!-- col38 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_3), -->
+                        <!--     column_alias='visit__referrer_id',               -->
+                        <!--   )                                                  -->
+                        <!-- col39 =                                                                                   -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
+                        <!-- col40 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
@@ -399,39 +395,39 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_19') -->
+                <!-- node_id = NodeId(id_str='ss_10') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys',]" -->
-                    <!-- node_id = NodeId(id_str='ss_18') -->
-                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_721), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                    <!-- node_id = NodeId(id_str='ss_9') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_193), column_alias='buys') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_17') -->
+                        <!-- node_id = NodeId(id_str='ss_8') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_719), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_191), column_alias='ds__day') -->
                         <!-- col1 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_720), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_192), column_alias='user') -->
                         <!-- col2 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_717), column_alias='buys') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_189), column_alias='buys') -->
                         <!-- col3 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_718), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_190), column_alias='visits') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_16') -->
+                            <!-- node_id = NodeId(id_str='ss_7') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -449,250 +445,250 @@
                             <!--   )                                                                             -->
                             <!-- col3 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_715), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_187), -->
                             <!--     column_alias='mf_internal_uuid',                   -->
                             <!--   )                                                    -->
                             <!-- col4 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_716), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
-                            <!-- join_0 =                                                -->
-                            <!--   SqlJoinDescription(                                   -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
-                            <!--     right_source_alias='subq_9',                        -->
-                            <!--     join_type=INNER,                                    -->
-                            <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
-                            <!--   )                                                     -->
+                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_188), column_alias='buys') -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- join_0 =                                               -->
+                            <!--   SqlJoinDescription(                                  -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_6), -->
+                            <!--     right_source_alias='subq_9',                       -->
+                            <!--     join_type=INNER,                                   -->
+                            <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
+                            <!--   )                                                    -->
                             <!-- where = None -->
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['visits', 'ds__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_13') -->
-                                <!-- col0 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
-                                <!--     column_alias='ds__day',                            -->
-                                <!--   )                                                    -->
-                                <!-- col1 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
-                                <!--     column_alias='user',                               -->
-                                <!--   )                                                    -->
-                                <!-- col2 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
-                                <!--     column_alias='visits',                             -->
-                                <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+                                <!-- node_id = NodeId(id_str='ss_4') -->
+                                <!-- col0 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
+                                <!--     column_alias='ds__day',                           -->
+                                <!--   )                                                   -->
+                                <!-- col1 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+                                <!--     column_alias='user',                              -->
+                                <!--   )                                                   -->
+                                <!-- col2 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
+                                <!--     column_alias='visits',                            -->
+                                <!--   )                                                   -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_12') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col4 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
-                                    <!--     column_alias='ds__year',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col5 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
-                                    <!--     column_alias='ds__extract_year',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col6 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
-                                    <!--     column_alias='ds__extract_quarter',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col7 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
-                                    <!--     column_alias='ds__extract_month',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col8 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
-                                    <!--     column_alias='ds__extract_day',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col9 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
-                                    <!--     column_alias='ds__extract_dow',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col10 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
-                                    <!--     column_alias='ds__extract_doy',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col11 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
-                                    <!--     column_alias='visit__ds__day',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col12 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
-                                    <!--     column_alias='visit__ds__week',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col13 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
-                                    <!--     column_alias='visit__ds__month',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col14 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
-                                    <!--     column_alias='visit__ds__quarter',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col15 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
-                                    <!--     column_alias='visit__ds__year',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col16 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
-                                    <!--     column_alias='visit__ds__extract_year',            -->
-                                    <!--   )                                                    -->
-                                    <!-- col17 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
-                                    <!--     column_alias='visit__ds__extract_quarter',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col18 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
-                                    <!--     column_alias='visit__ds__extract_month',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col19 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
-                                    <!--     column_alias='visit__ds__extract_day',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col20 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
-                                    <!--     column_alias='visit__ds__extract_dow',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col21 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
-                                    <!--     column_alias='visit__ds__extract_doy',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col22 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
-                                    <!--     column_alias='metric_time__day',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col23 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
-                                    <!--     column_alias='metric_time__week',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col24 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
-                                    <!--     column_alias='metric_time__month',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col25 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
-                                    <!--     column_alias='metric_time__quarter',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col26 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
-                                    <!--     column_alias='metric_time__year',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col27 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
-                                    <!--     column_alias='metric_time__extract_year',          -->
-                                    <!--   )                                                    -->
-                                    <!-- col28 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
-                                    <!--     column_alias='metric_time__extract_quarter',       -->
-                                    <!--   )                                                    -->
-                                    <!-- col29 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
-                                    <!--     column_alias='metric_time__extract_month',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col30 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
-                                    <!--     column_alias='metric_time__extract_day',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col31 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
-                                    <!--     column_alias='metric_time__extract_dow',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col32 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
-                                    <!--     column_alias='metric_time__extract_doy',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col33 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
-                                    <!--     column_alias='user',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col34 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
-                                    <!--     column_alias='session',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col35 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
-                                    <!--     column_alias='visit__user',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col36 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
-                                    <!--     column_alias='visit__session',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
-                                    <!--     column_alias='referrer_id',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
-                                    <!--     column_alias='visit__referrer_id',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col39 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
-                                    <!--     column_alias='visits',                             -->
-                                    <!--   )                                                    -->
-                                    <!-- col40 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
-                                    <!--     column_alias='visitors',                           -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_3') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col4 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                                    <!--     column_alias='ds__year',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col5 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                                    <!--     column_alias='ds__extract_year',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col6 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+                                    <!--     column_alias='ds__extract_quarter',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col7 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+                                    <!--     column_alias='ds__extract_month',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col8 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                                    <!--     column_alias='ds__extract_day',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col9 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                                    <!--     column_alias='ds__extract_dow',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col10 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+                                    <!--     column_alias='ds__extract_doy',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col11 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
+                                    <!--     column_alias='visit__ds__day',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col12 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+                                    <!--     column_alias='visit__ds__week',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col13 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
+                                    <!--     column_alias='visit__ds__month',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col14 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+                                    <!--     column_alias='visit__ds__quarter',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col15 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+                                    <!--     column_alias='visit__ds__year',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col16 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+                                    <!--     column_alias='visit__ds__extract_year',           -->
+                                    <!--   )                                                   -->
+                                    <!-- col17 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
+                                    <!--     column_alias='visit__ds__extract_quarter',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col18 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
+                                    <!--     column_alias='visit__ds__extract_month',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col19 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
+                                    <!--     column_alias='visit__ds__extract_day',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col20 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
+                                    <!--     column_alias='visit__ds__extract_dow',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col21 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+                                    <!--     column_alias='visit__ds__extract_doy',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col22 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+                                    <!--     column_alias='metric_time__day',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col23 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+                                    <!--     column_alias='metric_time__week',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col24 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+                                    <!--     column_alias='metric_time__month',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col25 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+                                    <!--     column_alias='metric_time__quarter',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col26 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                                    <!--     column_alias='metric_time__year',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
+                                    <!--     column_alias='metric_time__extract_year',         -->
+                                    <!--   )                                                   -->
+                                    <!-- col28 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+                                    <!--     column_alias='metric_time__extract_quarter',      -->
+                                    <!--   )                                                   -->
+                                    <!-- col29 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                                    <!--     column_alias='metric_time__extract_month',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col30 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                                    <!--     column_alias='metric_time__extract_day',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col31 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                                    <!--     column_alias='metric_time__extract_dow',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col32 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+                                    <!--     column_alias='metric_time__extract_doy',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col33 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+                                    <!--     column_alias='user',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col34 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+                                    <!--     column_alias='session',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col35 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                                    <!--     column_alias='visit__user',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col36 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_83), -->
+                                    <!--     column_alias='visit__session',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                                    <!--     column_alias='referrer_id',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
+                                    <!--     column_alias='visit__referrer_id',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col39 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+                                    <!--     column_alias='visits',                            -->
+                                    <!--   )                                                   -->
+                                    <!-- col40 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+                                    <!--     column_alias='visitors',                          -->
+                                    <!--   )                                                   -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
@@ -862,200 +858,200 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_15') -->
+                                <!-- node_id = NodeId(id_str='ss_6') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
                                 <!--     column_alias='ds__week',                           -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
                                 <!--     column_alias='ds__month',                          -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
                                 <!--     column_alias='ds__quarter',                        -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_132), -->
                                 <!--     column_alias='ds__year',                           -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
                                 <!--     column_alias='ds__extract_year',                   -->
                                 <!--   )                                                    -->
                                 <!-- col6 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
                                 <!--     column_alias='ds__extract_quarter',                -->
                                 <!--   )                                                    -->
                                 <!-- col7 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
                                 <!--     column_alias='ds__extract_month',                  -->
                                 <!--   )                                                    -->
                                 <!-- col8 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
                                 <!--     column_alias='ds__extract_day',                    -->
                                 <!--   )                                                    -->
                                 <!-- col9 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
                                 <!--     column_alias='ds__extract_dow',                    -->
                                 <!--   )                                                    -->
                                 <!-- col10 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
                                 <!--     column_alias='ds__extract_doy',                    -->
                                 <!--   )                                                    -->
                                 <!-- col11 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
                                 <!--     column_alias='buy__ds__day',                       -->
                                 <!--   )                                                    -->
                                 <!-- col12 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
                                 <!--     column_alias='buy__ds__week',                      -->
                                 <!--   )                                                    -->
                                 <!-- col13 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_141), -->
                                 <!--     column_alias='buy__ds__month',                     -->
                                 <!--   )                                                    -->
                                 <!-- col14 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_142), -->
                                 <!--     column_alias='buy__ds__quarter',                   -->
                                 <!--   )                                                    -->
                                 <!-- col15 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_143), -->
                                 <!--     column_alias='buy__ds__year',                      -->
                                 <!--   )                                                    -->
                                 <!-- col16 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_144), -->
                                 <!--     column_alias='buy__ds__extract_year',              -->
                                 <!--   )                                                    -->
                                 <!-- col17 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
                                 <!--     column_alias='buy__ds__extract_quarter',           -->
                                 <!--   )                                                    -->
                                 <!-- col18 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
                                 <!--     column_alias='buy__ds__extract_month',             -->
                                 <!--   )                                                    -->
                                 <!-- col19 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_147), -->
                                 <!--     column_alias='buy__ds__extract_day',               -->
                                 <!--   )                                                    -->
                                 <!-- col20 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_148), -->
                                 <!--     column_alias='buy__ds__extract_dow',               -->
                                 <!--   )                                                    -->
                                 <!-- col21 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_149), -->
                                 <!--     column_alias='buy__ds__extract_doy',               -->
                                 <!--   )                                                    -->
                                 <!-- col22 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_150), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col23 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_151), -->
                                 <!--     column_alias='metric_time__week',                  -->
                                 <!--   )                                                    -->
                                 <!-- col24 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_152), -->
                                 <!--     column_alias='metric_time__month',                 -->
                                 <!--   )                                                    -->
                                 <!-- col25 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_153), -->
                                 <!--     column_alias='metric_time__quarter',               -->
                                 <!--   )                                                    -->
                                 <!-- col26 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_154), -->
                                 <!--     column_alias='metric_time__year',                  -->
                                 <!--   )                                                    -->
                                 <!-- col27 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_155), -->
                                 <!--     column_alias='metric_time__extract_year',          -->
                                 <!--   )                                                    -->
                                 <!-- col28 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_156), -->
                                 <!--     column_alias='metric_time__extract_quarter',       -->
                                 <!--   )                                                    -->
                                 <!-- col29 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_157), -->
                                 <!--     column_alias='metric_time__extract_month',         -->
                                 <!--   )                                                    -->
                                 <!-- col30 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_158), -->
                                 <!--     column_alias='metric_time__extract_day',           -->
                                 <!--   )                                                    -->
                                 <!-- col31 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_159), -->
                                 <!--     column_alias='metric_time__extract_dow',           -->
                                 <!--   )                                                    -->
                                 <!-- col32 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_160), -->
                                 <!--     column_alias='metric_time__extract_doy',           -->
                                 <!--   )                                                    -->
                                 <!-- col33 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_161), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col34 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
                                 <!--     column_alias='session_id',                         -->
                                 <!--   )                                                    -->
                                 <!-- col35 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_163), -->
                                 <!--     column_alias='buy__user',                          -->
                                 <!--   )                                                    -->
                                 <!-- col36 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_164), -->
                                 <!--     column_alias='buy__session_id',                    -->
                                 <!--   )                                                    -->
                                 <!-- col37 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
                                 <!-- col38 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
                                 <!--     column_alias='buyers',                             -->
                                 <!--   )                                                    -->
                                 <!-- col39 =                                             -->
@@ -1063,207 +1059,207 @@
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_14') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col4 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
-                                    <!--     column_alias='ds__year',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col5 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
-                                    <!--     column_alias='ds__extract_year',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col6 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
-                                    <!--     column_alias='ds__extract_quarter',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col7 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
-                                    <!--     column_alias='ds__extract_month',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col8 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
-                                    <!--     column_alias='ds__extract_day',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col9 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
-                                    <!--     column_alias='ds__extract_dow',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col10 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
-                                    <!--     column_alias='ds__extract_doy',                    -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_5') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col4 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
+                                    <!--     column_alias='ds__year',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col5 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
+                                    <!--     column_alias='ds__extract_year',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col6 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
+                                    <!--     column_alias='ds__extract_quarter',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col7 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
+                                    <!--     column_alias='ds__extract_month',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col8 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_97), -->
+                                    <!--     column_alias='ds__extract_day',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col9 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_98), -->
+                                    <!--     column_alias='ds__extract_dow',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col10 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+                                    <!--     column_alias='ds__extract_doy',                   -->
+                                    <!--   )                                                   -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                                     <!--     column_alias='buy__ds__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
                                     <!--     column_alias='buy__ds__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
                                     <!--     column_alias='buy__ds__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
                                     <!--     column_alias='buy__ds__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
                                     <!--     column_alias='buy__ds__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
                                     <!--     column_alias='buy__ds__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
                                     <!--     column_alias='buy__ds__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
                                     <!--     column_alias='buy__ds__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
                                     <!--     column_alias='buy__ds__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
                                     <!--     column_alias='buy__ds__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
                                     <!--     column_alias='buy__ds__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_115), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_116), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_118), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_119), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
                                     <!--     column_alias='session_id',                         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
                                     <!--     column_alias='buy__user',                          -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
                                     <!--     column_alias='buy__session_id',                    -->
                                     <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
-                                    <!--     column_alias='buys',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
-                                    <!--     column_alias='buyers',                             -->
-                                    <!--   )                                                    -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+                                    <!--     column_alias='buys',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+                                    <!--     column_alias='buyers',                            -->
+                                    <!--   )                                                   -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_window__plan0.xml
+++ b/metricflow/test/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_window__plan0.xml
@@ -1,21 +1,21 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_21') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_758), column_alias='metric_time__day') -->
+        <!-- node_id = NodeId(id_str='ss_12') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_230), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_757), column_alias='visit__referrer_id') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_229), column_alias='visit__referrer_id') -->
         <!-- col2 =                                                -->
         <!--   SqlSelectColumn(                                    -->
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0), -->
         <!--     column_alias='visit_buy_conversion_rate_7days',   -->
         <!--   )                                                   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_20) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_20') -->
+            <!-- node_id = NodeId(id_str='ss_11') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -36,10 +36,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_19), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_10), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=FULL_OUTER,                               -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_2),    -->
@@ -58,234 +58,230 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_11') -->
-                <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_574), column_alias='metric_time__day') -->
-                <!-- col1 =                                                 -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
-                <!--     column_alias='visit__referrer_id',                 -->
-                <!--   )                                                    -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- col0 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
+                <!-- col1 =                                                -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                <!--     column_alias='visit__referrer_id',                -->
+                <!--   )                                                   -->
                 <!-- col2 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
-                <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_574), column_alias='metric_time__day') -->
-                <!-- group_by1 =                                            -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
-                <!--     column_alias='visit__referrer_id',                 -->
-                <!--   )                                                    -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- group_by0 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
+                <!-- group_by1 =                                           -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                <!--     column_alias='visit__referrer_id',                -->
+                <!--   )                                                   -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_10') -->
-                    <!-- col0 =                                                 -->
-                    <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
-                    <!--     column_alias='metric_time__day',                   -->
-                    <!--   )                                                    -->
-                    <!-- col1 =                                                 -->
-                    <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
-                    <!--     column_alias='visit__referrer_id',                 -->
-                    <!--   )                                                    -->
-                    <!-- col2 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_569), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- col0 =                                                -->
+                    <!--   SqlSelectColumn(                                    -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+                    <!--     column_alias='metric_time__day',                  -->
+                    <!--   )                                                   -->
+                    <!-- col1 =                                                -->
+                    <!--   SqlSelectColumn(                                    -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+                    <!--     column_alias='visit__referrer_id',                -->
+                    <!--   )                                                   -->
+                    <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_9') -->
-                        <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_532), column_alias='ds__day') -->
-                        <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='ds__week') -->
-                        <!-- col2 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
-                        <!--     column_alias='ds__month',                          -->
-                        <!--   )                                                    -->
-                        <!-- col3 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
-                        <!--     column_alias='ds__quarter',                        -->
-                        <!--   )                                                    -->
-                        <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_536), column_alias='ds__year') -->
-                        <!-- col5 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
-                        <!--     column_alias='ds__extract_year',                   -->
-                        <!--   )                                                    -->
-                        <!-- col6 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
-                        <!--     column_alias='ds__extract_quarter',                -->
-                        <!--   )                                                    -->
-                        <!-- col7 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539), -->
-                        <!--     column_alias='ds__extract_month',                  -->
-                        <!--   )                                                    -->
-                        <!-- col8 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540), -->
-                        <!--     column_alias='ds__extract_day',                    -->
-                        <!--   )                                                    -->
-                        <!-- col9 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
-                        <!--     column_alias='ds__extract_dow',                    -->
-                        <!--   )                                                    -->
-                        <!-- col10 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
-                        <!--     column_alias='ds__extract_doy',                    -->
-                        <!--   )                                                    -->
-                        <!-- col11 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
-                        <!--     column_alias='visit__ds__day',                     -->
-                        <!--   )                                                    -->
-                        <!-- col12 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
-                        <!--     column_alias='visit__ds__week',                    -->
-                        <!--   )                                                    -->
-                        <!-- col13 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
-                        <!--     column_alias='visit__ds__month',                   -->
-                        <!--   )                                                    -->
-                        <!-- col14 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
-                        <!--     column_alias='visit__ds__quarter',                 -->
-                        <!--   )                                                    -->
-                        <!-- col15 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
-                        <!--     column_alias='visit__ds__year',                    -->
-                        <!--   )                                                    -->
-                        <!-- col16 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
-                        <!--     column_alias='visit__ds__extract_year',            -->
-                        <!--   )                                                    -->
-                        <!-- col17 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
-                        <!--     column_alias='visit__ds__extract_quarter',         -->
-                        <!--   )                                                    -->
-                        <!-- col18 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
-                        <!--     column_alias='visit__ds__extract_month',           -->
-                        <!--   )                                                    -->
-                        <!-- col19 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
-                        <!--     column_alias='visit__ds__extract_day',             -->
-                        <!--   )                                                    -->
-                        <!-- col20 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
-                        <!--     column_alias='visit__ds__extract_dow',             -->
-                        <!--   )                                                    -->
-                        <!-- col21 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
-                        <!--     column_alias='visit__ds__extract_doy',             -->
-                        <!--   )                                                    -->
-                        <!-- col22 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
-                        <!--     column_alias='metric_time__day',                   -->
-                        <!--   )                                                    -->
-                        <!-- col23 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
-                        <!--     column_alias='metric_time__week',                  -->
-                        <!--   )                                                    -->
-                        <!-- col24 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
-                        <!--     column_alias='metric_time__month',                 -->
-                        <!--   )                                                    -->
-                        <!-- col25 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
-                        <!--     column_alias='metric_time__quarter',               -->
-                        <!--   )                                                    -->
-                        <!-- col26 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
-                        <!--     column_alias='metric_time__year',                  -->
-                        <!--   )                                                    -->
-                        <!-- col27 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
-                        <!--     column_alias='metric_time__extract_year',          -->
-                        <!--   )                                                    -->
-                        <!-- col28 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
-                        <!--     column_alias='metric_time__extract_quarter',       -->
-                        <!--   )                                                    -->
-                        <!-- col29 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
-                        <!--     column_alias='metric_time__extract_month',         -->
-                        <!--   )                                                    -->
-                        <!-- col30 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
-                        <!--     column_alias='metric_time__extract_day',           -->
-                        <!--   )                                                    -->
-                        <!-- col31 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
-                        <!--     column_alias='metric_time__extract_dow',           -->
-                        <!--   )                                                    -->
-                        <!-- col32 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
-                        <!--     column_alias='metric_time__extract_doy',           -->
-                        <!--   )                                                    -->
-                        <!-- col33 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_565), column_alias='user') -->
-                        <!-- col34 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_566), column_alias='session') -->
-                        <!-- col35 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
-                        <!--     column_alias='visit__user',                        -->
-                        <!--   )                                                    -->
-                        <!-- col36 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
-                        <!--     column_alias='visit__session',                     -->
-                        <!--   )                                                    -->
-                        <!-- col37 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
-                        <!--     column_alias='referrer_id',                        -->
-                        <!--   )                                                    -->
-                        <!-- col38 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
-                        <!--     column_alias='visit__referrer_id',                 -->
-                        <!--   )                                                    -->
-                        <!-- col39 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='visits') -->
-                        <!-- col40 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_529), column_alias='visitors') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- col0 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
+                        <!-- col1 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__week') -->
+                        <!-- col2 =                                                                                       -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='ds__month') -->
+                        <!-- col3 =                                               -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
+                        <!--     column_alias='ds__quarter',                      -->
+                        <!--   )                                                  -->
+                        <!-- col4 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='ds__year') -->
+                        <!-- col5 =                                               -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_9), -->
+                        <!--     column_alias='ds__extract_year',                 -->
+                        <!--   )                                                  -->
+                        <!-- col6 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
+                        <!--     column_alias='ds__extract_quarter',               -->
+                        <!--   )                                                   -->
+                        <!-- col7 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
+                        <!--     column_alias='ds__extract_month',                 -->
+                        <!--   )                                                   -->
+                        <!-- col8 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
+                        <!--     column_alias='ds__extract_day',                   -->
+                        <!--   )                                                   -->
+                        <!-- col9 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                        <!--     column_alias='ds__extract_dow',                   -->
+                        <!--   )                                                   -->
+                        <!-- col10 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_14), -->
+                        <!--     column_alias='ds__extract_doy',                   -->
+                        <!--   )                                                   -->
+                        <!-- col11 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_15), -->
+                        <!--     column_alias='visit__ds__day',                    -->
+                        <!--   )                                                   -->
+                        <!-- col12 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_16), -->
+                        <!--     column_alias='visit__ds__week',                   -->
+                        <!--   )                                                   -->
+                        <!-- col13 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_17), -->
+                        <!--     column_alias='visit__ds__month',                  -->
+                        <!--   )                                                   -->
+                        <!-- col14 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_18), -->
+                        <!--     column_alias='visit__ds__quarter',                -->
+                        <!--   )                                                   -->
+                        <!-- col15 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
+                        <!--     column_alias='visit__ds__year',                   -->
+                        <!--   )                                                   -->
+                        <!-- col16 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
+                        <!--     column_alias='visit__ds__extract_year',           -->
+                        <!--   )                                                   -->
+                        <!-- col17 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_21), -->
+                        <!--     column_alias='visit__ds__extract_quarter',        -->
+                        <!--   )                                                   -->
+                        <!-- col18 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
+                        <!--     column_alias='visit__ds__extract_month',          -->
+                        <!--   )                                                   -->
+                        <!-- col19 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
+                        <!--     column_alias='visit__ds__extract_day',            -->
+                        <!--   )                                                   -->
+                        <!-- col20 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_24), -->
+                        <!--     column_alias='visit__ds__extract_dow',            -->
+                        <!--   )                                                   -->
+                        <!-- col21 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_25), -->
+                        <!--     column_alias='visit__ds__extract_doy',            -->
+                        <!--   )                                                   -->
+                        <!-- col22 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_26), -->
+                        <!--     column_alias='metric_time__day',                  -->
+                        <!--   )                                                   -->
+                        <!-- col23 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
+                        <!--     column_alias='metric_time__week',                 -->
+                        <!--   )                                                   -->
+                        <!-- col24 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
+                        <!--     column_alias='metric_time__month',                -->
+                        <!--   )                                                   -->
+                        <!-- col25 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
+                        <!--     column_alias='metric_time__quarter',              -->
+                        <!--   )                                                   -->
+                        <!-- col26 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+                        <!--     column_alias='metric_time__year',                 -->
+                        <!--   )                                                   -->
+                        <!-- col27 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+                        <!--     column_alias='metric_time__extract_year',         -->
+                        <!--   )                                                   -->
+                        <!-- col28 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                        <!--     column_alias='metric_time__extract_quarter',      -->
+                        <!--   )                                                   -->
+                        <!-- col29 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                        <!--     column_alias='metric_time__extract_month',        -->
+                        <!--   )                                                   -->
+                        <!-- col30 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                        <!--     column_alias='metric_time__extract_day',          -->
+                        <!--   )                                                   -->
+                        <!-- col31 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                        <!--     column_alias='metric_time__extract_dow',          -->
+                        <!--   )                                                   -->
+                        <!-- col32 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
+                        <!--     column_alias='metric_time__extract_doy',          -->
+                        <!--   )                                                   -->
+                        <!-- col33 =                                                                                  -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='user') -->
+                        <!-- col34 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='session') -->
+                        <!-- col35 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                        <!--     column_alias='visit__user',                       -->
+                        <!--   )                                                   -->
+                        <!-- col36 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+                        <!--     column_alias='visit__session',                    -->
+                        <!--   )                                                   -->
+                        <!-- col37 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
+                        <!--     column_alias='referrer_id',                      -->
+                        <!--   )                                                  -->
+                        <!-- col38 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_3), -->
+                        <!--     column_alias='visit__referrer_id',               -->
+                        <!--   )                                                  -->
+                        <!-- col39 =                                                                                   -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
+                        <!-- col40 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
@@ -447,12 +443,12 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_19') -->
+                <!-- node_id = NodeId(id_str='ss_10') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_746), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_218), column_alias='metric_time__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_745), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_217), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- col2 =                                                                    -->
@@ -460,60 +456,60 @@
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                 <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_746), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_218), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_745), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_217), -->
                 <!--     column_alias='visit__referrer_id',                 -->
                 <!--   )                                                    -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_18') -->
+                    <!-- node_id = NodeId(id_str='ss_9') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_743), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_215), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_742), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_214), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
-                    <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_741), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                    <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_213), column_alias='buys') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_17') -->
+                        <!-- node_id = NodeId(id_str='ss_8') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_738), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_210), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_739), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_211), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_740), column_alias='user') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_212), column_alias='user') -->
                         <!-- col3 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_737), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_209), -->
                         <!--     column_alias='visit__referrer_id',                 -->
                         <!--   )                                                    -->
                         <!-- col4 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_735), column_alias='buys') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_207), column_alias='buys') -->
                         <!-- col5 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_736), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_208), column_alias='visits') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_16') -->
+                            <!-- node_id = NodeId(id_str='ss_7') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -541,262 +537,262 @@
                             <!--   )                                                                             -->
                             <!-- col5 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_733), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_205), -->
                             <!--     column_alias='mf_internal_uuid',                   -->
                             <!--   )                                                    -->
                             <!-- col6 =                                                                                    -->
-                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_734), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
-                            <!-- join_0 =                                                -->
-                            <!--   SqlJoinDescription(                                   -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
-                            <!--     right_source_alias='subq_9',                        -->
-                            <!--     join_type=INNER,                                    -->
-                            <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
-                            <!--   )                                                     -->
+                            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_206), column_alias='buys') -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- join_0 =                                               -->
+                            <!--   SqlJoinDescription(                                  -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_6), -->
+                            <!--     right_source_alias='subq_9',                       -->
+                            <!--     join_type=INNER,                                   -->
+                            <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
+                            <!--   )                                                    -->
                             <!-- where = None -->
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description =                                                         -->
                                 <!--   ("Pass Only Elements: ['visits', 'visit__referrer_id', 'ds__day', " -->
                                 <!--    "'metric_time__day', 'user']")                                     -->
-                                <!-- node_id = NodeId(id_str='ss_13') -->
-                                <!-- col0 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
-                                <!--     column_alias='ds__day',                            -->
-                                <!--   )                                                    -->
-                                <!-- col1 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
-                                <!--     column_alias='metric_time__day',                   -->
-                                <!--   )                                                    -->
-                                <!-- col2 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
-                                <!--     column_alias='user',                               -->
-                                <!--   )                                                    -->
-                                <!-- col3 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
-                                <!--     column_alias='visit__referrer_id',                 -->
-                                <!--   )                                                    -->
-                                <!-- col4 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
-                                <!--     column_alias='visits',                             -->
-                                <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+                                <!-- node_id = NodeId(id_str='ss_4') -->
+                                <!-- col0 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+                                <!--     column_alias='ds__day',                           -->
+                                <!--   )                                                   -->
+                                <!-- col1 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+                                <!--     column_alias='metric_time__day',                  -->
+                                <!--   )                                                   -->
+                                <!-- col2 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+                                <!--     column_alias='user',                              -->
+                                <!--   )                                                   -->
+                                <!-- col3 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+                                <!--     column_alias='visit__referrer_id',                -->
+                                <!--   )                                                   -->
+                                <!-- col4 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+                                <!--     column_alias='visits',                            -->
+                                <!--   )                                                   -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_12') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col4 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
-                                    <!--     column_alias='ds__year',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col5 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
-                                    <!--     column_alias='ds__extract_year',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col6 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
-                                    <!--     column_alias='ds__extract_quarter',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col7 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
-                                    <!--     column_alias='ds__extract_month',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col8 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
-                                    <!--     column_alias='ds__extract_day',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col9 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
-                                    <!--     column_alias='ds__extract_dow',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col10 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
-                                    <!--     column_alias='ds__extract_doy',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col11 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
-                                    <!--     column_alias='visit__ds__day',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col12 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
-                                    <!--     column_alias='visit__ds__week',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col13 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592), -->
-                                    <!--     column_alias='visit__ds__month',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col14 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593), -->
-                                    <!--     column_alias='visit__ds__quarter',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col15 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594), -->
-                                    <!--     column_alias='visit__ds__year',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col16 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595), -->
-                                    <!--     column_alias='visit__ds__extract_year',            -->
-                                    <!--   )                                                    -->
-                                    <!-- col17 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596), -->
-                                    <!--     column_alias='visit__ds__extract_quarter',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col18 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597), -->
-                                    <!--     column_alias='visit__ds__extract_month',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col19 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
-                                    <!--     column_alias='visit__ds__extract_day',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col20 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
-                                    <!--     column_alias='visit__ds__extract_dow',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col21 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
-                                    <!--     column_alias='visit__ds__extract_doy',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col22 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
-                                    <!--     column_alias='metric_time__day',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col23 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
-                                    <!--     column_alias='metric_time__week',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col24 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
-                                    <!--     column_alias='metric_time__month',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col25 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
-                                    <!--     column_alias='metric_time__quarter',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col26 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
-                                    <!--     column_alias='metric_time__year',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col27 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
-                                    <!--     column_alias='metric_time__extract_year',          -->
-                                    <!--   )                                                    -->
-                                    <!-- col28 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
-                                    <!--     column_alias='metric_time__extract_quarter',       -->
-                                    <!--   )                                                    -->
-                                    <!-- col29 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
-                                    <!--     column_alias='metric_time__extract_month',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col30 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
-                                    <!--     column_alias='metric_time__extract_day',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col31 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
-                                    <!--     column_alias='metric_time__extract_dow',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col32 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
-                                    <!--     column_alias='metric_time__extract_doy',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col33 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
-                                    <!--     column_alias='user',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col34 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
-                                    <!--     column_alias='session',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col35 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
-                                    <!--     column_alias='visit__user',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col36 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
-                                    <!--     column_alias='visit__session',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
-                                    <!--     column_alias='referrer_id',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
-                                    <!--     column_alias='visit__referrer_id',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col39 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
-                                    <!--     column_alias='visits',                             -->
-                                    <!--   )                                                    -->
-                                    <!-- col40 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
-                                    <!--     column_alias='visitors',                           -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_3') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col4 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                                    <!--     column_alias='ds__year',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col5 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                                    <!--     column_alias='ds__extract_year',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col6 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+                                    <!--     column_alias='ds__extract_quarter',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col7 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
+                                    <!--     column_alias='ds__extract_month',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col8 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+                                    <!--     column_alias='ds__extract_day',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col9 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
+                                    <!--     column_alias='ds__extract_dow',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col10 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+                                    <!--     column_alias='ds__extract_doy',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col11 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+                                    <!--     column_alias='visit__ds__day',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col12 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+                                    <!--     column_alias='visit__ds__week',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col13 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
+                                    <!--     column_alias='visit__ds__month',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col14 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
+                                    <!--     column_alias='visit__ds__quarter',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col15 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
+                                    <!--     column_alias='visit__ds__year',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col16 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
+                                    <!--     column_alias='visit__ds__extract_year',           -->
+                                    <!--   )                                                   -->
+                                    <!-- col17 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+                                    <!--     column_alias='visit__ds__extract_quarter',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col18 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+                                    <!--     column_alias='visit__ds__extract_month',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col19 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+                                    <!--     column_alias='visit__ds__extract_day',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col20 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+                                    <!--     column_alias='visit__ds__extract_dow',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col21 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+                                    <!--     column_alias='visit__ds__extract_doy',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col22 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                                    <!--     column_alias='metric_time__day',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col23 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
+                                    <!--     column_alias='metric_time__week',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col24 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+                                    <!--     column_alias='metric_time__month',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col25 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                                    <!--     column_alias='metric_time__quarter',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col26 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                                    <!--     column_alias='metric_time__year',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                                    <!--     column_alias='metric_time__extract_year',         -->
+                                    <!--   )                                                   -->
+                                    <!-- col28 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+                                    <!--     column_alias='metric_time__extract_quarter',      -->
+                                    <!--   )                                                   -->
+                                    <!-- col29 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+                                    <!--     column_alias='metric_time__extract_month',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col30 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+                                    <!--     column_alias='metric_time__extract_day',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col31 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                                    <!--     column_alias='metric_time__extract_dow',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col32 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_83), -->
+                                    <!--     column_alias='metric_time__extract_doy',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col33 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
+                                    <!--     column_alias='user',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col34 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
+                                    <!--     column_alias='session',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col35 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+                                    <!--     column_alias='visit__user',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col36 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+                                    <!--     column_alias='visit__session',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                                    <!--     column_alias='referrer_id',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+                                    <!--     column_alias='visit__referrer_id',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col39 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+                                    <!--     column_alias='visits',                            -->
+                                    <!--   )                                                   -->
+                                    <!-- col40 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+                                    <!--     column_alias='visitors',                          -->
+                                    <!--   )                                                   -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
@@ -966,200 +962,200 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_15') -->
+                                <!-- node_id = NodeId(id_str='ss_6') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
                                 <!--     column_alias='ds__week',                           -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
                                 <!--     column_alias='ds__month',                          -->
                                 <!--   )                                                    -->
                                 <!-- col3 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
                                 <!--     column_alias='ds__quarter',                        -->
                                 <!--   )                                                    -->
                                 <!-- col4 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
                                 <!--     column_alias='ds__year',                           -->
                                 <!--   )                                                    -->
                                 <!-- col5 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
                                 <!--     column_alias='ds__extract_year',                   -->
                                 <!--   )                                                    -->
                                 <!-- col6 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
                                 <!--     column_alias='ds__extract_quarter',                -->
                                 <!--   )                                                    -->
                                 <!-- col7 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_141), -->
                                 <!--     column_alias='ds__extract_month',                  -->
                                 <!--   )                                                    -->
                                 <!-- col8 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_142), -->
                                 <!--     column_alias='ds__extract_day',                    -->
                                 <!--   )                                                    -->
                                 <!-- col9 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_143), -->
                                 <!--     column_alias='ds__extract_dow',                    -->
                                 <!--   )                                                    -->
                                 <!-- col10 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_144), -->
                                 <!--     column_alias='ds__extract_doy',                    -->
                                 <!--   )                                                    -->
                                 <!-- col11 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
                                 <!--     column_alias='buy__ds__day',                       -->
                                 <!--   )                                                    -->
                                 <!-- col12 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
                                 <!--     column_alias='buy__ds__week',                      -->
                                 <!--   )                                                    -->
                                 <!-- col13 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_147), -->
                                 <!--     column_alias='buy__ds__month',                     -->
                                 <!--   )                                                    -->
                                 <!-- col14 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_148), -->
                                 <!--     column_alias='buy__ds__quarter',                   -->
                                 <!--   )                                                    -->
                                 <!-- col15 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_149), -->
                                 <!--     column_alias='buy__ds__year',                      -->
                                 <!--   )                                                    -->
                                 <!-- col16 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_150), -->
                                 <!--     column_alias='buy__ds__extract_year',              -->
                                 <!--   )                                                    -->
                                 <!-- col17 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_151), -->
                                 <!--     column_alias='buy__ds__extract_quarter',           -->
                                 <!--   )                                                    -->
                                 <!-- col18 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_152), -->
                                 <!--     column_alias='buy__ds__extract_month',             -->
                                 <!--   )                                                    -->
                                 <!-- col19 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_153), -->
                                 <!--     column_alias='buy__ds__extract_day',               -->
                                 <!--   )                                                    -->
                                 <!-- col20 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_154), -->
                                 <!--     column_alias='buy__ds__extract_dow',               -->
                                 <!--   )                                                    -->
                                 <!-- col21 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_155), -->
                                 <!--     column_alias='buy__ds__extract_doy',               -->
                                 <!--   )                                                    -->
                                 <!-- col22 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_156), -->
                                 <!--     column_alias='metric_time__day',                   -->
                                 <!--   )                                                    -->
                                 <!-- col23 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_157), -->
                                 <!--     column_alias='metric_time__week',                  -->
                                 <!--   )                                                    -->
                                 <!-- col24 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_158), -->
                                 <!--     column_alias='metric_time__month',                 -->
                                 <!--   )                                                    -->
                                 <!-- col25 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_159), -->
                                 <!--     column_alias='metric_time__quarter',               -->
                                 <!--   )                                                    -->
                                 <!-- col26 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_160), -->
                                 <!--     column_alias='metric_time__year',                  -->
                                 <!--   )                                                    -->
                                 <!-- col27 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_161), -->
                                 <!--     column_alias='metric_time__extract_year',          -->
                                 <!--   )                                                    -->
                                 <!-- col28 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
                                 <!--     column_alias='metric_time__extract_quarter',       -->
                                 <!--   )                                                    -->
                                 <!-- col29 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_163), -->
                                 <!--     column_alias='metric_time__extract_month',         -->
                                 <!--   )                                                    -->
                                 <!-- col30 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_164), -->
                                 <!--     column_alias='metric_time__extract_day',           -->
                                 <!--   )                                                    -->
                                 <!-- col31 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_165), -->
                                 <!--     column_alias='metric_time__extract_dow',           -->
                                 <!--   )                                                    -->
                                 <!-- col32 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_166), -->
                                 <!--     column_alias='metric_time__extract_doy',           -->
                                 <!--   )                                                    -->
                                 <!-- col33 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_167), -->
                                 <!--     column_alias='user',                               -->
                                 <!--   )                                                    -->
                                 <!-- col34 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_168), -->
                                 <!--     column_alias='session_id',                         -->
                                 <!--   )                                                    -->
                                 <!-- col35 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_169), -->
                                 <!--     column_alias='buy__user',                          -->
                                 <!--   )                                                    -->
                                 <!-- col36 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_698), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_170), -->
                                 <!--     column_alias='buy__session_id',                    -->
                                 <!--   )                                                    -->
                                 <!-- col37 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_132), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
                                 <!-- col38 =                                                -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
                                 <!--     column_alias='buyers',                             -->
                                 <!--   )                                                    -->
                                 <!-- col39 =                                             -->
@@ -1167,207 +1163,207 @@
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_14') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col4 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
-                                    <!--     column_alias='ds__year',                           -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_5') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_97), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_98), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col4 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+                                    <!--     column_alias='ds__year',                          -->
+                                    <!--   )                                                   -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
                                     <!--     column_alias='buy__ds__day',                       -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
                                     <!--     column_alias='buy__ds__week',                      -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
                                     <!--     column_alias='buy__ds__month',                     -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
                                     <!--     column_alias='buy__ds__quarter',                   -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
                                     <!--     column_alias='buy__ds__year',                      -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
                                     <!--     column_alias='buy__ds__extract_year',              -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
                                     <!--     column_alias='buy__ds__extract_quarter',           -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
                                     <!--     column_alias='buy__ds__extract_month',             -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
                                     <!--     column_alias='buy__ds__extract_day',               -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_115), -->
                                     <!--     column_alias='buy__ds__extract_dow',               -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_116), -->
                                     <!--     column_alias='buy__ds__extract_doy',               -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_118), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_119), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
                                     <!--     column_alias='session_id',                         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
                                     <!--     column_alias='buy__user',                          -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
                                     <!--     column_alias='buy__session_id',                    -->
                                     <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
-                                    <!--     column_alias='buys',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
-                                    <!--     column_alias='buyers',                             -->
-                                    <!--   )                                                    -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
+                                    <!--     column_alias='buys',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
+                                    <!--     column_alias='buyers',                            -->
+                                    <!--   )                                                   -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
@@ -1,17 +1,17 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_26') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_871), column_alias='ds__day') -->
+        <!-- node_id = NodeId(id_str='ss_17') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_343), column_alias='ds__day') -->
         <!-- col1 =                                                                                                       -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_870), column_alias='listing__country_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_342), column_alias='listing__country_latest') -->
         <!-- col2 = SqlSelectColumn(expr=SqlRatioComputationExpression(node_id=rc_0), column_alias='bookings_per_view') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_25) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_25') -->
+            <!-- node_id = NodeId(id_str='ss_16') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -32,10 +32,10 @@
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='views',                                                 -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_24), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_15), -->
             <!--     right_source_alias='subq_19',                       -->
             <!--     join_type=FULL_OUTER,                               -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_0),    -->
@@ -54,25 +54,25 @@
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='ss_16') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_711), column_alias='ds__day') -->
+                <!-- node_id = NodeId(id_str='ss_7') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_183), column_alias='ds__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_710), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_182), -->
                 <!--     column_alias='listing__country_latest',            -->
                 <!--   )                                                    -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_712), column_alias='bookings') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_184), column_alias='bookings') -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_15') -->
+                    <!-- node_id = NodeId(id_str='ss_6') -->
                     <!-- col0 =                                                                                       -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_709), column_alias='ds__day') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_181), column_alias='ds__day') -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_708), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_180), -->
                     <!--     column_alias='listing__country_latest',            -->
                     <!--   )                                                    -->
                     <!-- col2 =                                                                    -->
@@ -80,58 +80,58 @@
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                     <!--     column_alias='bookings',                                              -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                     <!-- group_by0 =                                                                                  -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_709), column_alias='ds__day') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_181), column_alias='ds__day') -->
                     <!-- group_by1 =                                            -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_708), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_180), -->
                     <!--     column_alias='listing__country_latest',            -->
                     <!--   )                                                    -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_14') -->
+                        <!-- node_id = NodeId(id_str='ss_5') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_706), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_178), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_705), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_177), -->
                         <!--     column_alias='listing__country_latest',            -->
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_704), column_alias='bookings') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_176), column_alias='bookings') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Join Standard Outputs' -->
-                            <!-- node_id = NodeId(id_str='ss_13') -->
+                            <!-- node_id = NodeId(id_str='ss_4') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_701), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_173), -->
                             <!--     column_alias='ds__day',                            -->
                             <!--   )                                                    -->
                             <!-- col1 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_702), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_174), -->
                             <!--     column_alias='listing',                            -->
                             <!--   )                                                    -->
                             <!-- col2 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_703), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_175), -->
                             <!--     column_alias='listing__country_latest',            -->
                             <!--   )                                                    -->
                             <!-- col3 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_700), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_172), -->
                             <!--     column_alias='bookings',                           -->
                             <!--   )                                                    -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_12),  -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
                             <!--     right_source_alias='subq_5',                         -->
                             <!--     join_type=LEFT_OUTER,                                -->
                             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -140,516 +140,516 @@
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['bookings', 'ds__day', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_10') -->
-                                <!-- col0 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
-                                <!--     column_alias='ds__day',                            -->
-                                <!--   )                                                    -->
+                                <!-- node_id = NodeId(id_str='ss_1') -->
+                                <!-- col0 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+                                <!--     column_alias='ds__day',                           -->
+                                <!--   )                                                   -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_628), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                                 <!--     column_alias='listing',                            -->
                                 <!--   )                                                    -->
-                                <!-- col2 =                                                 -->
-                                <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_626), -->
-                                <!--     column_alias='bookings',                           -->
-                                <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                                <!-- col2 =                                                -->
+                                <!--   SqlSelectColumn(                                    -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_98), -->
+                                <!--     column_alias='bookings',                          -->
+                                <!--   )                                                   -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_9') -->
-                                    <!-- col0 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_543), -->
-                                    <!--     column_alias='ds__day',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col1 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_544), -->
-                                    <!--     column_alias='ds__week',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col2 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
-                                    <!--     column_alias='ds__month',                          -->
-                                    <!--   )                                                    -->
-                                    <!-- col3 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
-                                    <!--     column_alias='ds__quarter',                        -->
-                                    <!--   )                                                    -->
-                                    <!-- col4 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_547), -->
-                                    <!--     column_alias='ds__year',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col5 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
-                                    <!--     column_alias='ds__extract_year',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col6 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
-                                    <!--     column_alias='ds__extract_quarter',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col7 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
-                                    <!--     column_alias='ds__extract_month',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col8 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
-                                    <!--     column_alias='ds__extract_day',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col9 =                                                 -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
-                                    <!--     column_alias='ds__extract_dow',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col10 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
-                                    <!--     column_alias='ds__extract_doy',                    -->
-                                    <!--   )                                                    -->
-                                    <!-- col11 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
-                                    <!--     column_alias='ds_partitioned__day',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col12 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
-                                    <!--     column_alias='ds_partitioned__week',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col13 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
-                                    <!--     column_alias='ds_partitioned__month',              -->
-                                    <!--   )                                                    -->
-                                    <!-- col14 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
-                                    <!--     column_alias='ds_partitioned__quarter',            -->
-                                    <!--   )                                                    -->
-                                    <!-- col15 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
-                                    <!--     column_alias='ds_partitioned__year',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col16 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
-                                    <!--     column_alias='ds_partitioned__extract_year',       -->
-                                    <!--   )                                                    -->
-                                    <!-- col17 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
-                                    <!--     column_alias='ds_partitioned__extract_quarter',    -->
-                                    <!--   )                                                    -->
-                                    <!-- col18 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
-                                    <!--     column_alias='ds_partitioned__extract_month',      -->
-                                    <!--   )                                                    -->
-                                    <!-- col19 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
-                                    <!--     column_alias='ds_partitioned__extract_day',        -->
-                                    <!--   )                                                    -->
-                                    <!-- col20 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
-                                    <!--     column_alias='ds_partitioned__extract_dow',        -->
-                                    <!--   )                                                    -->
-                                    <!-- col21 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
-                                    <!--     column_alias='ds_partitioned__extract_doy',        -->
-                                    <!--   )                                                    -->
-                                    <!-- col22 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
-                                    <!--     column_alias='paid_at__day',                       -->
-                                    <!--   )                                                    -->
-                                    <!-- col23 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_566), -->
-                                    <!--     column_alias='paid_at__week',                      -->
-                                    <!--   )                                                    -->
-                                    <!-- col24 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
-                                    <!--     column_alias='paid_at__month',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col25 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
-                                    <!--     column_alias='paid_at__quarter',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col26 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
-                                    <!--     column_alias='paid_at__year',                      -->
-                                    <!--   )                                                    -->
-                                    <!-- col27 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
-                                    <!--     column_alias='paid_at__extract_year',              -->
-                                    <!--   )                                                    -->
-                                    <!-- col28 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
-                                    <!--     column_alias='paid_at__extract_quarter',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col29 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
-                                    <!--     column_alias='paid_at__extract_month',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col30 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
-                                    <!--     column_alias='paid_at__extract_day',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col31 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
-                                    <!--     column_alias='paid_at__extract_dow',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col32 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
-                                    <!--     column_alias='paid_at__extract_doy',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col33 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
-                                    <!--     column_alias='booking__ds__day',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col34 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
-                                    <!--     column_alias='booking__ds__week',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col35 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
-                                    <!--     column_alias='booking__ds__month',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col36 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
-                                    <!--     column_alias='booking__ds__quarter',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col37 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
-                                    <!--     column_alias='booking__ds__year',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col38 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
-                                    <!--     column_alias='booking__ds__extract_year',          -->
-                                    <!--   )                                                    -->
-                                    <!-- col39 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
-                                    <!--     column_alias='booking__ds__extract_quarter',       -->
-                                    <!--   )                                                    -->
-                                    <!-- col40 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
-                                    <!--     column_alias='booking__ds__extract_month',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col41 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
-                                    <!--     column_alias='booking__ds__extract_day',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col42 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
-                                    <!--     column_alias='booking__ds__extract_dow',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col43 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
-                                    <!--     column_alias='booking__ds__extract_doy',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col44 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
-                                    <!--     column_alias='booking__ds_partitioned__day',       -->
-                                    <!--   )                                                    -->
-                                    <!-- col45 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
-                                    <!--     column_alias='booking__ds_partitioned__week',      -->
-                                    <!--   )                                                    -->
-                                    <!-- col46 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
-                                    <!--     column_alias='booking__ds_partitioned__month',     -->
-                                    <!--   )                                                    -->
-                                    <!-- col47 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
-                                    <!--     column_alias='booking__ds_partitioned__quarter',   -->
-                                    <!--   )                                                    -->
-                                    <!-- col48 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
-                                    <!--     column_alias='booking__ds_partitioned__year',      -->
-                                    <!--   )                                                    -->
+                                    <!-- node_id = NodeId(id_str='ss_0') -->
+                                    <!-- col0 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_15), -->
+                                    <!--     column_alias='ds__day',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col1 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_16), -->
+                                    <!--     column_alias='ds__week',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col2 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_17), -->
+                                    <!--     column_alias='ds__month',                         -->
+                                    <!--   )                                                   -->
+                                    <!-- col3 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_18), -->
+                                    <!--     column_alias='ds__quarter',                       -->
+                                    <!--   )                                                   -->
+                                    <!-- col4 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
+                                    <!--     column_alias='ds__year',                          -->
+                                    <!--   )                                                   -->
+                                    <!-- col5 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
+                                    <!--     column_alias='ds__extract_year',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col6 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_21), -->
+                                    <!--     column_alias='ds__extract_quarter',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col7 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
+                                    <!--     column_alias='ds__extract_month',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col8 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
+                                    <!--     column_alias='ds__extract_day',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col9 =                                                -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_24), -->
+                                    <!--     column_alias='ds__extract_dow',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col10 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_25), -->
+                                    <!--     column_alias='ds__extract_doy',                   -->
+                                    <!--   )                                                   -->
+                                    <!-- col11 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_26), -->
+                                    <!--     column_alias='ds_partitioned__day',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col12 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
+                                    <!--     column_alias='ds_partitioned__week',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col13 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
+                                    <!--     column_alias='ds_partitioned__month',             -->
+                                    <!--   )                                                   -->
+                                    <!-- col14 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
+                                    <!--     column_alias='ds_partitioned__quarter',           -->
+                                    <!--   )                                                   -->
+                                    <!-- col15 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+                                    <!--     column_alias='ds_partitioned__year',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col16 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+                                    <!--     column_alias='ds_partitioned__extract_year',      -->
+                                    <!--   )                                                   -->
+                                    <!-- col17 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                                    <!--     column_alias='ds_partitioned__extract_quarter',   -->
+                                    <!--   )                                                   -->
+                                    <!-- col18 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                                    <!--     column_alias='ds_partitioned__extract_month',     -->
+                                    <!--   )                                                   -->
+                                    <!-- col19 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                                    <!--     column_alias='ds_partitioned__extract_day',       -->
+                                    <!--   )                                                   -->
+                                    <!-- col20 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                                    <!--     column_alias='ds_partitioned__extract_dow',       -->
+                                    <!--   )                                                   -->
+                                    <!-- col21 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
+                                    <!--     column_alias='ds_partitioned__extract_doy',       -->
+                                    <!--   )                                                   -->
+                                    <!-- col22 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
+                                    <!--     column_alias='paid_at__day',                      -->
+                                    <!--   )                                                   -->
+                                    <!-- col23 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+                                    <!--     column_alias='paid_at__week',                     -->
+                                    <!--   )                                                   -->
+                                    <!-- col24 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                                    <!--     column_alias='paid_at__month',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col25 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+                                    <!--     column_alias='paid_at__quarter',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col26 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+                                    <!--     column_alias='paid_at__year',                     -->
+                                    <!--   )                                                   -->
+                                    <!-- col27 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+                                    <!--     column_alias='paid_at__extract_year',             -->
+                                    <!--   )                                                   -->
+                                    <!-- col28 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+                                    <!--     column_alias='paid_at__extract_quarter',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col29 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+                                    <!--     column_alias='paid_at__extract_month',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col30 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                                    <!--     column_alias='paid_at__extract_day',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col31 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
+                                    <!--     column_alias='paid_at__extract_dow',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col32 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+                                    <!--     column_alias='paid_at__extract_doy',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col33 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+                                    <!--     column_alias='booking__ds__day',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col34 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                                    <!--     column_alias='booking__ds__week',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col35 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+                                    <!--     column_alias='booking__ds__month',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col36 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                                    <!--     column_alias='booking__ds__quarter',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col37 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                                    <!--     column_alias='booking__ds__year',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col38 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+                                    <!--     column_alias='booking__ds__extract_year',         -->
+                                    <!--   )                                                   -->
+                                    <!-- col39 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+                                    <!--     column_alias='booking__ds__extract_quarter',      -->
+                                    <!--   )                                                   -->
+                                    <!-- col40 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                                    <!--     column_alias='booking__ds__extract_month',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col41 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                                    <!--     column_alias='booking__ds__extract_day',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col42 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+                                    <!--     column_alias='booking__ds__extract_dow',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col43 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
+                                    <!--     column_alias='booking__ds__extract_doy',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col44 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+                                    <!--     column_alias='booking__ds_partitioned__day',      -->
+                                    <!--   )                                                   -->
+                                    <!-- col45 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
+                                    <!--     column_alias='booking__ds_partitioned__week',     -->
+                                    <!--   )                                                   -->
+                                    <!-- col46 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+                                    <!--     column_alias='booking__ds_partitioned__month',    -->
+                                    <!--   )                                                   -->
+                                    <!-- col47 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+                                    <!--     column_alias='booking__ds_partitioned__quarter',  -->
+                                    <!--   )                                                   -->
+                                    <!-- col48 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+                                    <!--     column_alias='booking__ds_partitioned__year',     -->
+                                    <!--   )                                                   -->
                                     <!-- col49 =                                                   -->
                                     <!--   SqlSelectColumn(                                        -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_592),    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_64),     -->
                                     <!--     column_alias='booking__ds_partitioned__extract_year', -->
                                     <!--   )                                                       -->
                                     <!-- col50 =                                                      -->
                                     <!--   SqlSelectColumn(                                           -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_593),       -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_65),        -->
                                     <!--     column_alias='booking__ds_partitioned__extract_quarter', -->
                                     <!--   )                                                          -->
                                     <!-- col51 =                                                    -->
                                     <!--   SqlSelectColumn(                                         -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_594),     -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_66),      -->
                                     <!--     column_alias='booking__ds_partitioned__extract_month', -->
                                     <!--   )                                                        -->
                                     <!-- col52 =                                                  -->
                                     <!--   SqlSelectColumn(                                       -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_595),   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_67),    -->
                                     <!--     column_alias='booking__ds_partitioned__extract_day', -->
                                     <!--   )                                                      -->
                                     <!-- col53 =                                                  -->
                                     <!--   SqlSelectColumn(                                       -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_596),   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_68),    -->
                                     <!--     column_alias='booking__ds_partitioned__extract_dow', -->
                                     <!--   )                                                      -->
                                     <!-- col54 =                                                  -->
                                     <!--   SqlSelectColumn(                                       -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_597),   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_69),    -->
                                     <!--     column_alias='booking__ds_partitioned__extract_doy', -->
                                     <!--   )                                                      -->
-                                    <!-- col55 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
-                                    <!--     column_alias='booking__paid_at__day',              -->
-                                    <!--   )                                                    -->
-                                    <!-- col56 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
-                                    <!--     column_alias='booking__paid_at__week',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col57 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
-                                    <!--     column_alias='booking__paid_at__month',            -->
-                                    <!--   )                                                    -->
-                                    <!-- col58 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
-                                    <!--     column_alias='booking__paid_at__quarter',          -->
-                                    <!--   )                                                    -->
-                                    <!-- col59 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
-                                    <!--     column_alias='booking__paid_at__year',             -->
-                                    <!--   )                                                    -->
-                                    <!-- col60 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
-                                    <!--     column_alias='booking__paid_at__extract_year',     -->
-                                    <!--   )                                                    -->
-                                    <!-- col61 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
-                                    <!--     column_alias='booking__paid_at__extract_quarter',  -->
-                                    <!--   )                                                    -->
-                                    <!-- col62 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
-                                    <!--     column_alias='booking__paid_at__extract_month',    -->
-                                    <!--   )                                                    -->
-                                    <!-- col63 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
-                                    <!--     column_alias='booking__paid_at__extract_day',      -->
-                                    <!--   )                                                    -->
-                                    <!-- col64 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
-                                    <!--     column_alias='booking__paid_at__extract_dow',      -->
-                                    <!--   )                                                    -->
-                                    <!-- col65 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
-                                    <!--     column_alias='booking__paid_at__extract_doy',      -->
-                                    <!--   )                                                    -->
-                                    <!-- col66 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
-                                    <!--     column_alias='metric_time__day',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col67 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
-                                    <!--     column_alias='metric_time__week',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col68 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
-                                    <!--     column_alias='metric_time__month',                 -->
-                                    <!--   )                                                    -->
-                                    <!-- col69 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
-                                    <!--     column_alias='metric_time__quarter',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col70 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
-                                    <!--     column_alias='metric_time__year',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col71 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
-                                    <!--     column_alias='metric_time__extract_year',          -->
-                                    <!--   )                                                    -->
-                                    <!-- col72 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
-                                    <!--     column_alias='metric_time__extract_quarter',       -->
-                                    <!--   )                                                    -->
-                                    <!-- col73 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
-                                    <!--     column_alias='metric_time__extract_month',         -->
-                                    <!--   )                                                    -->
-                                    <!-- col74 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
-                                    <!--     column_alias='metric_time__extract_day',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col75 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
-                                    <!--     column_alias='metric_time__extract_dow',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col76 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
-                                    <!--     column_alias='metric_time__extract_doy',           -->
-                                    <!--   )                                                    -->
-                                    <!-- col77 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_620), -->
-                                    <!--     column_alias='listing',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col78 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_621), -->
-                                    <!--     column_alias='guest',                              -->
-                                    <!--   )                                                    -->
-                                    <!-- col79 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_622), -->
-                                    <!--     column_alias='host',                               -->
-                                    <!--   )                                                    -->
-                                    <!-- col80 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
-                                    <!--     column_alias='booking__listing',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col81 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
-                                    <!--     column_alias='booking__guest',                     -->
-                                    <!--   )                                                    -->
-                                    <!-- col82 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
-                                    <!--     column_alias='booking__host',                      -->
-                                    <!--   )                                                    -->
-                                    <!-- col83 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
-                                    <!--     column_alias='is_instant',                         -->
-                                    <!--   )                                                    -->
-                                    <!-- col84 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
-                                    <!--     column_alias='booking__is_instant',                -->
-                                    <!--   )                                                    -->
-                                    <!-- col85 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_528), -->
-                                    <!--     column_alias='bookings',                           -->
-                                    <!--   )                                                    -->
-                                    <!-- col86 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_529), -->
-                                    <!--     column_alias='instant_bookings',                   -->
-                                    <!--   )                                                    -->
-                                    <!-- col87 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
-                                    <!--     column_alias='booking_value',                      -->
-                                    <!--   )                                                    -->
-                                    <!-- col88 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
-                                    <!--     column_alias='max_booking_value',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col89 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
-                                    <!--     column_alias='min_booking_value',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col90 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_533), -->
-                                    <!--     column_alias='bookers',                            -->
-                                    <!--   )                                                    -->
-                                    <!-- col91 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
-                                    <!--     column_alias='average_booking_value',              -->
-                                    <!--   )                                                    -->
-                                    <!-- col92 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
-                                    <!--     column_alias='referred_bookings',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col93 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
-                                    <!--     column_alias='median_booking_value',               -->
-                                    <!--   )                                                    -->
-                                    <!-- col94 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
-                                    <!--     column_alias='booking_value_p99',                  -->
-                                    <!--   )                                                    -->
-                                    <!-- col95 =                                                -->
-                                    <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
-                                    <!--     column_alias='discrete_booking_value_p99',         -->
-                                    <!--   )                                                    -->
+                                    <!-- col55 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+                                    <!--     column_alias='booking__paid_at__day',             -->
+                                    <!--   )                                                   -->
+                                    <!-- col56 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+                                    <!--     column_alias='booking__paid_at__week',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col57 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+                                    <!--     column_alias='booking__paid_at__month',           -->
+                                    <!--   )                                                   -->
+                                    <!-- col58 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                                    <!--     column_alias='booking__paid_at__quarter',         -->
+                                    <!--   )                                                   -->
+                                    <!-- col59 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
+                                    <!--     column_alias='booking__paid_at__year',            -->
+                                    <!--   )                                                   -->
+                                    <!-- col60 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+                                    <!--     column_alias='booking__paid_at__extract_year',    -->
+                                    <!--   )                                                   -->
+                                    <!-- col61 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                                    <!--     column_alias='booking__paid_at__extract_quarter', -->
+                                    <!--   )                                                   -->
+                                    <!-- col62 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                                    <!--     column_alias='booking__paid_at__extract_month',   -->
+                                    <!--   )                                                   -->
+                                    <!-- col63 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                                    <!--     column_alias='booking__paid_at__extract_day',     -->
+                                    <!--   )                                                   -->
+                                    <!-- col64 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+                                    <!--     column_alias='booking__paid_at__extract_dow',     -->
+                                    <!--   )                                                   -->
+                                    <!-- col65 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+                                    <!--     column_alias='booking__paid_at__extract_doy',     -->
+                                    <!--   )                                                   -->
+                                    <!-- col66 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+                                    <!--     column_alias='metric_time__day',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col67 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                                    <!--     column_alias='metric_time__week',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col68 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_83), -->
+                                    <!--     column_alias='metric_time__month',                -->
+                                    <!--   )                                                   -->
+                                    <!-- col69 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
+                                    <!--     column_alias='metric_time__quarter',              -->
+                                    <!--   )                                                   -->
+                                    <!-- col70 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
+                                    <!--     column_alias='metric_time__year',                 -->
+                                    <!--   )                                                   -->
+                                    <!-- col71 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+                                    <!--     column_alias='metric_time__extract_year',         -->
+                                    <!--   )                                                   -->
+                                    <!-- col72 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+                                    <!--     column_alias='metric_time__extract_quarter',      -->
+                                    <!--   )                                                   -->
+                                    <!-- col73 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+                                    <!--     column_alias='metric_time__extract_month',        -->
+                                    <!--   )                                                   -->
+                                    <!-- col74 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+                                    <!--     column_alias='metric_time__extract_day',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col75 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+                                    <!--     column_alias='metric_time__extract_dow',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col76 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+                                    <!--     column_alias='metric_time__extract_doy',          -->
+                                    <!--   )                                                   -->
+                                    <!-- col77 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+                                    <!--     column_alias='listing',                           -->
+                                    <!--   )                                                   -->
+                                    <!-- col78 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
+                                    <!--     column_alias='guest',                             -->
+                                    <!--   )                                                   -->
+                                    <!-- col79 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
+                                    <!--     column_alias='host',                              -->
+                                    <!--   )                                                   -->
+                                    <!-- col80 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
+                                    <!--     column_alias='booking__listing',                  -->
+                                    <!--   )                                                   -->
+                                    <!-- col81 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
+                                    <!--     column_alias='booking__guest',                    -->
+                                    <!--   )                                                   -->
+                                    <!-- col82 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_97), -->
+                                    <!--     column_alias='booking__host',                     -->
+                                    <!--   )                                                   -->
+                                    <!-- col83 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                                    <!--     column_alias='is_instant',                        -->
+                                    <!--   )                                                   -->
+                                    <!-- col84 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_14), -->
+                                    <!--     column_alias='booking__is_instant',               -->
+                                    <!--   )                                                   -->
+                                    <!-- col85 =                                              -->
+                                    <!--   SqlSelectColumn(                                   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_0), -->
+                                    <!--     column_alias='bookings',                         -->
+                                    <!--   )                                                  -->
+                                    <!-- col86 =                                              -->
+                                    <!--   SqlSelectColumn(                                   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
+                                    <!--     column_alias='instant_bookings',                 -->
+                                    <!--   )                                                  -->
+                                    <!-- col87 =                                              -->
+                                    <!--   SqlSelectColumn(                                   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
+                                    <!--     column_alias='booking_value',                    -->
+                                    <!--   )                                                  -->
+                                    <!-- col88 =                                              -->
+                                    <!--   SqlSelectColumn(                                   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_3), -->
+                                    <!--     column_alias='max_booking_value',                -->
+                                    <!--   )                                                  -->
+                                    <!-- col89 =                                              -->
+                                    <!--   SqlSelectColumn(                                   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
+                                    <!--     column_alias='min_booking_value',                -->
+                                    <!--   )                                                  -->
+                                    <!-- col90 =                                              -->
+                                    <!--   SqlSelectColumn(                                   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_5), -->
+                                    <!--     column_alias='bookers',                          -->
+                                    <!--   )                                                  -->
+                                    <!-- col91 =                                              -->
+                                    <!--   SqlSelectColumn(                                   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_6), -->
+                                    <!--     column_alias='average_booking_value',            -->
+                                    <!--   )                                                  -->
+                                    <!-- col92 =                                              -->
+                                    <!--   SqlSelectColumn(                                   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
+                                    <!--     column_alias='referred_bookings',                -->
+                                    <!--   )                                                  -->
+                                    <!-- col93 =                                              -->
+                                    <!--   SqlSelectColumn(                                   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_8), -->
+                                    <!--     column_alias='median_booking_value',             -->
+                                    <!--   )                                                  -->
+                                    <!-- col94 =                                              -->
+                                    <!--   SqlSelectColumn(                                   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_9), -->
+                                    <!--     column_alias='booking_value_p99',                -->
+                                    <!--   )                                                  -->
+                                    <!-- col95 =                                               -->
+                                    <!--   SqlSelectColumn(                                    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
+                                    <!--     column_alias='discrete_booking_value_p99',        -->
+                                    <!--   )                                                   -->
                                     <!-- col96 =                                                      -->
                                     <!--   SqlSelectColumn(                                           -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_539),       -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_11),        -->
                                     <!--     column_alias='approximate_continuous_booking_value_p99', -->
                                     <!--   )                                                          -->
                                     <!-- col97 =                                                    -->
                                     <!--   SqlSelectColumn(                                         -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_540),     -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
                                     <!--     column_alias='approximate_discrete_booking_value_p99', -->
                                     <!--   )                                                        -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
@@ -1111,356 +1111,356 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_12') -->
+                                <!-- node_id = NodeId(id_str='ss_3') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_169), -->
                                 <!--     column_alias='listing',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_168), -->
                                 <!--     column_alias='country_latest',                     -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_11') -->
+                                    <!-- node_id = NodeId(id_str='ss_2') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_639), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_115), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_116), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_118), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_119), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
                                     <!--     column_alias='created_at__day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
                                     <!--     column_alias='created_at__week',                   -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
                                     <!--     column_alias='created_at__month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
                                     <!--     column_alias='created_at__quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
                                     <!--     column_alias='created_at__year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
                                     <!--     column_alias='created_at__extract_year',           -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
                                     <!--     column_alias='created_at__extract_quarter',        -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
                                     <!--     column_alias='created_at__extract_month',          -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
                                     <!--     column_alias='created_at__extract_day',            -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
                                     <!--     column_alias='created_at__extract_dow',            -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
                                     <!--     column_alias='created_at__extract_doy',            -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_132), -->
                                     <!--     column_alias='listing__ds__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
                                     <!--     column_alias='listing__ds__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
                                     <!--     column_alias='listing__ds__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
                                     <!--     column_alias='listing__ds__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
                                     <!--     column_alias='listing__ds__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
                                     <!--     column_alias='listing__ds__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
                                     <!--     column_alias='listing__ds__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
                                     <!--     column_alias='listing__ds__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
                                     <!--     column_alias='listing__ds__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_141), -->
                                     <!--     column_alias='listing__ds__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_142), -->
                                     <!--     column_alias='listing__ds__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_143), -->
                                     <!--     column_alias='listing__created_at__day',           -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_144), -->
                                     <!--     column_alias='listing__created_at__week',          -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
                                     <!--     column_alias='listing__created_at__month',         -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
                                     <!--     column_alias='listing__created_at__quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_147), -->
                                     <!--     column_alias='listing__created_at__year',          -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_148), -->
                                     <!--     column_alias='listing__created_at__extract_year',  -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                  -->
                                     <!--   SqlSelectColumn(                                       -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_677),   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_149),   -->
                                     <!--     column_alias='listing__created_at__extract_quarter', -->
                                     <!--   )                                                      -->
                                     <!-- col40 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_150), -->
                                     <!--     column_alias='listing__created_at__extract_month', -->
                                     <!--   )                                                    -->
                                     <!-- col41 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_151), -->
                                     <!--     column_alias='listing__created_at__extract_day',   -->
                                     <!--   )                                                    -->
                                     <!-- col42 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_152), -->
                                     <!--     column_alias='listing__created_at__extract_dow',   -->
                                     <!--   )                                                    -->
                                     <!-- col43 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_153), -->
                                     <!--     column_alias='listing__created_at__extract_doy',   -->
                                     <!--   )                                                    -->
                                     <!-- col44 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_154), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col45 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_155), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col46 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_684), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_156), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col47 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_685), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_157), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col48 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_686), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_158), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col49 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_687), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_159), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col50 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_688), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_160), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col51 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_689), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_161), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col52 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col53 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_163), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col54 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_164), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col55 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_165), -->
                                     <!--     column_alias='listing',                            -->
                                     <!--   )                                                    -->
                                     <!-- col56 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_166), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col57 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_167), -->
                                     <!--     column_alias='listing__user',                      -->
                                     <!--   )                                                    -->
                                     <!-- col58 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
                                     <!--     column_alias='country_latest',                     -->
                                     <!--   )                                                    -->
                                     <!-- col59 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
                                     <!--     column_alias='is_lux_latest',                      -->
                                     <!--   )                                                    -->
                                     <!-- col60 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
                                     <!--     column_alias='capacity_latest',                    -->
                                     <!--   )                                                    -->
                                     <!-- col61 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_635), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
                                     <!--     column_alias='listing__country_latest',            -->
                                     <!--   )                                                    -->
                                     <!-- col62 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_636), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
                                     <!--     column_alias='listing__is_lux_latest',             -->
                                     <!--   )                                                    -->
                                     <!-- col63 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
                                     <!--     column_alias='listing__capacity_latest',           -->
                                     <!--   )                                                    -->
                                     <!-- col64 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_629), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
                                     <!--     column_alias='listings',                           -->
                                     <!--   )                                                    -->
                                     <!-- col65 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_630), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
                                     <!--     column_alias='largest_listing',                    -->
                                     <!--   )                                                    -->
                                     <!-- col66 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_631), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
                                     <!--     column_alias='smallest_listing',                   -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
@@ -1767,25 +1767,25 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='ss_24') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_858), column_alias='ds__day') -->
+                <!-- node_id = NodeId(id_str='ss_15') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_330), column_alias='ds__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_857), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_329), -->
                 <!--     column_alias='listing__country_latest',            -->
                 <!--   )                                                    -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_859), column_alias='views') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_23) -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_331), column_alias='views') -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_23') -->
+                    <!-- node_id = NodeId(id_str='ss_14') -->
                     <!-- col0 =                                                                                       -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_856), column_alias='ds__day') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_328), column_alias='ds__day') -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_855), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_327), -->
                     <!--     column_alias='listing__country_latest',            -->
                     <!--   )                                                    -->
                     <!-- col2 =                                                                    -->
@@ -1793,58 +1793,58 @@
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                     <!--     column_alias='views',                                                 -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_22) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                     <!-- group_by0 =                                                                                  -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_856), column_alias='ds__day') -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_328), column_alias='ds__day') -->
                     <!-- group_by1 =                                            -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_855), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_327), -->
                     <!--     column_alias='listing__country_latest',            -->
                     <!--   )                                                    -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['views', 'listing__country_latest', 'ds__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_22') -->
+                        <!-- node_id = NodeId(id_str='ss_13') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_853), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_325), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_852), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_324), -->
                         <!--     column_alias='listing__country_latest',            -->
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                     -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_851), column_alias='views') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_21) -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_323), column_alias='views') -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Join Standard Outputs' -->
-                            <!-- node_id = NodeId(id_str='ss_21') -->
+                            <!-- node_id = NodeId(id_str='ss_12') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_848), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_320), -->
                             <!--     column_alias='ds__day',                            -->
                             <!--   )                                                    -->
                             <!-- col1 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_849), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_321), -->
                             <!--     column_alias='listing',                            -->
                             <!--   )                                                    -->
                             <!-- col2 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_850), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_322), -->
                             <!--     column_alias='listing__country_latest',            -->
                             <!--   )                                                    -->
                             <!-- col3 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_847), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_319), -->
                             <!--     column_alias='views',                              -->
                             <!--   )                                                    -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_20),  -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_11),  -->
                             <!--     right_source_alias='subq_15',                        -->
                             <!--     join_type=LEFT_OUTER,                                -->
                             <!--     on_condition=SqlComparisonExpression(node_id=cmp_1), -->
@@ -1853,326 +1853,326 @@
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['views', 'ds__day', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_18') -->
+                                <!-- node_id = NodeId(id_str='ss_9') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_774), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_246), -->
                                 <!--     column_alias='ds__day',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_775), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_247), -->
                                 <!--     column_alias='listing',                            -->
                                 <!--   )                                                    -->
                                 <!-- col2 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_773), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_245), -->
                                 <!--     column_alias='views',                              -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_17) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_17') -->
+                                    <!-- node_id = NodeId(id_str='ss_8') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_714), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_186), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_715), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_187), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_716), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_188), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_717), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_189), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_718), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_190), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_719), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_191), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_720), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_192), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_721), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_193), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_722), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_194), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_723), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_195), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_724), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_196), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_725), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_197), -->
                                     <!--     column_alias='ds_partitioned__day',                -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_726), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_198), -->
                                     <!--     column_alias='ds_partitioned__week',               -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_727), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_199), -->
                                     <!--     column_alias='ds_partitioned__month',              -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_728), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_200), -->
                                     <!--     column_alias='ds_partitioned__quarter',            -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_729), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_201), -->
                                     <!--     column_alias='ds_partitioned__year',               -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_730), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_202), -->
                                     <!--     column_alias='ds_partitioned__extract_year',       -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_731), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_203), -->
                                     <!--     column_alias='ds_partitioned__extract_quarter',    -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_732), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_204), -->
                                     <!--     column_alias='ds_partitioned__extract_month',      -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_733), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_205), -->
                                     <!--     column_alias='ds_partitioned__extract_day',        -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_734), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_206), -->
                                     <!--     column_alias='ds_partitioned__extract_dow',        -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_735), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_207), -->
                                     <!--     column_alias='ds_partitioned__extract_doy',        -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_736), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_208), -->
                                     <!--     column_alias='view__ds__day',                      -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_737), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_209), -->
                                     <!--     column_alias='view__ds__week',                     -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_738), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_210), -->
                                     <!--     column_alias='view__ds__month',                    -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_739), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_211), -->
                                     <!--     column_alias='view__ds__quarter',                  -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_740), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_212), -->
                                     <!--     column_alias='view__ds__year',                     -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_741), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_213), -->
                                     <!--     column_alias='view__ds__extract_year',             -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_742), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_214), -->
                                     <!--     column_alias='view__ds__extract_quarter',          -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_743), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_215), -->
                                     <!--     column_alias='view__ds__extract_month',            -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_744), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_216), -->
                                     <!--     column_alias='view__ds__extract_day',              -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_745), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_217), -->
                                     <!--     column_alias='view__ds__extract_dow',              -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_746), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_218), -->
                                     <!--     column_alias='view__ds__extract_doy',              -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_747), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_219), -->
                                     <!--     column_alias='view__ds_partitioned__day',          -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_748), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_220), -->
                                     <!--     column_alias='view__ds_partitioned__week',         -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_749), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_221), -->
                                     <!--     column_alias='view__ds_partitioned__month',        -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_750), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_222), -->
                                     <!--     column_alias='view__ds_partitioned__quarter',      -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_751), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_223), -->
                                     <!--     column_alias='view__ds_partitioned__year',         -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_752), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_224), -->
                                     <!--     column_alias='view__ds_partitioned__extract_year', -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                   -->
                                     <!--   SqlSelectColumn(                                        -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_753),    -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_225),    -->
                                     <!--     column_alias='view__ds_partitioned__extract_quarter', -->
                                     <!--   )                                                       -->
                                     <!-- col40 =                                                 -->
                                     <!--   SqlSelectColumn(                                      -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_754),  -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_226),  -->
                                     <!--     column_alias='view__ds_partitioned__extract_month', -->
                                     <!--   )                                                     -->
                                     <!-- col41 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_755), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_227), -->
                                     <!--     column_alias='view__ds_partitioned__extract_day',  -->
                                     <!--   )                                                    -->
                                     <!-- col42 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_756), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_228), -->
                                     <!--     column_alias='view__ds_partitioned__extract_dow',  -->
                                     <!--   )                                                    -->
                                     <!-- col43 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_757), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_229), -->
                                     <!--     column_alias='view__ds_partitioned__extract_doy',  -->
                                     <!--   )                                                    -->
                                     <!-- col44 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_758), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_230), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col45 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_759), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_231), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col46 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_760), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_232), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col47 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_761), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_233), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col48 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_762), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_234), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col49 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_763), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_235), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col50 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_764), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_236), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col51 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_765), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_237), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col52 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_766), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_238), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col53 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_767), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_239), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col54 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_768), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_240), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col55 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_769), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_241), -->
                                     <!--     column_alias='listing',                            -->
                                     <!--   )                                                    -->
                                     <!-- col56 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_770), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_242), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col57 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_771), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_243), -->
                                     <!--     column_alias='view__listing',                      -->
                                     <!--   )                                                    -->
                                     <!-- col58 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_772), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_244), -->
                                     <!--     column_alias='view__user',                         -->
                                     <!--   )                                                    -->
                                     <!-- col59 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_713), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_185), -->
                                     <!--     column_alias='views',                              -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28010) -->
@@ -2439,356 +2439,356 @@
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_20') -->
+                                <!-- node_id = NodeId(id_str='ss_11') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_844), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_316), -->
                                 <!--     column_alias='listing',                            -->
                                 <!--   )                                                    -->
                                 <!-- col1 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
-                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_843), -->
+                                <!--     expr=SqlColumnReferenceExpression(node_id=cr_315), -->
                                 <!--     column_alias='country_latest',                     -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_19) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_19') -->
+                                    <!-- node_id = NodeId(id_str='ss_10') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_785), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_257), -->
                                     <!--     column_alias='ds__day',                            -->
                                     <!--   )                                                    -->
                                     <!-- col1 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_786), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_258), -->
                                     <!--     column_alias='ds__week',                           -->
                                     <!--   )                                                    -->
                                     <!-- col2 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_787), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_259), -->
                                     <!--     column_alias='ds__month',                          -->
                                     <!--   )                                                    -->
                                     <!-- col3 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_788), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_260), -->
                                     <!--     column_alias='ds__quarter',                        -->
                                     <!--   )                                                    -->
                                     <!-- col4 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_789), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_261), -->
                                     <!--     column_alias='ds__year',                           -->
                                     <!--   )                                                    -->
                                     <!-- col5 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_790), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_262), -->
                                     <!--     column_alias='ds__extract_year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col6 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_791), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_263), -->
                                     <!--     column_alias='ds__extract_quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col7 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_792), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_264), -->
                                     <!--     column_alias='ds__extract_month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col8 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_793), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_265), -->
                                     <!--     column_alias='ds__extract_day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col9 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_794), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_266), -->
                                     <!--     column_alias='ds__extract_dow',                    -->
                                     <!--   )                                                    -->
                                     <!-- col10 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_795), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_267), -->
                                     <!--     column_alias='ds__extract_doy',                    -->
                                     <!--   )                                                    -->
                                     <!-- col11 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_796), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_268), -->
                                     <!--     column_alias='created_at__day',                    -->
                                     <!--   )                                                    -->
                                     <!-- col12 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_797), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_269), -->
                                     <!--     column_alias='created_at__week',                   -->
                                     <!--   )                                                    -->
                                     <!-- col13 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_798), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_270), -->
                                     <!--     column_alias='created_at__month',                  -->
                                     <!--   )                                                    -->
                                     <!-- col14 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_799), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_271), -->
                                     <!--     column_alias='created_at__quarter',                -->
                                     <!--   )                                                    -->
                                     <!-- col15 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_800), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_272), -->
                                     <!--     column_alias='created_at__year',                   -->
                                     <!--   )                                                    -->
                                     <!-- col16 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_801), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_273), -->
                                     <!--     column_alias='created_at__extract_year',           -->
                                     <!--   )                                                    -->
                                     <!-- col17 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_802), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_274), -->
                                     <!--     column_alias='created_at__extract_quarter',        -->
                                     <!--   )                                                    -->
                                     <!-- col18 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_803), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_275), -->
                                     <!--     column_alias='created_at__extract_month',          -->
                                     <!--   )                                                    -->
                                     <!-- col19 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_804), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_276), -->
                                     <!--     column_alias='created_at__extract_day',            -->
                                     <!--   )                                                    -->
                                     <!-- col20 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_805), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_277), -->
                                     <!--     column_alias='created_at__extract_dow',            -->
                                     <!--   )                                                    -->
                                     <!-- col21 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_806), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_278), -->
                                     <!--     column_alias='created_at__extract_doy',            -->
                                     <!--   )                                                    -->
                                     <!-- col22 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_807), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_279), -->
                                     <!--     column_alias='listing__ds__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col23 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_808), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_280), -->
                                     <!--     column_alias='listing__ds__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col24 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_809), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_281), -->
                                     <!--     column_alias='listing__ds__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col25 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_810), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_282), -->
                                     <!--     column_alias='listing__ds__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col26 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_811), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_283), -->
                                     <!--     column_alias='listing__ds__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col27 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_812), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_284), -->
                                     <!--     column_alias='listing__ds__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col28 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_813), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_285), -->
                                     <!--     column_alias='listing__ds__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col29 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_814), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_286), -->
                                     <!--     column_alias='listing__ds__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col30 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_815), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_287), -->
                                     <!--     column_alias='listing__ds__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col31 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_816), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_288), -->
                                     <!--     column_alias='listing__ds__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col32 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_817), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_289), -->
                                     <!--     column_alias='listing__ds__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col33 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_818), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_290), -->
                                     <!--     column_alias='listing__created_at__day',           -->
                                     <!--   )                                                    -->
                                     <!-- col34 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_819), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_291), -->
                                     <!--     column_alias='listing__created_at__week',          -->
                                     <!--   )                                                    -->
                                     <!-- col35 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_820), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_292), -->
                                     <!--     column_alias='listing__created_at__month',         -->
                                     <!--   )                                                    -->
                                     <!-- col36 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_821), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_293), -->
                                     <!--     column_alias='listing__created_at__quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col37 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_822), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_294), -->
                                     <!--     column_alias='listing__created_at__year',          -->
                                     <!--   )                                                    -->
                                     <!-- col38 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_823), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_295), -->
                                     <!--     column_alias='listing__created_at__extract_year',  -->
                                     <!--   )                                                    -->
                                     <!-- col39 =                                                  -->
                                     <!--   SqlSelectColumn(                                       -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_824),   -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_296),   -->
                                     <!--     column_alias='listing__created_at__extract_quarter', -->
                                     <!--   )                                                      -->
                                     <!-- col40 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_825), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_297), -->
                                     <!--     column_alias='listing__created_at__extract_month', -->
                                     <!--   )                                                    -->
                                     <!-- col41 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_826), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_298), -->
                                     <!--     column_alias='listing__created_at__extract_day',   -->
                                     <!--   )                                                    -->
                                     <!-- col42 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_827), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_299), -->
                                     <!--     column_alias='listing__created_at__extract_dow',   -->
                                     <!--   )                                                    -->
                                     <!-- col43 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_828), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_300), -->
                                     <!--     column_alias='listing__created_at__extract_doy',   -->
                                     <!--   )                                                    -->
                                     <!-- col44 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_829), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_301), -->
                                     <!--     column_alias='metric_time__day',                   -->
                                     <!--   )                                                    -->
                                     <!-- col45 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_830), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_302), -->
                                     <!--     column_alias='metric_time__week',                  -->
                                     <!--   )                                                    -->
                                     <!-- col46 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_831), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_303), -->
                                     <!--     column_alias='metric_time__month',                 -->
                                     <!--   )                                                    -->
                                     <!-- col47 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_832), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_304), -->
                                     <!--     column_alias='metric_time__quarter',               -->
                                     <!--   )                                                    -->
                                     <!-- col48 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_833), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_305), -->
                                     <!--     column_alias='metric_time__year',                  -->
                                     <!--   )                                                    -->
                                     <!-- col49 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_834), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_306), -->
                                     <!--     column_alias='metric_time__extract_year',          -->
                                     <!--   )                                                    -->
                                     <!-- col50 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_835), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_307), -->
                                     <!--     column_alias='metric_time__extract_quarter',       -->
                                     <!--   )                                                    -->
                                     <!-- col51 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_836), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_308), -->
                                     <!--     column_alias='metric_time__extract_month',         -->
                                     <!--   )                                                    -->
                                     <!-- col52 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_837), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_309), -->
                                     <!--     column_alias='metric_time__extract_day',           -->
                                     <!--   )                                                    -->
                                     <!-- col53 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_838), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_310), -->
                                     <!--     column_alias='metric_time__extract_dow',           -->
                                     <!--   )                                                    -->
                                     <!-- col54 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_839), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_311), -->
                                     <!--     column_alias='metric_time__extract_doy',           -->
                                     <!--   )                                                    -->
                                     <!-- col55 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_840), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_312), -->
                                     <!--     column_alias='listing',                            -->
                                     <!--   )                                                    -->
                                     <!-- col56 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_841), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_313), -->
                                     <!--     column_alias='user',                               -->
                                     <!--   )                                                    -->
                                     <!-- col57 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_842), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_314), -->
                                     <!--     column_alias='listing__user',                      -->
                                     <!--   )                                                    -->
                                     <!-- col58 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_779), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_251), -->
                                     <!--     column_alias='country_latest',                     -->
                                     <!--   )                                                    -->
                                     <!-- col59 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_780), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_252), -->
                                     <!--     column_alias='is_lux_latest',                      -->
                                     <!--   )                                                    -->
                                     <!-- col60 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_781), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_253), -->
                                     <!--     column_alias='capacity_latest',                    -->
                                     <!--   )                                                    -->
                                     <!-- col61 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_782), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_254), -->
                                     <!--     column_alias='listing__country_latest',            -->
                                     <!--   )                                                    -->
                                     <!-- col62 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_783), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_255), -->
                                     <!--     column_alias='listing__is_lux_latest',             -->
                                     <!--   )                                                    -->
                                     <!-- col63 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_784), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_256), -->
                                     <!--     column_alias='listing__capacity_latest',           -->
                                     <!--   )                                                    -->
                                     <!-- col64 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_776), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_248), -->
                                     <!--     column_alias='listings',                           -->
                                     <!--   )                                                    -->
                                     <!-- col65 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_777), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_249), -->
                                     <!--     column_alias='largest_listing',                    -->
                                     <!--   )                                                    -->
                                     <!-- col66 =                                                -->
                                     <!--   SqlSelectColumn(                                     -->
-                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_778), -->
+                                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_250), -->
                                     <!--     column_alias='smallest_listing',                   -->
                                     <!--   )                                                    -->
                                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimension_with_joined_where_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimension_with_joined_where_constraint__plan0.xml
@@ -1,413 +1,413 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest',]" -->
-        <!-- node_id = NodeId(id_str='ss_4') -->
+        <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 =                                                                                                       -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_140), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='user__home_state_latest') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
         <!-- group_by0 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_140), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Output with WHERE' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_93), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='ds__year') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_74), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_75), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_76), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_99), column_alias='ds__extract_quarter') -->
-            <!-- col7 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_100), column_alias='ds__extract_month') -->
-            <!-- col8 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_101), column_alias='ds__extract_day') -->
-            <!-- col9 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='ds__extract_dow') -->
-            <!-- col10 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='ds__extract_doy') -->
-            <!-- col11 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='created_at__day') -->
-            <!-- col12 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='created_at__week') -->
-            <!-- col13 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='created_at__month') -->
-            <!-- col14 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='created_at__quarter') -->
-            <!-- col15 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='created_at__year') -->
-            <!-- col16 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
-            <!--     column_alias='created_at__extract_year',           -->
-            <!--   )                                                    -->
-            <!-- col17 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
-            <!--     column_alias='created_at__extract_quarter',        -->
-            <!--   )                                                    -->
-            <!-- col18 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
-            <!--     column_alias='created_at__extract_month',          -->
-            <!--   )                                                    -->
-            <!-- col19 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
-            <!--     column_alias='created_at__extract_day',            -->
-            <!--   )                                                    -->
-            <!-- col20 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
-            <!--     column_alias='created_at__extract_dow',            -->
-            <!--   )                                                    -->
-            <!-- col21 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
-            <!--     column_alias='created_at__extract_doy',            -->
-            <!--   )                                                    -->
-            <!-- col22 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_115), column_alias='listing__ds__day') -->
-            <!-- col23 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_116), column_alias='listing__ds__week') -->
-            <!-- col24 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_117), column_alias='listing__ds__month') -->
-            <!-- col25 =                                                                                                   -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__ds__quarter') -->
-            <!-- col26 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='listing__ds__year') -->
-            <!-- col27 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
-            <!--     column_alias='listing__ds__extract_year',          -->
-            <!--   )                                                    -->
-            <!-- col28 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
-            <!--     column_alias='listing__ds__extract_quarter',       -->
-            <!--   )                                                    -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_77), column_alias='ds__extract_quarter') -->
+            <!-- col7 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_78), column_alias='ds__extract_month') -->
+            <!-- col8 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='ds__extract_day') -->
+            <!-- col9 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='ds__extract_dow') -->
+            <!-- col10 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='ds__extract_doy') -->
+            <!-- col11 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='created_at__day') -->
+            <!-- col12 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='created_at__week') -->
+            <!-- col13 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='created_at__month') -->
+            <!-- col14 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='created_at__quarter') -->
+            <!-- col15 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='created_at__year') -->
+            <!-- col16 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+            <!--     column_alias='created_at__extract_year',          -->
+            <!--   )                                                   -->
+            <!-- col17 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+            <!--     column_alias='created_at__extract_quarter',       -->
+            <!--   )                                                   -->
+            <!-- col18 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+            <!--     column_alias='created_at__extract_month',         -->
+            <!--   )                                                   -->
+            <!-- col19 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+            <!--     column_alias='created_at__extract_day',           -->
+            <!--   )                                                   -->
+            <!-- col20 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+            <!--     column_alias='created_at__extract_dow',           -->
+            <!--   )                                                   -->
+            <!-- col21 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+            <!--     column_alias='created_at__extract_doy',           -->
+            <!--   )                                                   -->
+            <!-- col22 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_93), column_alias='listing__ds__day') -->
+            <!-- col23 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='listing__ds__week') -->
+            <!-- col24 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='listing__ds__month') -->
+            <!-- col25 =                                                                                                  -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='listing__ds__quarter') -->
+            <!-- col26 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='listing__ds__year') -->
+            <!-- col27 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_98), -->
+            <!--     column_alias='listing__ds__extract_year',         -->
+            <!--   )                                                   -->
+            <!-- col28 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+            <!--     column_alias='listing__ds__extract_quarter',      -->
+            <!--   )                                                   -->
             <!-- col29 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
             <!--     column_alias='listing__ds__extract_month',         -->
             <!--   )                                                    -->
             <!-- col30 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
             <!--     column_alias='listing__ds__extract_day',           -->
             <!--   )                                                    -->
             <!-- col31 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
             <!--     column_alias='listing__ds__extract_dow',           -->
             <!--   )                                                    -->
             <!-- col32 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
             <!--     column_alias='listing__ds__extract_doy',           -->
             <!--   )                                                    -->
             <!-- col33 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
             <!--     column_alias='listing__created_at__day',           -->
             <!--   )                                                    -->
             <!-- col34 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
             <!--     column_alias='listing__created_at__week',          -->
             <!--   )                                                    -->
             <!-- col35 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
             <!--     column_alias='listing__created_at__month',         -->
             <!--   )                                                    -->
             <!-- col36 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
             <!--     column_alias='listing__created_at__quarter',       -->
             <!--   )                                                    -->
             <!-- col37 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
             <!--     column_alias='listing__created_at__year',          -->
             <!--   )                                                    -->
             <!-- col38 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
             <!--     column_alias='listing__created_at__extract_year',  -->
             <!--   )                                                    -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_132),   -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_110),   -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
             <!--     column_alias='listing__created_at__extract_day',   -->
             <!--   )                                                    -->
             <!-- col42 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
             <!--     column_alias='listing__created_at__extract_dow',   -->
             <!--   )                                                    -->
             <!-- col43 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
             <!--     column_alias='listing__created_at__extract_doy',   -->
             <!--   )                                                    -->
-            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_137), column_alias='listing') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_138), column_alias='user') -->
+            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_115), column_alias='listing') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_116), column_alias='user') -->
             <!-- col46 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_139), column_alias='listing__user') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_117), column_alias='listing__user') -->
             <!-- col47 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='country_latest') -->
-            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_87), column_alias='is_lux_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_64), column_alias='country_latest') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_65), column_alias='is_lux_latest') -->
             <!-- col49 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_88), column_alias='capacity_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_66), column_alias='capacity_latest') -->
             <!-- col50 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
             <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
             <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
             <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
             <!--     column_alias='user__home_state_latest',           -->
             <!--   )                                                   -->
-            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listings') -->
+            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listings') -->
             <!-- col55 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='largest_listing') -->
             <!-- col56 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='smallest_listing') -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- where = SqlStringExpression(node_id=str_0 sql_expr=listing__country_latest = 'us') -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='ds__month') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__week') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__month') -->
                 <!-- col3 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__quarter') -->
+                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__year') -->
                 <!-- col5 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__extract_year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__extract_year') -->
                 <!-- col6 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
                 <!--     column_alias='ds__extract_quarter',               -->
                 <!--   )                                                   -->
                 <!-- col7 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__extract_month') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_month') -->
                 <!-- col8 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_day') -->
                 <!-- col9 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_dow') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_dow') -->
                 <!-- col10 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_doy') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_doy') -->
                 <!-- col11 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='created_at__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='created_at__day') -->
                 <!-- col12 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='created_at__week') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__week') -->
                 <!-- col13 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='created_at__month') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__month') -->
                 <!-- col14 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
                 <!--     column_alias='created_at__quarter',               -->
                 <!--   )                                                   -->
                 <!-- col15 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__year') -->
                 <!-- col16 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
                 <!--     column_alias='created_at__extract_year',          -->
                 <!--   )                                                   -->
                 <!-- col17 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
                 <!--     column_alias='created_at__extract_quarter',       -->
                 <!--   )                                                   -->
                 <!-- col18 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
                 <!--     column_alias='created_at__extract_month',         -->
                 <!--   )                                                   -->
                 <!-- col19 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
                 <!--     column_alias='created_at__extract_day',           -->
                 <!--   )                                                   -->
                 <!-- col20 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
                 <!--     column_alias='created_at__extract_dow',           -->
                 <!--   )                                                   -->
                 <!-- col21 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
                 <!--     column_alias='created_at__extract_doy',           -->
                 <!--   )                                                   -->
                 <!-- col22 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing__ds__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='listing__ds__day') -->
                 <!-- col23 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing__ds__week') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__week') -->
                 <!-- col24 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
                 <!--     column_alias='listing__ds__month',                -->
                 <!--   )                                                   -->
                 <!-- col25 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
                 <!--     column_alias='listing__ds__quarter',              -->
                 <!--   )                                                   -->
                 <!-- col26 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__year') -->
                 <!-- col27 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
                 <!--     column_alias='listing__ds__extract_year',         -->
                 <!--   )                                                   -->
                 <!-- col28 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
                 <!--     column_alias='listing__ds__extract_quarter',      -->
                 <!--   )                                                   -->
                 <!-- col29 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
                 <!--     column_alias='listing__ds__extract_month',        -->
                 <!--   )                                                   -->
                 <!-- col30 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
                 <!--     column_alias='listing__ds__extract_day',          -->
                 <!--   )                                                   -->
                 <!-- col31 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
                 <!--     column_alias='listing__ds__extract_dow',          -->
                 <!--   )                                                   -->
                 <!-- col32 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
                 <!--     column_alias='listing__ds__extract_doy',          -->
                 <!--   )                                                   -->
                 <!-- col33 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
                 <!--     column_alias='listing__created_at__day',          -->
                 <!--   )                                                   -->
                 <!-- col34 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
                 <!--     column_alias='listing__created_at__week',         -->
                 <!--   )                                                   -->
                 <!-- col35 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
                 <!--     column_alias='listing__created_at__month',        -->
                 <!--   )                                                   -->
                 <!-- col36 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
                 <!--     column_alias='listing__created_at__quarter',      -->
                 <!--   )                                                   -->
                 <!-- col37 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
                 <!--     column_alias='listing__created_at__year',         -->
                 <!--   )                                                   -->
                 <!-- col38 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
                 <!--     column_alias='listing__created_at__extract_year', -->
                 <!--   )                                                   -->
                 <!-- col39 =                                                  -->
                 <!--   SqlSelectColumn(                                       -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_74),    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52),    -->
                 <!--     column_alias='listing__created_at__extract_quarter', -->
                 <!--   )                                                      -->
                 <!-- col40 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_75),  -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),  -->
                 <!--     column_alias='listing__created_at__extract_month', -->
                 <!--   )                                                    -->
                 <!-- col41 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
                 <!--     column_alias='listing__created_at__extract_day',  -->
                 <!--   )                                                   -->
                 <!-- col42 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
                 <!--     column_alias='listing__created_at__extract_dow',  -->
                 <!--   )                                                   -->
                 <!-- col43 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
                 <!--     column_alias='listing__created_at__extract_doy',  -->
                 <!--   )                                                   -->
-                <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='listing') -->
-                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='user') -->
+                <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing') -->
+                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='user') -->
                 <!-- col46 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__user') -->
-                <!-- col47 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='country_latest') -->
-                <!-- col48 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='is_lux_latest') -->
-                <!-- col49 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='capacity_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__user') -->
+                <!-- col47 =                                                                                           -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='country_latest') -->
+                <!-- col48 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='is_lux_latest') -->
+                <!-- col49 =                                                                                            -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='capacity_latest') -->
                 <!-- col50 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
                 <!--     column_alias='listing__country_latest',           -->
                 <!--   )                                                   -->
                 <!-- col51 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
                 <!--     column_alias='listing__is_lux_latest',            -->
                 <!--   )                                                   -->
                 <!-- col52 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
                 <!--     column_alias='listing__capacity_latest',          -->
                 <!--   )                                                   -->
                 <!-- col53 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
                 <!--     column_alias='user__home_state_latest',           -->
                 <!--   )                                                   -->
-                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='listings') -->
-                <!-- col55 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='largest_listing') -->
-                <!-- col56 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='smallest_listing') -->
+                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='listings') -->
+                <!-- col55 =                                                                                            -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='largest_listing') -->
+                <!-- col56 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='smallest_listing') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_0),   -->
                 <!--     right_source_alias='subq_2',                         -->
                 <!--     join_type=FULL_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -656,13 +656,13 @@
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
-                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='user') -->
-                    <!-- col1 =                                                -->
-                    <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
-                    <!--     column_alias='home_state_latest',                 -->
-                    <!--   )                                                   -->
+                    <!-- node_id = NodeId(id_str='ss_0') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
+                    <!-- col1 =                                               -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_0), -->
+                    <!--     column_alias='home_state_latest',                -->
+                    <!--   )                                                  -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
                     <!-- where = None -->
                     <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
@@ -1,210 +1,209 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 =                                                                                                     -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='user__home_state_latest') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- group_by0 =                                                                                                -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                 -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_2') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__year') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='ds__extract_quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_quarter') -->
             <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__extract_month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_month') -->
             <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_day') -->
             <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='created_at__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='created_at__day') -->
             <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='created_at__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__week') -->
             <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='created_at__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__month') -->
             <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='created_at__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__quarter') -->
             <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__year') -->
             <!-- col16 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
             <!--     column_alias='created_at__extract_year',          -->
             <!--   )                                                   -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
             <!--     column_alias='created_at__extract_quarter',       -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
             <!--     column_alias='created_at__extract_month',         -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
             <!--     column_alias='created_at__extract_day',           -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
             <!--     column_alias='created_at__extract_dow',           -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
             <!--     column_alias='created_at__extract_doy',           -->
             <!--   )                                                   -->
             <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing__ds__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='listing__ds__day') -->
             <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing__ds__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__week') -->
             <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__ds__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__month') -->
             <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__ds__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='listing__ds__quarter') -->
             <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__year') -->
             <!-- col27 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
             <!--     column_alias='listing__ds__extract_year',         -->
             <!--   )                                                   -->
             <!-- col28 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
             <!--     column_alias='listing__ds__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col29 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
             <!--     column_alias='listing__ds__extract_month',        -->
             <!--   )                                                   -->
             <!-- col30 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
             <!--     column_alias='listing__ds__extract_day',          -->
             <!--   )                                                   -->
             <!-- col31 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
             <!--     column_alias='listing__ds__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col32 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
             <!--     column_alias='listing__ds__extract_doy',          -->
             <!--   )                                                   -->
             <!-- col33 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
             <!--     column_alias='listing__created_at__day',          -->
             <!--   )                                                   -->
             <!-- col34 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
             <!--     column_alias='listing__created_at__week',         -->
             <!--   )                                                   -->
             <!-- col35 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
             <!--     column_alias='listing__created_at__month',        -->
             <!--   )                                                   -->
             <!-- col36 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
             <!--     column_alias='listing__created_at__quarter',      -->
             <!--   )                                                   -->
             <!-- col37 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
             <!--     column_alias='listing__created_at__year',         -->
             <!--   )                                                   -->
             <!-- col38 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
             <!--     column_alias='listing__created_at__extract_year', -->
             <!--   )                                                   -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_74),    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52),    -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_75),  -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),  -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
             <!--     column_alias='listing__created_at__extract_day',  -->
             <!--   )                                                   -->
             <!-- col42 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
             <!--     column_alias='listing__created_at__extract_dow',  -->
             <!--   )                                                   -->
             <!-- col43 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
             <!--     column_alias='listing__created_at__extract_doy',  -->
             <!--   )                                                   -->
-            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='listing') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='user') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__user') -->
-            <!-- col47 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='country_latest') -->
-            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='is_lux_latest') -->
-            <!-- col49 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='capacity_latest') -->
+            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='user') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__user') -->
+            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='country_latest') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='is_lux_latest') -->
+            <!-- col49 =                                                                                            -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='capacity_latest') -->
             <!-- col50 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
             <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
             <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
             <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
             <!--     column_alias='user__home_state_latest',           -->
             <!--   )                                                   -->
-            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='listings') -->
-            <!-- col55 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='largest_listing') -->
-            <!-- col56 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='smallest_listing') -->
+            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='listings') -->
+            <!-- col55 =                                                                                            -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='largest_listing') -->
+            <!-- col56 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_0),   -->
             <!--     right_source_alias='subq_2',                         -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -418,10 +417,10 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='user') -->
-                <!-- col1 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='home_state_latest') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
+                <!-- col1 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='home_state_latest') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
                 <!-- where = None -->
                 <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
+++ b/metricflow/test/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
@@ -1,417 +1,417 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
-        <!-- node_id = NodeId(id_str='ss_4') -->
+        <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_140), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                       -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_141), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='user__home_state_latest') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
         <!-- group_by0 =                                                                                                 -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_140), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_141), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Output with WHERE' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_93), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='ds__year') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_74), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_75), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_76), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_99), column_alias='ds__extract_quarter') -->
-            <!-- col7 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_100), column_alias='ds__extract_month') -->
-            <!-- col8 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_101), column_alias='ds__extract_day') -->
-            <!-- col9 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='ds__extract_dow') -->
-            <!-- col10 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='ds__extract_doy') -->
-            <!-- col11 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='created_at__day') -->
-            <!-- col12 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='created_at__week') -->
-            <!-- col13 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='created_at__month') -->
-            <!-- col14 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='created_at__quarter') -->
-            <!-- col15 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='created_at__year') -->
-            <!-- col16 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
-            <!--     column_alias='created_at__extract_year',           -->
-            <!--   )                                                    -->
-            <!-- col17 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
-            <!--     column_alias='created_at__extract_quarter',        -->
-            <!--   )                                                    -->
-            <!-- col18 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
-            <!--     column_alias='created_at__extract_month',          -->
-            <!--   )                                                    -->
-            <!-- col19 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
-            <!--     column_alias='created_at__extract_day',            -->
-            <!--   )                                                    -->
-            <!-- col20 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
-            <!--     column_alias='created_at__extract_dow',            -->
-            <!--   )                                                    -->
-            <!-- col21 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
-            <!--     column_alias='created_at__extract_doy',            -->
-            <!--   )                                                    -->
-            <!-- col22 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_115), column_alias='listing__ds__day') -->
-            <!-- col23 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_116), column_alias='listing__ds__week') -->
-            <!-- col24 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_117), column_alias='listing__ds__month') -->
-            <!-- col25 =                                                                                                   -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__ds__quarter') -->
-            <!-- col26 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='listing__ds__year') -->
-            <!-- col27 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
-            <!--     column_alias='listing__ds__extract_year',          -->
-            <!--   )                                                    -->
-            <!-- col28 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
-            <!--     column_alias='listing__ds__extract_quarter',       -->
-            <!--   )                                                    -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_77), column_alias='ds__extract_quarter') -->
+            <!-- col7 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_78), column_alias='ds__extract_month') -->
+            <!-- col8 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='ds__extract_day') -->
+            <!-- col9 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='ds__extract_dow') -->
+            <!-- col10 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='ds__extract_doy') -->
+            <!-- col11 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='created_at__day') -->
+            <!-- col12 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='created_at__week') -->
+            <!-- col13 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='created_at__month') -->
+            <!-- col14 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='created_at__quarter') -->
+            <!-- col15 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='created_at__year') -->
+            <!-- col16 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+            <!--     column_alias='created_at__extract_year',          -->
+            <!--   )                                                   -->
+            <!-- col17 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+            <!--     column_alias='created_at__extract_quarter',       -->
+            <!--   )                                                   -->
+            <!-- col18 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+            <!--     column_alias='created_at__extract_month',         -->
+            <!--   )                                                   -->
+            <!-- col19 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+            <!--     column_alias='created_at__extract_day',           -->
+            <!--   )                                                   -->
+            <!-- col20 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+            <!--     column_alias='created_at__extract_dow',           -->
+            <!--   )                                                   -->
+            <!-- col21 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+            <!--     column_alias='created_at__extract_doy',           -->
+            <!--   )                                                   -->
+            <!-- col22 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_93), column_alias='listing__ds__day') -->
+            <!-- col23 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='listing__ds__week') -->
+            <!-- col24 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='listing__ds__month') -->
+            <!-- col25 =                                                                                                  -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='listing__ds__quarter') -->
+            <!-- col26 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='listing__ds__year') -->
+            <!-- col27 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_98), -->
+            <!--     column_alias='listing__ds__extract_year',         -->
+            <!--   )                                                   -->
+            <!-- col28 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+            <!--     column_alias='listing__ds__extract_quarter',      -->
+            <!--   )                                                   -->
             <!-- col29 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
             <!--     column_alias='listing__ds__extract_month',         -->
             <!--   )                                                    -->
             <!-- col30 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
             <!--     column_alias='listing__ds__extract_day',           -->
             <!--   )                                                    -->
             <!-- col31 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
             <!--     column_alias='listing__ds__extract_dow',           -->
             <!--   )                                                    -->
             <!-- col32 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_103), -->
             <!--     column_alias='listing__ds__extract_doy',           -->
             <!--   )                                                    -->
             <!-- col33 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
             <!--     column_alias='listing__created_at__day',           -->
             <!--   )                                                    -->
             <!-- col34 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
             <!--     column_alias='listing__created_at__week',          -->
             <!--   )                                                    -->
             <!-- col35 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
             <!--     column_alias='listing__created_at__month',         -->
             <!--   )                                                    -->
             <!-- col36 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
             <!--     column_alias='listing__created_at__quarter',       -->
             <!--   )                                                    -->
             <!-- col37 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
             <!--     column_alias='listing__created_at__year',          -->
             <!--   )                                                    -->
             <!-- col38 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
             <!--     column_alias='listing__created_at__extract_year',  -->
             <!--   )                                                    -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_132),   -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_110),   -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
             <!--     column_alias='listing__created_at__extract_day',   -->
             <!--   )                                                    -->
             <!-- col42 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
             <!--     column_alias='listing__created_at__extract_dow',   -->
             <!--   )                                                    -->
             <!-- col43 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
             <!--     column_alias='listing__created_at__extract_doy',   -->
             <!--   )                                                    -->
-            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_137), column_alias='listing') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_138), column_alias='user') -->
+            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_115), column_alias='listing') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_116), column_alias='user') -->
             <!-- col46 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_139), column_alias='listing__user') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_117), column_alias='listing__user') -->
             <!-- col47 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='country_latest') -->
-            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_87), column_alias='is_lux_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_64), column_alias='country_latest') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_65), column_alias='is_lux_latest') -->
             <!-- col49 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_88), column_alias='capacity_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_66), column_alias='capacity_latest') -->
             <!-- col50 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
             <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
             <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
             <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
             <!--     column_alias='user__home_state_latest',           -->
             <!--   )                                                   -->
-            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listings') -->
+            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listings') -->
             <!-- col55 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='largest_listing') -->
             <!-- col56 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='smallest_listing') -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- where = SqlStringExpression(node_id=str_0 sql_expr=user__home_state_latest = 'us') -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='ds__month') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__week') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__month') -->
                 <!-- col3 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__quarter') -->
+                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__year') -->
                 <!-- col5 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__extract_year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__extract_year') -->
                 <!-- col6 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
                 <!--     column_alias='ds__extract_quarter',               -->
                 <!--   )                                                   -->
                 <!-- col7 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__extract_month') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_month') -->
                 <!-- col8 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_day') -->
                 <!-- col9 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_dow') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_dow') -->
                 <!-- col10 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_doy') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_doy') -->
                 <!-- col11 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='created_at__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='created_at__day') -->
                 <!-- col12 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='created_at__week') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__week') -->
                 <!-- col13 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='created_at__month') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__month') -->
                 <!-- col14 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
                 <!--     column_alias='created_at__quarter',               -->
                 <!--   )                                                   -->
                 <!-- col15 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__year') -->
                 <!-- col16 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
                 <!--     column_alias='created_at__extract_year',          -->
                 <!--   )                                                   -->
                 <!-- col17 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
                 <!--     column_alias='created_at__extract_quarter',       -->
                 <!--   )                                                   -->
                 <!-- col18 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
                 <!--     column_alias='created_at__extract_month',         -->
                 <!--   )                                                   -->
                 <!-- col19 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
                 <!--     column_alias='created_at__extract_day',           -->
                 <!--   )                                                   -->
                 <!-- col20 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
                 <!--     column_alias='created_at__extract_dow',           -->
                 <!--   )                                                   -->
                 <!-- col21 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
                 <!--     column_alias='created_at__extract_doy',           -->
                 <!--   )                                                   -->
                 <!-- col22 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing__ds__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='listing__ds__day') -->
                 <!-- col23 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing__ds__week') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__week') -->
                 <!-- col24 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
                 <!--     column_alias='listing__ds__month',                -->
                 <!--   )                                                   -->
                 <!-- col25 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
                 <!--     column_alias='listing__ds__quarter',              -->
                 <!--   )                                                   -->
                 <!-- col26 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__year') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__year') -->
                 <!-- col27 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
                 <!--     column_alias='listing__ds__extract_year',         -->
                 <!--   )                                                   -->
                 <!-- col28 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
                 <!--     column_alias='listing__ds__extract_quarter',      -->
                 <!--   )                                                   -->
                 <!-- col29 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
                 <!--     column_alias='listing__ds__extract_month',        -->
                 <!--   )                                                   -->
                 <!-- col30 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
                 <!--     column_alias='listing__ds__extract_day',          -->
                 <!--   )                                                   -->
                 <!-- col31 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
                 <!--     column_alias='listing__ds__extract_dow',          -->
                 <!--   )                                                   -->
                 <!-- col32 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
                 <!--     column_alias='listing__ds__extract_doy',          -->
                 <!--   )                                                   -->
                 <!-- col33 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
                 <!--     column_alias='listing__created_at__day',          -->
                 <!--   )                                                   -->
                 <!-- col34 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
                 <!--     column_alias='listing__created_at__week',         -->
                 <!--   )                                                   -->
                 <!-- col35 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
                 <!--     column_alias='listing__created_at__month',        -->
                 <!--   )                                                   -->
                 <!-- col36 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
                 <!--     column_alias='listing__created_at__quarter',      -->
                 <!--   )                                                   -->
                 <!-- col37 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
                 <!--     column_alias='listing__created_at__year',         -->
                 <!--   )                                                   -->
                 <!-- col38 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
                 <!--     column_alias='listing__created_at__extract_year', -->
                 <!--   )                                                   -->
                 <!-- col39 =                                                  -->
                 <!--   SqlSelectColumn(                                       -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_74),    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52),    -->
                 <!--     column_alias='listing__created_at__extract_quarter', -->
                 <!--   )                                                      -->
                 <!-- col40 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_75),  -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),  -->
                 <!--     column_alias='listing__created_at__extract_month', -->
                 <!--   )                                                    -->
                 <!-- col41 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
                 <!--     column_alias='listing__created_at__extract_day',  -->
                 <!--   )                                                   -->
                 <!-- col42 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
                 <!--     column_alias='listing__created_at__extract_dow',  -->
                 <!--   )                                                   -->
                 <!-- col43 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
                 <!--     column_alias='listing__created_at__extract_doy',  -->
                 <!--   )                                                   -->
-                <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='listing') -->
-                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='user') -->
+                <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing') -->
+                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='user') -->
                 <!-- col46 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__user') -->
-                <!-- col47 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='country_latest') -->
-                <!-- col48 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='is_lux_latest') -->
-                <!-- col49 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='capacity_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__user') -->
+                <!-- col47 =                                                                                           -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='country_latest') -->
+                <!-- col48 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='is_lux_latest') -->
+                <!-- col49 =                                                                                            -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='capacity_latest') -->
                 <!-- col50 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
                 <!--     column_alias='listing__country_latest',           -->
                 <!--   )                                                   -->
                 <!-- col51 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
                 <!--     column_alias='listing__is_lux_latest',            -->
                 <!--   )                                                   -->
                 <!-- col52 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
                 <!--     column_alias='listing__capacity_latest',          -->
                 <!--   )                                                   -->
                 <!-- col53 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
                 <!--     column_alias='user__home_state_latest',           -->
                 <!--   )                                                   -->
-                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='listings') -->
-                <!-- col55 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='largest_listing') -->
-                <!-- col56 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='smallest_listing') -->
+                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='listings') -->
+                <!-- col55 =                                                                                            -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='largest_listing') -->
+                <!-- col56 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='smallest_listing') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_0),   -->
                 <!--     right_source_alias='subq_2',                         -->
                 <!--     join_type=FULL_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -660,13 +660,13 @@
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
-                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='user') -->
-                    <!-- col1 =                                                -->
-                    <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
-                    <!--     column_alias='home_state_latest',                 -->
-                    <!--   )                                                   -->
+                    <!-- node_id = NodeId(id_str='ss_0') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
+                    <!-- col1 =                                               -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_0), -->
+                    <!--     column_alias='home_state_latest',                -->
+                    <!--   )                                                  -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
                     <!-- where = None -->
                     <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
+++ b/metricflow/test/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
@@ -1,210 +1,209 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 =                                                                                                     -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='user__home_state_latest') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- group_by0 =                                                                                                -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                 -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_2') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__year') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='ds__extract_quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_quarter') -->
             <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__extract_month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_month') -->
             <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_day') -->
             <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='created_at__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='created_at__day') -->
             <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='created_at__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__week') -->
             <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='created_at__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__month') -->
             <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='created_at__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__quarter') -->
             <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__year') -->
             <!-- col16 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
             <!--     column_alias='created_at__extract_year',          -->
             <!--   )                                                   -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
             <!--     column_alias='created_at__extract_quarter',       -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
             <!--     column_alias='created_at__extract_month',         -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
             <!--     column_alias='created_at__extract_day',           -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
             <!--     column_alias='created_at__extract_dow',           -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
             <!--     column_alias='created_at__extract_doy',           -->
             <!--   )                                                   -->
             <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing__ds__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='listing__ds__day') -->
             <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing__ds__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__week') -->
             <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__ds__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__month') -->
             <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__ds__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='listing__ds__quarter') -->
             <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__year') -->
             <!-- col27 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
             <!--     column_alias='listing__ds__extract_year',         -->
             <!--   )                                                   -->
             <!-- col28 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
             <!--     column_alias='listing__ds__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col29 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
             <!--     column_alias='listing__ds__extract_month',        -->
             <!--   )                                                   -->
             <!-- col30 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
             <!--     column_alias='listing__ds__extract_day',          -->
             <!--   )                                                   -->
             <!-- col31 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
             <!--     column_alias='listing__ds__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col32 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
             <!--     column_alias='listing__ds__extract_doy',          -->
             <!--   )                                                   -->
             <!-- col33 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
             <!--     column_alias='listing__created_at__day',          -->
             <!--   )                                                   -->
             <!-- col34 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
             <!--     column_alias='listing__created_at__week',         -->
             <!--   )                                                   -->
             <!-- col35 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
             <!--     column_alias='listing__created_at__month',        -->
             <!--   )                                                   -->
             <!-- col36 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
             <!--     column_alias='listing__created_at__quarter',      -->
             <!--   )                                                   -->
             <!-- col37 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
             <!--     column_alias='listing__created_at__year',         -->
             <!--   )                                                   -->
             <!-- col38 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
             <!--     column_alias='listing__created_at__extract_year', -->
             <!--   )                                                   -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_74),    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52),    -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_75),  -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),  -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
             <!--     column_alias='listing__created_at__extract_day',  -->
             <!--   )                                                   -->
             <!-- col42 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
             <!--     column_alias='listing__created_at__extract_dow',  -->
             <!--   )                                                   -->
             <!-- col43 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
             <!--     column_alias='listing__created_at__extract_doy',  -->
             <!--   )                                                   -->
-            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_79), column_alias='listing') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='user') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__user') -->
-            <!-- col47 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='country_latest') -->
-            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='is_lux_latest') -->
-            <!-- col49 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='capacity_latest') -->
+            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='user') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__user') -->
+            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='country_latest') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='is_lux_latest') -->
+            <!-- col49 =                                                                                            -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='capacity_latest') -->
             <!-- col50 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
             <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
             <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
             <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
             <!--     column_alias='user__home_state_latest',           -->
             <!--   )                                                   -->
-            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='listings') -->
-            <!-- col55 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='largest_listing') -->
-            <!-- col56 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='smallest_listing') -->
+            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='listings') -->
+            <!-- col55 =                                                                                            -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='largest_listing') -->
+            <!-- col56 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_0),   -->
             <!--     right_source_alias='subq_2',                         -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -418,10 +417,10 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='user') -->
-                <!-- col1 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='home_state_latest') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
+                <!-- col1 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='home_state_latest') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
                 <!-- where = None -->
                 <!-- distinct = False -->

--- a/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
@@ -1,7 +1,7 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Combine Aggregated Outputs' -->
-        <!-- node_id = NodeId(id_str='ss_17') -->
+        <!-- node_id = NodeId(id_str='ss_8') -->
         <!-- col0 =                                                                         -->
         <!--   SqlSelectColumn(                                                             -->
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
@@ -17,10 +17,10 @@
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
         <!--     column_alias='booking_payments',                                      -->
         <!--   )                                                                       -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_16),  -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_7),   -->
         <!--     right_source_alias='subq_9',                         -->
         <!--     join_type=FULL_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -34,508 +34,505 @@
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_12') -->
+            <!-- node_id = NodeId(id_str='ss_3') -->
             <!-- col0 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_630), column_alias='metric_time__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_631), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='metric_time__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='bookings') -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_11') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_629), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_101), column_alias='metric_time__day') -->
                 <!-- col1 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='bookings',                                              -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_629), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_101), column_alias='metric_time__day') -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_10') -->
-                    <!-- col0 =                                                 -->
-                    <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_627), -->
-                    <!--     column_alias='metric_time__day',                   -->
-                    <!--   )                                                    -->
-                    <!-- col1 =                                                                                        -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_626), column_alias='bookings') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- col0 =                                                -->
+                    <!--   SqlSelectColumn(                                    -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+                    <!--     column_alias='metric_time__day',                  -->
+                    <!--   )                                                   -->
+                    <!-- col1 =                                                                                       -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='bookings') -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_9') -->
-                        <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_543), column_alias='ds__day') -->
-                        <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_544), column_alias='ds__week') -->
-                        <!-- col2 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_545), -->
-                        <!--     column_alias='ds__month',                          -->
-                        <!--   )                                                    -->
-                        <!-- col3 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_546), -->
-                        <!--     column_alias='ds__quarter',                        -->
-                        <!--   )                                                    -->
-                        <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_547), column_alias='ds__year') -->
-                        <!-- col5 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_548), -->
-                        <!--     column_alias='ds__extract_year',                   -->
-                        <!--   )                                                    -->
-                        <!-- col6 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_549), -->
-                        <!--     column_alias='ds__extract_quarter',                -->
-                        <!--   )                                                    -->
-                        <!-- col7 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_550), -->
-                        <!--     column_alias='ds__extract_month',                  -->
-                        <!--   )                                                    -->
-                        <!-- col8 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_551), -->
-                        <!--     column_alias='ds__extract_day',                    -->
-                        <!--   )                                                    -->
-                        <!-- col9 =                                                 -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_552), -->
-                        <!--     column_alias='ds__extract_dow',                    -->
-                        <!--   )                                                    -->
-                        <!-- col10 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_553), -->
-                        <!--     column_alias='ds__extract_doy',                    -->
-                        <!--   )                                                    -->
-                        <!-- col11 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_554), -->
-                        <!--     column_alias='ds_partitioned__day',                -->
-                        <!--   )                                                    -->
-                        <!-- col12 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_555), -->
-                        <!--     column_alias='ds_partitioned__week',               -->
-                        <!--   )                                                    -->
-                        <!-- col13 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_556), -->
-                        <!--     column_alias='ds_partitioned__month',              -->
-                        <!--   )                                                    -->
-                        <!-- col14 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_557), -->
-                        <!--     column_alias='ds_partitioned__quarter',            -->
-                        <!--   )                                                    -->
-                        <!-- col15 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_558), -->
-                        <!--     column_alias='ds_partitioned__year',               -->
-                        <!--   )                                                    -->
-                        <!-- col16 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_559), -->
-                        <!--     column_alias='ds_partitioned__extract_year',       -->
-                        <!--   )                                                    -->
-                        <!-- col17 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_560), -->
-                        <!--     column_alias='ds_partitioned__extract_quarter',    -->
-                        <!--   )                                                    -->
-                        <!-- col18 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_561), -->
-                        <!--     column_alias='ds_partitioned__extract_month',      -->
-                        <!--   )                                                    -->
-                        <!-- col19 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_562), -->
-                        <!--     column_alias='ds_partitioned__extract_day',        -->
-                        <!--   )                                                    -->
-                        <!-- col20 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_563), -->
-                        <!--     column_alias='ds_partitioned__extract_dow',        -->
-                        <!--   )                                                    -->
-                        <!-- col21 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_564), -->
-                        <!--     column_alias='ds_partitioned__extract_doy',        -->
-                        <!--   )                                                    -->
-                        <!-- col22 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_565), -->
-                        <!--     column_alias='paid_at__day',                       -->
-                        <!--   )                                                    -->
-                        <!-- col23 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_566), -->
-                        <!--     column_alias='paid_at__week',                      -->
-                        <!--   )                                                    -->
-                        <!-- col24 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_567), -->
-                        <!--     column_alias='paid_at__month',                     -->
-                        <!--   )                                                    -->
-                        <!-- col25 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_568), -->
-                        <!--     column_alias='paid_at__quarter',                   -->
-                        <!--   )                                                    -->
-                        <!-- col26 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_569), -->
-                        <!--     column_alias='paid_at__year',                      -->
-                        <!--   )                                                    -->
-                        <!-- col27 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_570), -->
-                        <!--     column_alias='paid_at__extract_year',              -->
-                        <!--   )                                                    -->
-                        <!-- col28 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_571), -->
-                        <!--     column_alias='paid_at__extract_quarter',           -->
-                        <!--   )                                                    -->
-                        <!-- col29 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_572), -->
-                        <!--     column_alias='paid_at__extract_month',             -->
-                        <!--   )                                                    -->
-                        <!-- col30 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_573), -->
-                        <!--     column_alias='paid_at__extract_day',               -->
-                        <!--   )                                                    -->
-                        <!-- col31 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_574), -->
-                        <!--     column_alias='paid_at__extract_dow',               -->
-                        <!--   )                                                    -->
-                        <!-- col32 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_575), -->
-                        <!--     column_alias='paid_at__extract_doy',               -->
-                        <!--   )                                                    -->
-                        <!-- col33 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_576), -->
-                        <!--     column_alias='booking__ds__day',                   -->
-                        <!--   )                                                    -->
-                        <!-- col34 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_577), -->
-                        <!--     column_alias='booking__ds__week',                  -->
-                        <!--   )                                                    -->
-                        <!-- col35 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_578), -->
-                        <!--     column_alias='booking__ds__month',                 -->
-                        <!--   )                                                    -->
-                        <!-- col36 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_579), -->
-                        <!--     column_alias='booking__ds__quarter',               -->
-                        <!--   )                                                    -->
-                        <!-- col37 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_580), -->
-                        <!--     column_alias='booking__ds__year',                  -->
-                        <!--   )                                                    -->
-                        <!-- col38 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_581), -->
-                        <!--     column_alias='booking__ds__extract_year',          -->
-                        <!--   )                                                    -->
-                        <!-- col39 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_582), -->
-                        <!--     column_alias='booking__ds__extract_quarter',       -->
-                        <!--   )                                                    -->
-                        <!-- col40 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_583), -->
-                        <!--     column_alias='booking__ds__extract_month',         -->
-                        <!--   )                                                    -->
-                        <!-- col41 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_584), -->
-                        <!--     column_alias='booking__ds__extract_day',           -->
-                        <!--   )                                                    -->
-                        <!-- col42 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_585), -->
-                        <!--     column_alias='booking__ds__extract_dow',           -->
-                        <!--   )                                                    -->
-                        <!-- col43 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_586), -->
-                        <!--     column_alias='booking__ds__extract_doy',           -->
-                        <!--   )                                                    -->
-                        <!-- col44 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_587), -->
-                        <!--     column_alias='booking__ds_partitioned__day',       -->
-                        <!--   )                                                    -->
-                        <!-- col45 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_588), -->
-                        <!--     column_alias='booking__ds_partitioned__week',      -->
-                        <!--   )                                                    -->
-                        <!-- col46 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_589), -->
-                        <!--     column_alias='booking__ds_partitioned__month',     -->
-                        <!--   )                                                    -->
-                        <!-- col47 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_590), -->
-                        <!--     column_alias='booking__ds_partitioned__quarter',   -->
-                        <!--   )                                                    -->
-                        <!-- col48 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_591), -->
-                        <!--     column_alias='booking__ds_partitioned__year',      -->
-                        <!--   )                                                    -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- col0 =                                                                                      -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__day') -->
+                        <!-- col1 =                                                                                       -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__week') -->
+                        <!-- col2 =                                                                                        -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__month') -->
+                        <!-- col3 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_18), -->
+                        <!--     column_alias='ds__quarter',                       -->
+                        <!--   )                                                   -->
+                        <!-- col4 =                                                                                       -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__year') -->
+                        <!-- col5 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
+                        <!--     column_alias='ds__extract_year',                  -->
+                        <!--   )                                                   -->
+                        <!-- col6 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_21), -->
+                        <!--     column_alias='ds__extract_quarter',               -->
+                        <!--   )                                                   -->
+                        <!-- col7 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_22), -->
+                        <!--     column_alias='ds__extract_month',                 -->
+                        <!--   )                                                   -->
+                        <!-- col8 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
+                        <!--     column_alias='ds__extract_day',                   -->
+                        <!--   )                                                   -->
+                        <!-- col9 =                                                -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_24), -->
+                        <!--     column_alias='ds__extract_dow',                   -->
+                        <!--   )                                                   -->
+                        <!-- col10 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_25), -->
+                        <!--     column_alias='ds__extract_doy',                   -->
+                        <!--   )                                                   -->
+                        <!-- col11 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_26), -->
+                        <!--     column_alias='ds_partitioned__day',               -->
+                        <!--   )                                                   -->
+                        <!-- col12 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
+                        <!--     column_alias='ds_partitioned__week',              -->
+                        <!--   )                                                   -->
+                        <!-- col13 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
+                        <!--     column_alias='ds_partitioned__month',             -->
+                        <!--   )                                                   -->
+                        <!-- col14 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
+                        <!--     column_alias='ds_partitioned__quarter',           -->
+                        <!--   )                                                   -->
+                        <!-- col15 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
+                        <!--     column_alias='ds_partitioned__year',              -->
+                        <!--   )                                                   -->
+                        <!-- col16 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
+                        <!--     column_alias='ds_partitioned__extract_year',      -->
+                        <!--   )                                                   -->
+                        <!-- col17 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                        <!--     column_alias='ds_partitioned__extract_quarter',   -->
+                        <!--   )                                                   -->
+                        <!-- col18 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                        <!--     column_alias='ds_partitioned__extract_month',     -->
+                        <!--   )                                                   -->
+                        <!-- col19 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                        <!--     column_alias='ds_partitioned__extract_day',       -->
+                        <!--   )                                                   -->
+                        <!-- col20 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                        <!--     column_alias='ds_partitioned__extract_dow',       -->
+                        <!--   )                                                   -->
+                        <!-- col21 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
+                        <!--     column_alias='ds_partitioned__extract_doy',       -->
+                        <!--   )                                                   -->
+                        <!-- col22 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
+                        <!--     column_alias='paid_at__day',                      -->
+                        <!--   )                                                   -->
+                        <!-- col23 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+                        <!--     column_alias='paid_at__week',                     -->
+                        <!--   )                                                   -->
+                        <!-- col24 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                        <!--     column_alias='paid_at__month',                    -->
+                        <!--   )                                                   -->
+                        <!-- col25 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+                        <!--     column_alias='paid_at__quarter',                  -->
+                        <!--   )                                                   -->
+                        <!-- col26 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+                        <!--     column_alias='paid_at__year',                     -->
+                        <!--   )                                                   -->
+                        <!-- col27 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+                        <!--     column_alias='paid_at__extract_year',             -->
+                        <!--   )                                                   -->
+                        <!-- col28 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+                        <!--     column_alias='paid_at__extract_quarter',          -->
+                        <!--   )                                                   -->
+                        <!-- col29 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+                        <!--     column_alias='paid_at__extract_month',            -->
+                        <!--   )                                                   -->
+                        <!-- col30 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
+                        <!--     column_alias='paid_at__extract_day',              -->
+                        <!--   )                                                   -->
+                        <!-- col31 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
+                        <!--     column_alias='paid_at__extract_dow',              -->
+                        <!--   )                                                   -->
+                        <!-- col32 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
+                        <!--     column_alias='paid_at__extract_doy',              -->
+                        <!--   )                                                   -->
+                        <!-- col33 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
+                        <!--     column_alias='booking__ds__day',                  -->
+                        <!--   )                                                   -->
+                        <!-- col34 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
+                        <!--     column_alias='booking__ds__week',                 -->
+                        <!--   )                                                   -->
+                        <!-- col35 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
+                        <!--     column_alias='booking__ds__month',                -->
+                        <!--   )                                                   -->
+                        <!-- col36 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                        <!--     column_alias='booking__ds__quarter',              -->
+                        <!--   )                                                   -->
+                        <!-- col37 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                        <!--     column_alias='booking__ds__year',                 -->
+                        <!--   )                                                   -->
+                        <!-- col38 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
+                        <!--     column_alias='booking__ds__extract_year',         -->
+                        <!--   )                                                   -->
+                        <!-- col39 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
+                        <!--     column_alias='booking__ds__extract_quarter',      -->
+                        <!--   )                                                   -->
+                        <!-- col40 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+                        <!--     column_alias='booking__ds__extract_month',        -->
+                        <!--   )                                                   -->
+                        <!-- col41 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                        <!--     column_alias='booking__ds__extract_day',          -->
+                        <!--   )                                                   -->
+                        <!-- col42 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+                        <!--     column_alias='booking__ds__extract_dow',          -->
+                        <!--   )                                                   -->
+                        <!-- col43 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
+                        <!--     column_alias='booking__ds__extract_doy',          -->
+                        <!--   )                                                   -->
+                        <!-- col44 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+                        <!--     column_alias='booking__ds_partitioned__day',      -->
+                        <!--   )                                                   -->
+                        <!-- col45 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
+                        <!--     column_alias='booking__ds_partitioned__week',     -->
+                        <!--   )                                                   -->
+                        <!-- col46 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
+                        <!--     column_alias='booking__ds_partitioned__month',    -->
+                        <!--   )                                                   -->
+                        <!-- col47 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
+                        <!--     column_alias='booking__ds_partitioned__quarter',  -->
+                        <!--   )                                                   -->
+                        <!-- col48 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+                        <!--     column_alias='booking__ds_partitioned__year',     -->
+                        <!--   )                                                   -->
                         <!-- col49 =                                                   -->
                         <!--   SqlSelectColumn(                                        -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_592),    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_64),     -->
                         <!--     column_alias='booking__ds_partitioned__extract_year', -->
                         <!--   )                                                       -->
                         <!-- col50 =                                                      -->
                         <!--   SqlSelectColumn(                                           -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_593),       -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_65),        -->
                         <!--     column_alias='booking__ds_partitioned__extract_quarter', -->
                         <!--   )                                                          -->
                         <!-- col51 =                                                    -->
                         <!--   SqlSelectColumn(                                         -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_594),     -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_66),      -->
                         <!--     column_alias='booking__ds_partitioned__extract_month', -->
                         <!--   )                                                        -->
                         <!-- col52 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_595),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_67),    -->
                         <!--     column_alias='booking__ds_partitioned__extract_day', -->
                         <!--   )                                                      -->
                         <!-- col53 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_596),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_68),    -->
                         <!--     column_alias='booking__ds_partitioned__extract_dow', -->
                         <!--   )                                                      -->
                         <!-- col54 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_597),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_69),    -->
                         <!--     column_alias='booking__ds_partitioned__extract_doy', -->
                         <!--   )                                                      -->
-                        <!-- col55 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_598), -->
-                        <!--     column_alias='booking__paid_at__day',              -->
-                        <!--   )                                                    -->
-                        <!-- col56 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_599), -->
-                        <!--     column_alias='booking__paid_at__week',             -->
-                        <!--   )                                                    -->
-                        <!-- col57 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_600), -->
-                        <!--     column_alias='booking__paid_at__month',            -->
-                        <!--   )                                                    -->
-                        <!-- col58 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_601), -->
-                        <!--     column_alias='booking__paid_at__quarter',          -->
-                        <!--   )                                                    -->
-                        <!-- col59 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_602), -->
-                        <!--     column_alias='booking__paid_at__year',             -->
-                        <!--   )                                                    -->
-                        <!-- col60 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_603), -->
-                        <!--     column_alias='booking__paid_at__extract_year',     -->
-                        <!--   )                                                    -->
-                        <!-- col61 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_604), -->
-                        <!--     column_alias='booking__paid_at__extract_quarter',  -->
-                        <!--   )                                                    -->
-                        <!-- col62 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_605), -->
-                        <!--     column_alias='booking__paid_at__extract_month',    -->
-                        <!--   )                                                    -->
-                        <!-- col63 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_606), -->
-                        <!--     column_alias='booking__paid_at__extract_day',      -->
-                        <!--   )                                                    -->
-                        <!-- col64 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_607), -->
-                        <!--     column_alias='booking__paid_at__extract_dow',      -->
-                        <!--   )                                                    -->
-                        <!-- col65 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_608), -->
-                        <!--     column_alias='booking__paid_at__extract_doy',      -->
-                        <!--   )                                                    -->
-                        <!-- col66 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_609), -->
-                        <!--     column_alias='metric_time__day',                   -->
-                        <!--   )                                                    -->
-                        <!-- col67 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_610), -->
-                        <!--     column_alias='metric_time__week',                  -->
-                        <!--   )                                                    -->
-                        <!-- col68 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_611), -->
-                        <!--     column_alias='metric_time__month',                 -->
-                        <!--   )                                                    -->
-                        <!-- col69 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_612), -->
-                        <!--     column_alias='metric_time__quarter',               -->
-                        <!--   )                                                    -->
-                        <!-- col70 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_613), -->
-                        <!--     column_alias='metric_time__year',                  -->
-                        <!--   )                                                    -->
-                        <!-- col71 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_614), -->
-                        <!--     column_alias='metric_time__extract_year',          -->
-                        <!--   )                                                    -->
-                        <!-- col72 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_615), -->
-                        <!--     column_alias='metric_time__extract_quarter',       -->
-                        <!--   )                                                    -->
-                        <!-- col73 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_616), -->
-                        <!--     column_alias='metric_time__extract_month',         -->
-                        <!--   )                                                    -->
-                        <!-- col74 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_617), -->
-                        <!--     column_alias='metric_time__extract_day',           -->
-                        <!--   )                                                    -->
-                        <!-- col75 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_618), -->
-                        <!--     column_alias='metric_time__extract_dow',           -->
-                        <!--   )                                                    -->
-                        <!-- col76 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_619), -->
-                        <!--     column_alias='metric_time__extract_doy',           -->
-                        <!--   )                                                    -->
-                        <!-- col77 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_620), column_alias='listing') -->
-                        <!-- col78 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_621), column_alias='guest') -->
-                        <!-- col79 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_622), column_alias='host') -->
-                        <!-- col80 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_623), -->
-                        <!--     column_alias='booking__listing',                   -->
-                        <!--   )                                                    -->
-                        <!-- col81 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_624), -->
-                        <!--     column_alias='booking__guest',                     -->
-                        <!--   )                                                    -->
-                        <!-- col82 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_625), -->
-                        <!--     column_alias='booking__host',                      -->
-                        <!--   )                                                    -->
-                        <!-- col83 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_541), -->
-                        <!--     column_alias='is_instant',                         -->
-                        <!--   )                                                    -->
-                        <!-- col84 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_542), -->
-                        <!--     column_alias='booking__is_instant',                -->
-                        <!--   )                                                    -->
-                        <!-- col85 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_528), column_alias='bookings') -->
-                        <!-- col86 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_529), -->
-                        <!--     column_alias='instant_bookings',                   -->
-                        <!--   )                                                    -->
-                        <!-- col87 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_530), -->
-                        <!--     column_alias='booking_value',                      -->
-                        <!--   )                                                    -->
-                        <!-- col88 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_531), -->
-                        <!--     column_alias='max_booking_value',                  -->
-                        <!--   )                                                    -->
-                        <!-- col89 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_532), -->
-                        <!--     column_alias='min_booking_value',                  -->
-                        <!--   )                                                    -->
-                        <!-- col90 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_533), column_alias='bookers') -->
-                        <!-- col91 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_534), -->
-                        <!--     column_alias='average_booking_value',              -->
-                        <!--   )                                                    -->
-                        <!-- col92 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_535), -->
-                        <!--     column_alias='referred_bookings',                  -->
-                        <!--   )                                                    -->
-                        <!-- col93 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_536), -->
-                        <!--     column_alias='median_booking_value',               -->
-                        <!--   )                                                    -->
-                        <!-- col94 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_537), -->
-                        <!--     column_alias='booking_value_p99',                  -->
-                        <!--   )                                                    -->
-                        <!-- col95 =                                                -->
-                        <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_538), -->
-                        <!--     column_alias='discrete_booking_value_p99',         -->
-                        <!--   )                                                    -->
+                        <!-- col55 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+                        <!--     column_alias='booking__paid_at__day',             -->
+                        <!--   )                                                   -->
+                        <!-- col56 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
+                        <!--     column_alias='booking__paid_at__week',            -->
+                        <!--   )                                                   -->
+                        <!-- col57 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+                        <!--     column_alias='booking__paid_at__month',           -->
+                        <!--   )                                                   -->
+                        <!-- col58 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                        <!--     column_alias='booking__paid_at__quarter',         -->
+                        <!--   )                                                   -->
+                        <!-- col59 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
+                        <!--     column_alias='booking__paid_at__year',            -->
+                        <!--   )                                                   -->
+                        <!-- col60 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+                        <!--     column_alias='booking__paid_at__extract_year',    -->
+                        <!--   )                                                   -->
+                        <!-- col61 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                        <!--     column_alias='booking__paid_at__extract_quarter', -->
+                        <!--   )                                                   -->
+                        <!-- col62 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                        <!--     column_alias='booking__paid_at__extract_month',   -->
+                        <!--   )                                                   -->
+                        <!-- col63 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                        <!--     column_alias='booking__paid_at__extract_day',     -->
+                        <!--   )                                                   -->
+                        <!-- col64 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+                        <!--     column_alias='booking__paid_at__extract_dow',     -->
+                        <!--   )                                                   -->
+                        <!-- col65 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+                        <!--     column_alias='booking__paid_at__extract_doy',     -->
+                        <!--   )                                                   -->
+                        <!-- col66 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+                        <!--     column_alias='metric_time__day',                  -->
+                        <!--   )                                                   -->
+                        <!-- col67 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                        <!--     column_alias='metric_time__week',                 -->
+                        <!--   )                                                   -->
+                        <!-- col68 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_83), -->
+                        <!--     column_alias='metric_time__month',                -->
+                        <!--   )                                                   -->
+                        <!-- col69 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
+                        <!--     column_alias='metric_time__quarter',              -->
+                        <!--   )                                                   -->
+                        <!-- col70 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
+                        <!--     column_alias='metric_time__year',                 -->
+                        <!--   )                                                   -->
+                        <!-- col71 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+                        <!--     column_alias='metric_time__extract_year',         -->
+                        <!--   )                                                   -->
+                        <!-- col72 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+                        <!--     column_alias='metric_time__extract_quarter',      -->
+                        <!--   )                                                   -->
+                        <!-- col73 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+                        <!--     column_alias='metric_time__extract_month',        -->
+                        <!--   )                                                   -->
+                        <!-- col74 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+                        <!--     column_alias='metric_time__extract_day',          -->
+                        <!--   )                                                   -->
+                        <!-- col75 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+                        <!--     column_alias='metric_time__extract_dow',          -->
+                        <!--   )                                                   -->
+                        <!-- col76 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+                        <!--     column_alias='metric_time__extract_doy',          -->
+                        <!--   )                                                   -->
+                        <!-- col77 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_92), column_alias='listing') -->
+                        <!-- col78 =                                                                                   -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_93), column_alias='guest') -->
+                        <!-- col79 =                                                                                  -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='host') -->
+                        <!-- col80 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
+                        <!--     column_alias='booking__listing',                  -->
+                        <!--   )                                                   -->
+                        <!-- col81 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
+                        <!--     column_alias='booking__guest',                    -->
+                        <!--   )                                                   -->
+                        <!-- col82 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_97), -->
+                        <!--     column_alias='booking__host',                     -->
+                        <!--   )                                                   -->
+                        <!-- col83 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                        <!--     column_alias='is_instant',                        -->
+                        <!--   )                                                   -->
+                        <!-- col84 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_14), -->
+                        <!--     column_alias='booking__is_instant',               -->
+                        <!--   )                                                   -->
+                        <!-- col85 =                                                                                     -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
+                        <!-- col86 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
+                        <!--     column_alias='instant_bookings',                 -->
+                        <!--   )                                                  -->
+                        <!-- col87 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
+                        <!--     column_alias='booking_value',                    -->
+                        <!--   )                                                  -->
+                        <!-- col88 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_3), -->
+                        <!--     column_alias='max_booking_value',                -->
+                        <!--   )                                                  -->
+                        <!-- col89 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
+                        <!--     column_alias='min_booking_value',                -->
+                        <!--   )                                                  -->
+                        <!-- col90 =                                                                                    -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='bookers') -->
+                        <!-- col91 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_6), -->
+                        <!--     column_alias='average_booking_value',            -->
+                        <!--   )                                                  -->
+                        <!-- col92 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
+                        <!--     column_alias='referred_bookings',                -->
+                        <!--   )                                                  -->
+                        <!-- col93 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_8), -->
+                        <!--     column_alias='median_booking_value',             -->
+                        <!--   )                                                  -->
+                        <!-- col94 =                                              -->
+                        <!--   SqlSelectColumn(                                   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_9), -->
+                        <!--     column_alias='booking_value_p99',                -->
+                        <!--   )                                                  -->
+                        <!-- col95 =                                               -->
+                        <!--   SqlSelectColumn(                                    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
+                        <!--     column_alias='discrete_booking_value_p99',        -->
+                        <!--   )                                                   -->
                         <!-- col96 =                                                      -->
                         <!--   SqlSelectColumn(                                           -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_539),       -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_11),        -->
                         <!--     column_alias='approximate_continuous_booking_value_p99', -->
                         <!--   )                                                          -->
                         <!-- col97 =                                                    -->
                         <!--   SqlSelectColumn(                                         -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_540),     -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
                         <!--     column_alias='approximate_discrete_booking_value_p99', -->
                         <!--   )                                                        -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
@@ -990,458 +987,458 @@
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_16') -->
+            <!-- node_id = NodeId(id_str='ss_7') -->
             <!-- col0 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_722), column_alias='metric_time__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_194), column_alias='metric_time__day') -->
             <!-- col1 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_723), column_alias='booking_payments') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_195), column_alias='booking_payments') -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_15') -->
+                <!-- node_id = NodeId(id_str='ss_6') -->
                 <!-- col0 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_721), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_193), column_alias='metric_time__day') -->
                 <!-- col1 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='booking_payments',                                      -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                 <!-- group_by0 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_721), column_alias='metric_time__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_193), column_alias='metric_time__day') -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['booking_payments', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_14') -->
+                    <!-- node_id = NodeId(id_str='ss_5') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_719), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_191), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
                     <!-- col1 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_718), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_190), -->
                     <!--     column_alias='booking_payments',                   -->
                     <!--   )                                                    -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'paid_at'" -->
-                        <!-- node_id = NodeId(id_str='ss_13') -->
+                        <!-- node_id = NodeId(id_str='ss_4') -->
                         <!-- col0 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_635), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='ds__day') -->
                         <!-- col1 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_636), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='ds__week') -->
                         <!-- col2 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_637), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
                         <!--     column_alias='ds__month',                          -->
                         <!--   )                                                    -->
                         <!-- col3 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_638), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
                         <!--     column_alias='ds__quarter',                        -->
                         <!--   )                                                    -->
                         <!-- col4 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_639), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_111), column_alias='ds__year') -->
                         <!-- col5 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_640), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
                         <!--     column_alias='ds__extract_year',                   -->
                         <!--   )                                                    -->
                         <!-- col6 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_641), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
                         <!--     column_alias='ds__extract_quarter',                -->
                         <!--   )                                                    -->
                         <!-- col7 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_642), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
                         <!--     column_alias='ds__extract_month',                  -->
                         <!--   )                                                    -->
                         <!-- col8 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_643), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_115), -->
                         <!--     column_alias='ds__extract_day',                    -->
                         <!--   )                                                    -->
                         <!-- col9 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_644), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_116), -->
                         <!--     column_alias='ds__extract_dow',                    -->
                         <!--   )                                                    -->
                         <!-- col10 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_645), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
                         <!--     column_alias='ds__extract_doy',                    -->
                         <!--   )                                                    -->
                         <!-- col11 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_646), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_118), -->
                         <!--     column_alias='ds_partitioned__day',                -->
                         <!--   )                                                    -->
                         <!-- col12 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_647), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_119), -->
                         <!--     column_alias='ds_partitioned__week',               -->
                         <!--   )                                                    -->
                         <!-- col13 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_648), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
                         <!--     column_alias='ds_partitioned__month',              -->
                         <!--   )                                                    -->
                         <!-- col14 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_649), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
                         <!--     column_alias='ds_partitioned__quarter',            -->
                         <!--   )                                                    -->
                         <!-- col15 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_650), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
                         <!--     column_alias='ds_partitioned__year',               -->
                         <!--   )                                                    -->
                         <!-- col16 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_651), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
                         <!--     column_alias='ds_partitioned__extract_year',       -->
                         <!--   )                                                    -->
                         <!-- col17 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_652), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
                         <!--     column_alias='ds_partitioned__extract_quarter',    -->
                         <!--   )                                                    -->
                         <!-- col18 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_653), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_125), -->
                         <!--     column_alias='ds_partitioned__extract_month',      -->
                         <!--   )                                                    -->
                         <!-- col19 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_654), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
                         <!--     column_alias='ds_partitioned__extract_day',        -->
                         <!--   )                                                    -->
                         <!-- col20 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_655), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
                         <!--     column_alias='ds_partitioned__extract_dow',        -->
                         <!--   )                                                    -->
                         <!-- col21 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_656), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
                         <!--     column_alias='ds_partitioned__extract_doy',        -->
                         <!--   )                                                    -->
                         <!-- col22 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_657), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
                         <!--     column_alias='paid_at__day',                       -->
                         <!--   )                                                    -->
                         <!-- col23 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_658), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
                         <!--     column_alias='paid_at__week',                      -->
                         <!--   )                                                    -->
                         <!-- col24 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_659), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
                         <!--     column_alias='paid_at__month',                     -->
                         <!--   )                                                    -->
                         <!-- col25 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_660), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_132), -->
                         <!--     column_alias='paid_at__quarter',                   -->
                         <!--   )                                                    -->
                         <!-- col26 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_661), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
                         <!--     column_alias='paid_at__year',                      -->
                         <!--   )                                                    -->
                         <!-- col27 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_662), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
                         <!--     column_alias='paid_at__extract_year',              -->
                         <!--   )                                                    -->
                         <!-- col28 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_663), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
                         <!--     column_alias='paid_at__extract_quarter',           -->
                         <!--   )                                                    -->
                         <!-- col29 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_664), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
                         <!--     column_alias='paid_at__extract_month',             -->
                         <!--   )                                                    -->
                         <!-- col30 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_665), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
                         <!--     column_alias='paid_at__extract_day',               -->
                         <!--   )                                                    -->
                         <!-- col31 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_666), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
                         <!--     column_alias='paid_at__extract_dow',               -->
                         <!--   )                                                    -->
                         <!-- col32 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_667), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
                         <!--     column_alias='paid_at__extract_doy',               -->
                         <!--   )                                                    -->
                         <!-- col33 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_668), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
                         <!--     column_alias='booking__ds__day',                   -->
                         <!--   )                                                    -->
                         <!-- col34 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_669), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_141), -->
                         <!--     column_alias='booking__ds__week',                  -->
                         <!--   )                                                    -->
                         <!-- col35 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_670), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_142), -->
                         <!--     column_alias='booking__ds__month',                 -->
                         <!--   )                                                    -->
                         <!-- col36 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_671), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_143), -->
                         <!--     column_alias='booking__ds__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col37 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_672), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_144), -->
                         <!--     column_alias='booking__ds__year',                  -->
                         <!--   )                                                    -->
                         <!-- col38 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_673), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
                         <!--     column_alias='booking__ds__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col39 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_674), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
                         <!--     column_alias='booking__ds__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col40 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_675), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_147), -->
                         <!--     column_alias='booking__ds__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col41 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_676), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_148), -->
                         <!--     column_alias='booking__ds__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col42 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_677), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_149), -->
                         <!--     column_alias='booking__ds__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col43 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_678), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_150), -->
                         <!--     column_alias='booking__ds__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col44 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_679), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_151), -->
                         <!--     column_alias='booking__ds_partitioned__day',       -->
                         <!--   )                                                    -->
                         <!-- col45 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_680), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_152), -->
                         <!--     column_alias='booking__ds_partitioned__week',      -->
                         <!--   )                                                    -->
                         <!-- col46 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_681), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_153), -->
                         <!--     column_alias='booking__ds_partitioned__month',     -->
                         <!--   )                                                    -->
                         <!-- col47 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_682), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_154), -->
                         <!--     column_alias='booking__ds_partitioned__quarter',   -->
                         <!--   )                                                    -->
                         <!-- col48 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_683), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_155), -->
                         <!--     column_alias='booking__ds_partitioned__year',      -->
                         <!--   )                                                    -->
                         <!-- col49 =                                                   -->
                         <!--   SqlSelectColumn(                                        -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_684),    -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_156),    -->
                         <!--     column_alias='booking__ds_partitioned__extract_year', -->
                         <!--   )                                                       -->
                         <!-- col50 =                                                      -->
                         <!--   SqlSelectColumn(                                           -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_685),       -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_157),       -->
                         <!--     column_alias='booking__ds_partitioned__extract_quarter', -->
                         <!--   )                                                          -->
                         <!-- col51 =                                                    -->
                         <!--   SqlSelectColumn(                                         -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_686),     -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_158),     -->
                         <!--     column_alias='booking__ds_partitioned__extract_month', -->
                         <!--   )                                                        -->
                         <!-- col52 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_687),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_159),   -->
                         <!--     column_alias='booking__ds_partitioned__extract_day', -->
                         <!--   )                                                      -->
                         <!-- col53 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_688),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_160),   -->
                         <!--     column_alias='booking__ds_partitioned__extract_dow', -->
                         <!--   )                                                      -->
                         <!-- col54 =                                                  -->
                         <!--   SqlSelectColumn(                                       -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_689),   -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_161),   -->
                         <!--     column_alias='booking__ds_partitioned__extract_doy', -->
                         <!--   )                                                      -->
                         <!-- col55 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_690), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
                         <!--     column_alias='booking__paid_at__day',              -->
                         <!--   )                                                    -->
                         <!-- col56 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_691), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_163), -->
                         <!--     column_alias='booking__paid_at__week',             -->
                         <!--   )                                                    -->
                         <!-- col57 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_692), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_164), -->
                         <!--     column_alias='booking__paid_at__month',            -->
                         <!--   )                                                    -->
                         <!-- col58 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_693), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_165), -->
                         <!--     column_alias='booking__paid_at__quarter',          -->
                         <!--   )                                                    -->
                         <!-- col59 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_694), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_166), -->
                         <!--     column_alias='booking__paid_at__year',             -->
                         <!--   )                                                    -->
                         <!-- col60 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_695), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_167), -->
                         <!--     column_alias='booking__paid_at__extract_year',     -->
                         <!--   )                                                    -->
                         <!-- col61 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_696), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_168), -->
                         <!--     column_alias='booking__paid_at__extract_quarter',  -->
                         <!--   )                                                    -->
                         <!-- col62 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_697), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_169), -->
                         <!--     column_alias='booking__paid_at__extract_month',    -->
                         <!--   )                                                    -->
                         <!-- col63 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_698), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_170), -->
                         <!--     column_alias='booking__paid_at__extract_day',      -->
                         <!--   )                                                    -->
                         <!-- col64 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_699), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_171), -->
                         <!--     column_alias='booking__paid_at__extract_dow',      -->
                         <!--   )                                                    -->
                         <!-- col65 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_700), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_172), -->
                         <!--     column_alias='booking__paid_at__extract_doy',      -->
                         <!--   )                                                    -->
                         <!-- col66 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_701), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_173), -->
                         <!--     column_alias='metric_time__day',                   -->
                         <!--   )                                                    -->
                         <!-- col67 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_702), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_174), -->
                         <!--     column_alias='metric_time__week',                  -->
                         <!--   )                                                    -->
                         <!-- col68 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_703), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_175), -->
                         <!--     column_alias='metric_time__month',                 -->
                         <!--   )                                                    -->
                         <!-- col69 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_704), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_176), -->
                         <!--     column_alias='metric_time__quarter',               -->
                         <!--   )                                                    -->
                         <!-- col70 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_705), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_177), -->
                         <!--     column_alias='metric_time__year',                  -->
                         <!--   )                                                    -->
                         <!-- col71 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_706), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_178), -->
                         <!--     column_alias='metric_time__extract_year',          -->
                         <!--   )                                                    -->
                         <!-- col72 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_707), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_179), -->
                         <!--     column_alias='metric_time__extract_quarter',       -->
                         <!--   )                                                    -->
                         <!-- col73 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_708), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_180), -->
                         <!--     column_alias='metric_time__extract_month',         -->
                         <!--   )                                                    -->
                         <!-- col74 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_709), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_181), -->
                         <!--     column_alias='metric_time__extract_day',           -->
                         <!--   )                                                    -->
                         <!-- col75 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_710), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_182), -->
                         <!--     column_alias='metric_time__extract_dow',           -->
                         <!--   )                                                    -->
                         <!-- col76 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_711), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_183), -->
                         <!--     column_alias='metric_time__extract_doy',           -->
                         <!--   )                                                    -->
                         <!-- col77 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_712), column_alias='listing') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_184), column_alias='listing') -->
                         <!-- col78 =                                                                                    -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_713), column_alias='guest') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_185), column_alias='guest') -->
                         <!-- col79 =                                                                                   -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_714), column_alias='host') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_186), column_alias='host') -->
                         <!-- col80 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_715), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_187), -->
                         <!--     column_alias='booking__listing',                   -->
                         <!--   )                                                    -->
                         <!-- col81 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_716), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_188), -->
                         <!--     column_alias='booking__guest',                     -->
                         <!--   )                                                    -->
                         <!-- col82 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_717), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_189), -->
                         <!--     column_alias='booking__host',                      -->
                         <!--   )                                                    -->
                         <!-- col83 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_633), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
                         <!--     column_alias='is_instant',                         -->
                         <!--   )                                                    -->
                         <!-- col84 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_634), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
                         <!--     column_alias='booking__is_instant',                -->
                         <!--   )                                                    -->
                         <!-- col85 =                                                -->
                         <!--   SqlSelectColumn(                                     -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_632), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
                         <!--     column_alias='booking_payments',                   -->
                         <!--   )                                                    -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
@@ -2,443 +2,437 @@
     <SqlSelectStatementNode>
         <!-- description =                                                                                     -->
         <!--   "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']" -->
-        <!-- node_id = NodeId(id_str='ss_8') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_213), column_alias='metric_time__day') -->
+        <!-- node_id = NodeId(id_str='ss_7') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_191), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_211), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_189), column_alias='listing__is_lux_latest') -->
         <!-- col2 =                                                                                                       -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_212), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_190), column_alias='user__home_state_latest') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
         <!-- group_by0 =                                                                                           -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_213), column_alias='metric_time__day') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_191), column_alias='metric_time__day') -->
         <!-- group_by1 =                                                                                                 -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_211), column_alias='listing__is_lux_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_189), column_alias='listing__is_lux_latest') -->
         <!-- group_by2 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_212), column_alias='user__home_state_latest') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_190), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]' -->
-            <!-- node_id = NodeId(id_str='ss_7') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_163), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_164), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_165), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_166), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_167), column_alias='ds__year') -->
+            <!-- node_id = NodeId(id_str='ss_6') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_141), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_142), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_143), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_144), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_145), column_alias='ds__year') -->
             <!-- col5 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_168), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_146), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                   -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_169), column_alias='ds__extract_quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_147), column_alias='ds__extract_quarter') -->
             <!-- col7 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_170), column_alias='ds__extract_month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_148), column_alias='ds__extract_month') -->
             <!-- col8 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_171), column_alias='ds__extract_day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_149), column_alias='ds__extract_day') -->
             <!-- col9 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_172), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_150), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_173), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_151), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_174), column_alias='created_at__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_152), column_alias='created_at__day') -->
             <!-- col12 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_175), column_alias='created_at__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_153), column_alias='created_at__week') -->
             <!-- col13 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_176), column_alias='created_at__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_154), column_alias='created_at__month') -->
             <!-- col14 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_177), column_alias='created_at__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_155), column_alias='created_at__quarter') -->
             <!-- col15 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_178), column_alias='created_at__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_156), column_alias='created_at__year') -->
             <!-- col16 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_179), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_157), -->
             <!--     column_alias='created_at__extract_year',           -->
             <!--   )                                                    -->
             <!-- col17 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_180), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_158), -->
             <!--     column_alias='created_at__extract_quarter',        -->
             <!--   )                                                    -->
             <!-- col18 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_181), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_159), -->
             <!--     column_alias='created_at__extract_month',          -->
             <!--   )                                                    -->
             <!-- col19 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_182), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_160), -->
             <!--     column_alias='created_at__extract_day',            -->
             <!--   )                                                    -->
             <!-- col20 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_183), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_161), -->
             <!--     column_alias='created_at__extract_dow',            -->
             <!--   )                                                    -->
             <!-- col21 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_184), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
             <!--     column_alias='created_at__extract_doy',            -->
             <!--   )                                                    -->
             <!-- col22 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_185), column_alias='listing__ds__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_163), column_alias='listing__ds__day') -->
             <!-- col23 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_186), column_alias='listing__ds__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_164), column_alias='listing__ds__week') -->
             <!-- col24 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_187), column_alias='listing__ds__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_165), column_alias='listing__ds__month') -->
             <!-- col25 =                                                                                                   -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_188), column_alias='listing__ds__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_166), column_alias='listing__ds__quarter') -->
             <!-- col26 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_189), column_alias='listing__ds__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_167), column_alias='listing__ds__year') -->
             <!-- col27 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_190), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_168), -->
             <!--     column_alias='listing__ds__extract_year',          -->
             <!--   )                                                    -->
             <!-- col28 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_191), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_169), -->
             <!--     column_alias='listing__ds__extract_quarter',       -->
             <!--   )                                                    -->
             <!-- col29 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_192), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_170), -->
             <!--     column_alias='listing__ds__extract_month',         -->
             <!--   )                                                    -->
             <!-- col30 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_193), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_171), -->
             <!--     column_alias='listing__ds__extract_day',           -->
             <!--   )                                                    -->
             <!-- col31 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_194), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_172), -->
             <!--     column_alias='listing__ds__extract_dow',           -->
             <!--   )                                                    -->
             <!-- col32 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_195), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_173), -->
             <!--     column_alias='listing__ds__extract_doy',           -->
             <!--   )                                                    -->
             <!-- col33 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_196), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_174), -->
             <!--     column_alias='listing__created_at__day',           -->
             <!--   )                                                    -->
             <!-- col34 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_197), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_175), -->
             <!--     column_alias='listing__created_at__week',          -->
             <!--   )                                                    -->
             <!-- col35 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_198), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_176), -->
             <!--     column_alias='listing__created_at__month',         -->
             <!--   )                                                    -->
             <!-- col36 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_199), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_177), -->
             <!--     column_alias='listing__created_at__quarter',       -->
             <!--   )                                                    -->
             <!-- col37 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_200), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_178), -->
             <!--     column_alias='listing__created_at__year',          -->
             <!--   )                                                    -->
             <!-- col38 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_201), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_179), -->
             <!--     column_alias='listing__created_at__extract_year',  -->
             <!--   )                                                    -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_202),   -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_180),   -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_203), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_181), -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_204), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_182), -->
             <!--     column_alias='listing__created_at__extract_day',   -->
             <!--   )                                                    -->
             <!-- col42 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_205), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_183), -->
             <!--     column_alias='listing__created_at__extract_dow',   -->
             <!--   )                                                    -->
             <!-- col43 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_206), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_184), -->
             <!--     column_alias='listing__created_at__extract_doy',   -->
             <!--   )                                                    -->
             <!-- col44 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_207), column_alias='metric_time__day') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_208), column_alias='listing') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_209), column_alias='user') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_185), column_alias='metric_time__day') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_186), column_alias='listing') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_187), column_alias='user') -->
             <!-- col47 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_210), column_alias='listing__user') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_188), column_alias='listing__user') -->
             <!-- col48 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_156), column_alias='country_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_134), column_alias='country_latest') -->
             <!-- col49 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_157), column_alias='is_lux_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_135), column_alias='is_lux_latest') -->
             <!-- col50 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_158), column_alias='capacity_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_136), column_alias='capacity_latest') -->
             <!-- col51 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_159), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
             <!--     column_alias='listing__country_latest',            -->
             <!--   )                                                    -->
             <!-- col52 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_160), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
             <!--     column_alias='listing__is_lux_latest',             -->
             <!--   )                                                    -->
             <!-- col53 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_161), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
             <!--     column_alias='listing__capacity_latest',           -->
             <!--   )                                                    -->
             <!-- col54 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_162), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
             <!--     column_alias='user__home_state_latest',            -->
             <!--   )                                                    -->
-            <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_153), column_alias='listings') -->
+            <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_131), column_alias='listings') -->
             <!-- col56 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_154), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_132), column_alias='largest_listing') -->
             <!-- col57 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_155), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_133), column_alias='smallest_listing') -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
             <!-- where = SqlBetweenExpression(node_id=betw_1) -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_6') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='ds__month') -->
-                <!-- col3 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='ds__year') -->
-                <!-- col5 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='ds__extract_year') -->
-                <!-- col6 =                                                 -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
-                <!--     column_alias='ds__extract_quarter',                -->
-                <!--   )                                                    -->
-                <!-- col7 =                                                 -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
-                <!--     column_alias='ds__extract_month',                  -->
-                <!--   )                                                    -->
-                <!-- col8 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_111), column_alias='ds__extract_day') -->
-                <!-- col9 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_112), column_alias='ds__extract_dow') -->
-                <!-- col10 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_113), column_alias='ds__extract_doy') -->
-                <!-- col11 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_114), column_alias='created_at__day') -->
-                <!-- col12 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_115), column_alias='created_at__week') -->
-                <!-- col13 =                                                -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_116), -->
-                <!--     column_alias='created_at__month',                  -->
-                <!--   )                                                    -->
-                <!-- col14 =                                                -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
-                <!--     column_alias='created_at__quarter',                -->
-                <!--   )                                                    -->
-                <!-- col15 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='created_at__year') -->
-                <!-- col16 =                                                -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_119), -->
-                <!--     column_alias='created_at__extract_year',           -->
-                <!--   )                                                    -->
-                <!-- col17 =                                                -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_120), -->
-                <!--     column_alias='created_at__extract_quarter',        -->
-                <!--   )                                                    -->
-                <!-- col18 =                                                -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
-                <!--     column_alias='created_at__extract_month',          -->
-                <!--   )                                                    -->
+                <!-- node_id = NodeId(id_str='ss_5') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='ds__day') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='ds__week') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='ds__month') -->
+                <!-- col3 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='ds__quarter') -->
+                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='ds__year') -->
+                <!-- col5 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='ds__extract_year') -->
+                <!-- col6 =                                                -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+                <!--     column_alias='ds__extract_quarter',               -->
+                <!--   )                                                   -->
+                <!-- col7 =                                                                                                -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_88), column_alias='ds__extract_month') -->
+                <!-- col8 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_89), column_alias='ds__extract_day') -->
+                <!-- col9 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_90), column_alias='ds__extract_dow') -->
+                <!-- col10 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_91), column_alias='ds__extract_doy') -->
+                <!-- col11 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_92), column_alias='created_at__day') -->
+                <!-- col12 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_93), column_alias='created_at__week') -->
+                <!-- col13 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='created_at__month') -->
+                <!-- col14 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
+                <!--     column_alias='created_at__quarter',               -->
+                <!--   )                                                   -->
+                <!-- col15 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='created_at__year') -->
+                <!-- col16 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_97), -->
+                <!--     column_alias='created_at__extract_year',          -->
+                <!--   )                                                   -->
+                <!-- col17 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_98), -->
+                <!--     column_alias='created_at__extract_quarter',       -->
+                <!--   )                                                   -->
+                <!-- col18 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+                <!--     column_alias='created_at__extract_month',         -->
+                <!--   )                                                   -->
                 <!-- col19 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                 <!--     column_alias='created_at__extract_day',            -->
                 <!--   )                                                    -->
                 <!-- col20 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
                 <!--     column_alias='created_at__extract_dow',            -->
                 <!--   )                                                    -->
                 <!-- col21 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
                 <!--     column_alias='created_at__extract_doy',            -->
                 <!--   )                                                    -->
                 <!-- col22 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_125), column_alias='listing__ds__day') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='listing__ds__day') -->
                 <!-- col23 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_126), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
                 <!--     column_alias='listing__ds__week',                  -->
                 <!--   )                                                    -->
                 <!-- col24 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_127), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_105), -->
                 <!--     column_alias='listing__ds__month',                 -->
                 <!--   )                                                    -->
                 <!-- col25 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_128), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
                 <!--     column_alias='listing__ds__quarter',               -->
                 <!--   )                                                    -->
                 <!-- col26 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
                 <!--     column_alias='listing__ds__year',                  -->
                 <!--   )                                                    -->
                 <!-- col27 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_130), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_108), -->
                 <!--     column_alias='listing__ds__extract_year',          -->
                 <!--   )                                                    -->
                 <!-- col28 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_131), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_109), -->
                 <!--     column_alias='listing__ds__extract_quarter',       -->
                 <!--   )                                                    -->
                 <!-- col29 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_132), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_110), -->
                 <!--     column_alias='listing__ds__extract_month',         -->
                 <!--   )                                                    -->
                 <!-- col30 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_133), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_111), -->
                 <!--     column_alias='listing__ds__extract_day',           -->
                 <!--   )                                                    -->
                 <!-- col31 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_134), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_112), -->
                 <!--     column_alias='listing__ds__extract_dow',           -->
                 <!--   )                                                    -->
                 <!-- col32 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_135), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_113), -->
                 <!--     column_alias='listing__ds__extract_doy',           -->
                 <!--   )                                                    -->
                 <!-- col33 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_136), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_114), -->
                 <!--     column_alias='listing__created_at__day',           -->
                 <!--   )                                                    -->
                 <!-- col34 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_137), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_115), -->
                 <!--     column_alias='listing__created_at__week',          -->
                 <!--   )                                                    -->
                 <!-- col35 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_138), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_116), -->
                 <!--     column_alias='listing__created_at__month',         -->
                 <!--   )                                                    -->
                 <!-- col36 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_139), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_117), -->
                 <!--     column_alias='listing__created_at__quarter',       -->
                 <!--   )                                                    -->
                 <!-- col37 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_118), -->
                 <!--     column_alias='listing__created_at__year',          -->
                 <!--   )                                                    -->
                 <!-- col38 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_141), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_119), -->
                 <!--     column_alias='listing__created_at__extract_year',  -->
                 <!--   )                                                    -->
                 <!-- col39 =                                                  -->
                 <!--   SqlSelectColumn(                                       -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_142),   -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_120),   -->
                 <!--     column_alias='listing__created_at__extract_quarter', -->
                 <!--   )                                                      -->
                 <!-- col40 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_143), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_121), -->
                 <!--     column_alias='listing__created_at__extract_month', -->
                 <!--   )                                                    -->
                 <!-- col41 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_144), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_122), -->
                 <!--     column_alias='listing__created_at__extract_day',   -->
                 <!--   )                                                    -->
                 <!-- col42 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_123), -->
                 <!--     column_alias='listing__created_at__extract_dow',   -->
                 <!--   )                                                    -->
                 <!-- col43 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_124), -->
                 <!--     column_alias='listing__created_at__extract_doy',   -->
                 <!--   )                                                    -->
                 <!-- col44 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_150), column_alias='metric_time__day') -->
-                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_147), column_alias='listing') -->
-                <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_148), column_alias='user') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_128), column_alias='metric_time__day') -->
+                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_125), column_alias='listing') -->
+                <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_126), column_alias='user') -->
                 <!-- col47 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_149), column_alias='listing__user') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_127), column_alias='listing__user') -->
                 <!-- col48 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_97), column_alias='country_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_75), column_alias='country_latest') -->
                 <!-- col49 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='is_lux_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_76), column_alias='is_lux_latest') -->
                 <!-- col50 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_99), column_alias='capacity_latest') -->
-                <!-- col51 =                                                -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
-                <!--     column_alias='listing__country_latest',            -->
-                <!--   )                                                    -->
-                <!-- col52 =                                                -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
-                <!--     column_alias='listing__is_lux_latest',             -->
-                <!--   )                                                    -->
-                <!-- col53 =                                                -->
-                <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_102), -->
-                <!--     column_alias='listing__capacity_latest',           -->
-                <!--   )                                                    -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_77), column_alias='capacity_latest') -->
+                <!-- col51 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                <!--     column_alias='listing__country_latest',           -->
+                <!--   )                                                   -->
+                <!-- col52 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+                <!--     column_alias='listing__is_lux_latest',            -->
+                <!--   )                                                   -->
+                <!-- col53 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+                <!--     column_alias='listing__capacity_latest',          -->
+                <!--   )                                                   -->
                 <!-- col54 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_151), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_129), -->
                 <!--     column_alias='user__home_state_latest',            -->
                 <!--   )                                                    -->
-                <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_94), column_alias='listings') -->
+                <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='listings') -->
                 <!-- col56 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_95), column_alias='largest_listing') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='largest_listing') -->
                 <!-- col57 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_96), column_alias='smallest_listing') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_74), column_alias='smallest_listing') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
                 <!-- join_0 =                                               -->
                 <!--   SqlJoinDescription(                                  -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_4), -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_3), -->
                 <!--     right_source_alias='subq_3',                       -->
                 <!--     join_type=CROSS_JOIN,                              -->
                 <!--   )                                                    -->
                 <!-- join_1 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_5),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_4),   -->
                 <!--     right_source_alias='subq_5',                         -->
                 <!--     join_type=FULL_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -687,114 +681,114 @@
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-                    <!-- node_id = NodeId(id_str='ss_4') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
                     <!--     column_alias='metric_time__day',                  -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_3') -->
+                        <!-- node_id = NodeId(id_str='ss_2') -->
                         <!-- col0 =                                                                                      -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_67), column_alias='ds__day') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__day') -->
                         <!-- col1 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_68), column_alias='ds__week') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='ds__week') -->
                         <!-- col2 =                                                                                        -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_69), column_alias='ds__month') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='ds__month') -->
                         <!-- col3 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
                         <!--     column_alias='ds__quarter',                       -->
                         <!--   )                                                   -->
                         <!-- col4 =                                                                                       -->
-                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='ds__year') -->
+                        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='ds__year') -->
                         <!-- col5 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
                         <!--     column_alias='ds__extract_year',                  -->
                         <!--   )                                                   -->
                         <!-- col6 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
                         <!--     column_alias='ds__extract_quarter',               -->
                         <!--   )                                                   -->
                         <!-- col7 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
                         <!--     column_alias='ds__extract_month',                 -->
                         <!--   )                                                   -->
                         <!-- col8 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
                         <!--     column_alias='ds__extract_day',                   -->
                         <!--   )                                                   -->
                         <!-- col9 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
                         <!--     column_alias='ds__extract_dow',                   -->
                         <!--   )                                                   -->
                         <!-- col10 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
                         <!--     column_alias='ds__extract_doy',                   -->
                         <!--   )                                                   -->
                         <!-- col11 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
                         <!--     column_alias='metric_time__day',                  -->
                         <!--   )                                                   -->
                         <!-- col12 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
                         <!--     column_alias='metric_time__week',                 -->
                         <!--   )                                                   -->
                         <!-- col13 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
                         <!--     column_alias='metric_time__month',                -->
                         <!--   )                                                   -->
                         <!-- col14 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
                         <!--     column_alias='metric_time__quarter',              -->
                         <!--   )                                                   -->
                         <!-- col15 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
                         <!--     column_alias='metric_time__year',                 -->
                         <!--   )                                                   -->
                         <!-- col16 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_83), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_61), -->
                         <!--     column_alias='metric_time__extract_year',         -->
                         <!--   )                                                   -->
                         <!-- col17 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
                         <!--     column_alias='metric_time__extract_quarter',      -->
                         <!--   )                                                   -->
                         <!-- col18 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
                         <!--     column_alias='metric_time__extract_month',        -->
                         <!--   )                                                   -->
                         <!-- col19 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
                         <!--     column_alias='metric_time__extract_day',          -->
                         <!--   )                                                   -->
                         <!-- col20 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
                         <!--     column_alias='metric_time__extract_dow',          -->
                         <!--   )                                                   -->
                         <!-- col21 =                                               -->
                         <!--   SqlSelectColumn(                                    -->
-                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+                        <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
                         <!--     column_alias='metric_time__extract_doy',          -->
                         <!--   )                                                   -->
                         <!-- from_source = SqlSelectStatementNode(node_id=ss_28012) -->
@@ -862,11 +856,11 @@
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='ss_5') -->
-                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_91), column_alias='user') -->
+                    <!-- node_id = NodeId(id_str='ss_4') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_69), column_alias='user') -->
                     <!-- col1 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
                     <!--     column_alias='home_state_latest',                 -->
                     <!--   )                                                   -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
@@ -1,71 +1,69 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-        <!-- node_id = NodeId(id_str='ss_2') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='metric_time__day') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- node_id = NodeId(id_str='ss_1') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='metric_time__day') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- group_by0 =                                                                                          -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='metric_time__day') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='metric_time__day') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Metric Time Dimension 'ds'" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='ds__year') -->
-            <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='ds__extract_year') -->
-            <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='ds__extract_quarter') -->
-            <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='ds__extract_month') -->
-            <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='ds__extract_day') -->
-            <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='ds__extract_dow') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__year') -->
+            <!-- col5 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__extract_year') -->
+            <!-- col6 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='ds__extract_quarter') -->
+            <!-- col7 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='ds__extract_month') -->
+            <!-- col8 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='ds__extract_day') -->
+            <!-- col9 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_33), column_alias='metric_time__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='metric_time__day') -->
             <!-- col12 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_34), column_alias='metric_time__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='metric_time__week') -->
             <!-- col13 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='metric_time__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='metric_time__month') -->
             <!-- col14 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='metric_time__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='metric_time__quarter') -->
             <!-- col15 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='metric_time__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='metric_time__year') -->
             <!-- col16 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_16), -->
             <!--     column_alias='metric_time__extract_year',         -->
             <!--   )                                                   -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_17), -->
             <!--     column_alias='metric_time__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_18), -->
             <!--     column_alias='metric_time__extract_month',        -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
             <!--     column_alias='metric_time__extract_day',          -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
             <!--     column_alias='metric_time__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_21), -->
             <!--     column_alias='metric_time__extract_doy',          -->
             <!--   )                                                   -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28012) -->

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
@@ -1,72 +1,70 @@
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['metric_time__quarter',]" -->
-        <!-- node_id = NodeId(id_str='ss_2') -->
+        <!-- node_id = NodeId(id_str='ss_1') -->
         <!-- col0 =                                                                                                   -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='metric_time__quarter') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='metric_time__quarter') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- group_by0 =                                                                                              -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='metric_time__quarter') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='metric_time__quarter') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Metric Time Dimension 'ds'" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='ds__year') -->
-            <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='ds__extract_year') -->
-            <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='ds__extract_quarter') -->
-            <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='ds__extract_month') -->
-            <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='ds__extract_day') -->
-            <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='ds__extract_dow') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__year') -->
+            <!-- col5 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__extract_year') -->
+            <!-- col6 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='ds__extract_quarter') -->
+            <!-- col7 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='ds__extract_month') -->
+            <!-- col8 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='ds__extract_day') -->
+            <!-- col9 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_33), column_alias='metric_time__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='metric_time__day') -->
             <!-- col12 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_34), column_alias='metric_time__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='metric_time__week') -->
             <!-- col13 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='metric_time__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='metric_time__month') -->
             <!-- col14 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='metric_time__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='metric_time__quarter') -->
             <!-- col15 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='metric_time__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='metric_time__year') -->
             <!-- col16 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_16), -->
             <!--     column_alias='metric_time__extract_year',         -->
             <!--   )                                                   -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_17), -->
             <!--     column_alias='metric_time__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_18), -->
             <!--     column_alias='metric_time__extract_month',        -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
             <!--     column_alias='metric_time__extract_day',          -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
             <!--     column_alias='metric_time__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_21), -->
             <!--     column_alias='metric_time__extract_doy',          -->
             <!--   )                                                   -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28012) -->

--- a/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
+++ b/metricflow/test/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
@@ -2,222 +2,221 @@
     <SqlSelectStatementNode>
         <!-- description =                                                                                     -->
         <!--   "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']" -->
-        <!-- node_id = NodeId(id_str='ss_5') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_109), column_alias='metric_time__day') -->
-        <!-- col1 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='listing__is_lux_latest') -->
-        <!-- col2 =                                                                                                       -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
-        <!-- group_by0 =                                                                                           -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_109), column_alias='metric_time__day') -->
-        <!-- group_by1 =                                                                                                 -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='listing__is_lux_latest') -->
-        <!-- group_by2 =                                                                                                  -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_108), column_alias='user__home_state_latest') -->
+        <!-- node_id = NodeId(id_str='ss_4') -->
+        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_87), column_alias='metric_time__day') -->
+        <!-- col1 =                                                                                                     -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='listing__is_lux_latest') -->
+        <!-- col2 =                                                                                                      -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='user__home_state_latest') -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!-- group_by0 =                                                                                          -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_87), column_alias='metric_time__day') -->
+        <!-- group_by1 =                                                                                                -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='listing__is_lux_latest') -->
+        <!-- group_by2 =                                                                                                 -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_4') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='ds__year') -->
+            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='ds__day') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='ds__week') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__month') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__quarter') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__year') -->
             <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='ds__extract_year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='ds__extract_year') -->
             <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_64), column_alias='ds__extract_quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__extract_quarter') -->
             <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_65), column_alias='ds__extract_month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_month') -->
             <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_66), column_alias='ds__extract_day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_day') -->
             <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_67), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_dow') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_68), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='ds__extract_doy') -->
             <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_69), column_alias='created_at__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='created_at__day') -->
             <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_70), column_alias='created_at__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='created_at__week') -->
             <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='created_at__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='created_at__month') -->
             <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='created_at__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__quarter') -->
             <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='created_at__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_51), column_alias='created_at__year') -->
             <!-- col16 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
             <!--     column_alias='created_at__extract_year',          -->
             <!--   )                                                   -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
             <!--     column_alias='created_at__extract_quarter',       -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
             <!--     column_alias='created_at__extract_month',         -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
             <!--     column_alias='created_at__extract_day',           -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
             <!--     column_alias='created_at__extract_dow',           -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
             <!--     column_alias='created_at__extract_doy',           -->
             <!--   )                                                   -->
             <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='listing__ds__day') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing__ds__day') -->
             <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='listing__ds__week') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__ds__week') -->
             <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='listing__ds__month') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__ds__month') -->
             <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing__ds__quarter') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__quarter') -->
             <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='listing__ds__year') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='listing__ds__year') -->
             <!-- col27 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
             <!--     column_alias='listing__ds__extract_year',         -->
             <!--   )                                                   -->
             <!-- col28 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
             <!--     column_alias='listing__ds__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col29 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_87), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
             <!--     column_alias='listing__ds__extract_month',        -->
             <!--   )                                                   -->
             <!-- col30 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
             <!--     column_alias='listing__ds__extract_day',          -->
             <!--   )                                                   -->
             <!-- col31 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
             <!--     column_alias='listing__ds__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col32 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
             <!--     column_alias='listing__ds__extract_doy',          -->
             <!--   )                                                   -->
             <!-- col33 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
             <!--     column_alias='listing__created_at__day',          -->
             <!--   )                                                   -->
             <!-- col34 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
             <!--     column_alias='listing__created_at__week',         -->
             <!--   )                                                   -->
             <!-- col35 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
             <!--     column_alias='listing__created_at__month',        -->
             <!--   )                                                   -->
             <!-- col36 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
             <!--     column_alias='listing__created_at__quarter',      -->
             <!--   )                                                   -->
             <!-- col37 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
             <!--     column_alias='listing__created_at__year',         -->
             <!--   )                                                   -->
             <!-- col38 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
             <!--     column_alias='listing__created_at__extract_year', -->
             <!--   )                                                   -->
             <!-- col39 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_97),    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_75),    -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
             <!-- col40 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_98),  -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_76),  -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
             <!-- col41 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
             <!--     column_alias='listing__created_at__extract_day',  -->
             <!--   )                                                   -->
-            <!-- col42 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
-            <!--     column_alias='listing__created_at__extract_dow',   -->
-            <!--   )                                                    -->
-            <!-- col43 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_101), -->
-            <!--     column_alias='listing__created_at__extract_doy',   -->
-            <!--   )                                                    -->
-            <!-- col44 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='metric_time__day') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='listing') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='user') -->
-            <!-- col47 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='listing__user') -->
+            <!-- col42 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_78), -->
+            <!--     column_alias='listing__created_at__extract_dow',  -->
+            <!--   )                                                   -->
+            <!-- col43 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
+            <!--     column_alias='listing__created_at__extract_doy',  -->
+            <!--   )                                                   -->
+            <!-- col44 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='metric_time__day') -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_80), column_alias='listing') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_81), column_alias='user') -->
+            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='listing__user') -->
             <!-- col48 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_52), column_alias='country_latest') -->
-            <!-- col49 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_53), column_alias='is_lux_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='country_latest') -->
+            <!-- col49 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='is_lux_latest') -->
             <!-- col50 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_54), column_alias='capacity_latest') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='capacity_latest') -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
             <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
             <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
             <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
-            <!-- col54 =                                                -->
-            <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_106), -->
-            <!--     column_alias='user__home_state_latest',            -->
-            <!--   )                                                    -->
-            <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='listings') -->
+            <!-- col54 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
+            <!--     column_alias='user__home_state_latest',           -->
+            <!--   )                                                   -->
+            <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='listings') -->
             <!-- col56 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='largest_listing') -->
             <!-- col57 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_51), column_alias='smallest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
             <!-- join_0 =                                               -->
             <!--   SqlJoinDescription(                                  -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_2), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_1), -->
             <!--     right_source_alias='subq_3',                       -->
             <!--     join_type=CROSS_JOIN,                              -->
             <!--   )                                                    -->
             <!-- join_1 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
             <!--     right_source_alias='subq_5',                         -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -431,108 +430,107 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='metric_time__day') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='metric_time__day') -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Metric Time Dimension 'ds'" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
-                    <!-- col0 =                                                                                      -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__day') -->
-                    <!-- col1 =                                                                                       -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__week') -->
-                    <!-- col2 =                                                                                        -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__month') -->
-                    <!-- col3 =                                                                                          -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='ds__quarter') -->
-                    <!-- col4 =                                                                                       -->
-                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='ds__year') -->
-                    <!-- col5 =                                                -->
-                    <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
-                    <!--     column_alias='ds__extract_year',                  -->
-                    <!--   )                                                   -->
-                    <!-- col6 =                                                -->
-                    <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
-                    <!--     column_alias='ds__extract_quarter',               -->
-                    <!--   )                                                   -->
-                    <!-- col7 =                                                -->
-                    <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
-                    <!--     column_alias='ds__extract_month',                 -->
-                    <!--   )                                                   -->
-                    <!-- col8 =                                                -->
-                    <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
-                    <!--     column_alias='ds__extract_day',                   -->
-                    <!--   )                                                   -->
-                    <!-- col9 =                                                -->
-                    <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
-                    <!--     column_alias='ds__extract_dow',                   -->
-                    <!--   )                                                   -->
+                    <!-- node_id = NodeId(id_str='ss_0') -->
+                    <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
+                    <!-- col1 =                                                                                      -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
+                    <!-- col2 =                                                                                       -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__month') -->
+                    <!-- col3 =                                                                                         -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='ds__quarter') -->
+                    <!-- col4 =                                                                                      -->
+                    <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__year') -->
+                    <!-- col5 =                                               -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_5), -->
+                    <!--     column_alias='ds__extract_year',                 -->
+                    <!--   )                                                  -->
+                    <!-- col6 =                                               -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_6), -->
+                    <!--     column_alias='ds__extract_quarter',              -->
+                    <!--   )                                                  -->
+                    <!-- col7 =                                               -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
+                    <!--     column_alias='ds__extract_month',                -->
+                    <!--   )                                                  -->
+                    <!-- col8 =                                               -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_8), -->
+                    <!--     column_alias='ds__extract_day',                  -->
+                    <!--   )                                                  -->
+                    <!-- col9 =                                               -->
+                    <!--   SqlSelectColumn(                                   -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_9), -->
+                    <!--     column_alias='ds__extract_dow',                  -->
+                    <!--   )                                                  -->
                     <!-- col10 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
                     <!--     column_alias='ds__extract_doy',                   -->
                     <!--   )                                                   -->
                     <!-- col11 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
                     <!--     column_alias='metric_time__day',                  -->
                     <!--   )                                                   -->
                     <!-- col12 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
                     <!--     column_alias='metric_time__week',                 -->
                     <!--   )                                                   -->
                     <!-- col13 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
                     <!--     column_alias='metric_time__month',                -->
                     <!--   )                                                   -->
                     <!-- col14 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_14), -->
                     <!--     column_alias='metric_time__quarter',              -->
                     <!--   )                                                   -->
                     <!-- col15 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_15), -->
                     <!--     column_alias='metric_time__year',                 -->
                     <!--   )                                                   -->
                     <!-- col16 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_16), -->
                     <!--     column_alias='metric_time__extract_year',         -->
                     <!--   )                                                   -->
                     <!-- col17 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_17), -->
                     <!--     column_alias='metric_time__extract_quarter',      -->
                     <!--   )                                                   -->
                     <!-- col18 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_18), -->
                     <!--     column_alias='metric_time__extract_month',        -->
                     <!--   )                                                   -->
                     <!-- col19 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
                     <!--     column_alias='metric_time__extract_day',          -->
                     <!--   )                                                   -->
                     <!-- col20 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
                     <!--     column_alias='metric_time__extract_dow',          -->
                     <!--   )                                                   -->
                     <!-- col21 =                                               -->
                     <!--   SqlSelectColumn(                                    -->
-                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
+                    <!--     expr=SqlColumnReferenceExpression(node_id=cr_21), -->
                     <!--     column_alias='metric_time__extract_doy',          -->
                     <!--   )                                                   -->
                     <!-- from_source = SqlSelectStatementNode(node_id=ss_28012) -->
@@ -594,10 +592,10 @@
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                <!-- node_id = NodeId(id_str='ss_3') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='user') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='user') -->
                 <!-- col1 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='home_state_latest') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='home_state_latest') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
                 <!-- where = None -->
                 <!-- distinct = False -->


### PR DESCRIPTION
### Description

When building a `DataflowPlan`, nodes from `SourceNodeSet` are used as common building blocks for different queries using the same semantic manifest. When the output for a `DataflowPlanNode` is computed, the output is lazily computed and then cached since the output will be required many times for the same nodes (e.g. between queries, and between common join candidates). The output contains generated IDs, and so precomputing the output nodes for nodes from `SourceNodeSet` will have the following effects:

* The runtime of building the `DataflowPlan` should be a little more consistent between queries at the expense of initialization time.
* The IDs in the generated output will be consistent regardless of the order queries seen by the `DataflowPlanBuilder`.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
