### PR TITLE
Streamline Changelog generation to remove invalid issue links

### DIFF
--- a/.changes/unreleased/Dependencies-20240119-174213.yaml
+++ b/.changes/unreleased/Dependencies-20240119-174213.yaml
@@ -3,4 +3,4 @@ body: Remove unused numpy dependency
 time: 2024-01-19T17:42:13.46617-08:00
 custom:
   Author: tlento
-  PR: "984"
+  Issue: "984"

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -21,14 +21,6 @@ kinds:
   - label: Features
   - label: Fixes
   - label: Docs
-    changeFormat: |-
-      {{- $IssueList := list }}
-      {{- $changes := splitList " " $.Custom.Issue }}
-      {{- range $issueNbr := $changes }}
-        {{- $changeLink := "[dbt-docs/#nbr](https://github.com/dbt-labs/dbt-docs/issues/nbr)" | replace "nbr" $issueNbr }}
-        {{- $IssueList = append $IssueList $changeLink }}
-      {{- end -}}
-      - {{.Body}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}})
   - label: Under the Hood
   - label: Dependencies
     changeFormat: |-

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -53,24 +53,23 @@ footerFormat: |
       {{- $authorLower := lower $author }}
       {{- /* we only want to include non-core team contributors */}}
       {{- if not (has $authorLower $maintainers)}}
-        {{- $changeList := splitList " " $change.Custom.Author }}
-          {{- $IssueList := list }}
-          {{- $changeLink := $change.Kind }}
-          {{- $changes := splitList " " $change.Custom.Issue }}
-          {{- range $issueNbr := $changes }}
-            {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/issues/nbr)" | replace "nbr" $issueNbr }}
-            {{- $IssueList = append $IssueList $changeLink  }}
-          {{- end -}}
-          {{- /* check if this contributor has other changes associated with them already */}}
-          {{- if hasKey $contributorDict $author }}
-            {{- $contributionList := get $contributorDict $author }}
-            {{- $contributionList = concat $contributionList $IssueList  }}
-            {{- $contributorDict := set $contributorDict $author $contributionList }}
-          {{- else }}
-            {{- $contributionList := $IssueList }}
-            {{- $contributorDict := set $contributorDict $author $contributionList }}
-          {{- end }}
-        {{- end}}
+        {{- $IssueList := list }}
+        {{- $changeLink := $change.Kind }}
+        {{- $changes := splitList " " $change.Custom.Issue }}
+        {{- range $issueNbr := $changes }}
+          {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/issues/nbr)" | replace "nbr" $issueNbr }}
+          {{- $IssueList = append $IssueList $changeLink  }}
+        {{- end -}}
+        {{- /* check if this contributor has other changes associated with them already */}}
+        {{- if hasKey $contributorDict $author }}
+          {{- $contributionList := get $contributorDict $author }}
+          {{- $contributionList = concat $contributionList $IssueList  }}
+          {{- $contributorDict := set $contributorDict $author $contributionList }}
+        {{- else }}
+          {{- $contributionList := $IssueList }}
+          {{- $contributorDict := set $contributorDict $author $contributionList }}
+        {{- end }}
+      {{- end}}
     {{- end}}
   {{- end }}
   {{- /* no indentation here for formatting so the final markdown doesn't have unneeded indentations */}}

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -11,10 +11,12 @@ changeFormat: |-
   {{- $IssueList := list }}
   {{- $changes := splitList " " $.Custom.Issue }}
   {{- range $issueNbr := $changes }}
-    {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/issues/nbr)" | replace "nbr" $issueNbr }}
-    {{- $IssueList = append $IssueList $changeLink  }}
+    {{- if atoi $issueNbr }}
+      {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/issues/nbr)" | replace "nbr" $issueNbr }}
+      {{- $IssueList = append $IssueList $changeLink  }}
+    {{- end -}}
   {{- end -}}
-  - {{.Body}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}})
+  - {{.Body}}{{if $IssueList}} ({{ join ", " $IssueList }}){{end}}
 
 kinds:
   - label: Breaking Changes
@@ -57,8 +59,10 @@ footerFormat: |
         {{- $changeLink := $change.Kind }}
         {{- $changes := splitList " " $change.Custom.Issue }}
         {{- range $issueNbr := $changes }}
-          {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/issues/nbr)" | replace "nbr" $issueNbr }}
-          {{- $IssueList = append $IssueList $changeLink  }}
+          {{- if atoi $issueNbr }}
+            {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/issues/nbr)" | replace "nbr" $issueNbr }}
+            {{- $IssueList = append $IssueList $changeLink  }}
+          {{- end -}}
         {{- end -}}
         {{- /* check if this contributor has other changes associated with them already */}}
         {{- if hasKey $contributorDict $author }}
@@ -76,6 +80,6 @@ footerFormat: |
   {{- if $contributorDict}}
   ### Contributors
   {{- range $k,$v := $contributorDict }}
-  - [@{{$k}}](https://github.com/{{$k}}) ({{ range $index, $element := $v }}{{if $index}}, {{end}}{{$element}}{{end}})
+  - [@{{$k}}](https://github.com/{{$k}}){{if $v}} ({{ join ", " $v }}){{end}}
   {{- end }}
   {{- end }}

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -23,43 +23,7 @@ kinds:
   - label: Docs
   - label: Under the Hood
   - label: Dependencies
-    changeFormat: |-
-      {{- $PRList := list }}
-      {{- $changes := splitList " " $.Custom.PR }}
-      {{- range $pullrequest := $changes }}
-        {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/pull/nbr)" | replace "nbr" $pullrequest }}
-        {{- $PRList = append $PRList $changeLink  }}
-      {{- end -}}
-      - {{.Body}} ({{ range $index, $element := $PRList }}{{if $index}}, {{end}}{{$element}}{{end}})
-    skipGlobalChoices: true
-    additionalChoices:
-      - key: Author
-        label: GitHub Username(s) (separated by a single space if multiple)
-        type: string
-        minLength: 3
-      - key: PR
-        label: GitHub Pull Request Number (separated by a single space if multiple)
-        type: string
-        minLength: 1
   - label: Security
-    changeFormat: |-
-      {{- $PRList := list }}
-      {{- $changes := splitList " " $.Custom.PR }}
-      {{- range $pullrequest := $changes }}
-        {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/pull/nbr)" | replace "nbr" $pullrequest }}
-        {{- $PRList = append $PRList $changeLink  }}
-      {{- end -}}
-      - {{.Body}} ({{ range $index, $element := $PRList }}{{if $index}}, {{end}}{{$element}}{{end}})
-    skipGlobalChoices: true
-    additionalChoices:
-      - key: Author
-        label: GitHub Username(s) (separated by a single space if multiple)
-        type: string
-        minLength: 3
-      - key: PR
-        label: GitHub Pull Request Number (separated by a single space if multiple)
-        type: string
-        minLength: 1
 
 newlines:
   afterChangelogHeader: 1
@@ -74,7 +38,7 @@ custom:
   type: string
   minLength: 3
 - key: Issue
-  label: GitHub Issue Number (separated by a single space if multiple)
+  label: "GitHub Issue (or PR) Number(s) (separated by a single space if multiple)"
   type: string
   minLength: 1
 
@@ -92,19 +56,11 @@ footerFormat: |
         {{- $changeList := splitList " " $change.Custom.Author }}
           {{- $IssueList := list }}
           {{- $changeLink := $change.Kind }}
-          {{- if or (eq $change.Kind "Dependencies") (eq $change.Kind "Security") }}
-            {{- $changes := splitList " " $change.Custom.PR }}
-            {{- range $issueNbr := $changes }}
-              {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/pull/nbr)" | replace "nbr" $issueNbr }}
-              {{- $IssueList = append $IssueList $changeLink  }}
-            {{- end -}}
-          {{- else }}
-            {{- $changes := splitList " " $change.Custom.Issue }}
-            {{- range $issueNbr := $changes }}
-              {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/issues/nbr)" | replace "nbr" $issueNbr }}
-              {{- $IssueList = append $IssueList $changeLink  }}
-            {{- end -}}
-          {{- end }}
+          {{- $changes := splitList " " $change.Custom.Issue }}
+          {{- range $issueNbr := $changes }}
+            {{- $changeLink := "[#nbr](https://github.com/dbt-labs/metricflow/issues/nbr)" | replace "nbr" $issueNbr }}
+            {{- $IssueList = append $IssueList $changeLink  }}
+          {{- end -}}
           {{- /* check if this contributor has other changes associated with them already */}}
           {{- if hasKey $contributorDict $author }}
             {{- $contributionList := get $contributorDict $author }}

--- a/.github/workflows/bot-changelog.yml
+++ b/.github/workflows/bot-changelog.yml
@@ -58,4 +58,4 @@ jobs:
         commit_message: "Add automated changelog yaml from template for bot PR"
         changie_kind: ${{ matrix.changie_kind }}
         label: ${{ matrix.label }}
-        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  PR: ${{ github.event.pull_request.number }}"
+        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  Issue: ${{ github.event.pull_request.number }}"


### PR DESCRIPTION
The `Issue` entry in our changelogs is required to be non-empty,
and if it is we format the value into a GitHub link in the final
changelog. This leads to broken links pointing at things like
issue `None` or `0`.

This change updates the changelog formatting to skip over those
entries when forming issue links, and skip formatting in issue
lists if no issues are included. We still include the contributor
and change body, so all due credit remains, just minus the need
for validating common circumventions to our request for issue
numbers.

Running `changie batch 0.205.0  -d` on the underlying trunk commit
and comparing it here illustrates the new behavior with the
docs entry - and the associated author change list - no longer
including bad links.

Since the logic involved was fairly complicated, the initial commits
in this PR cut down on certain sources of complexity in the
changelog formatting. Specifically:

- Remove custom changeFormat from Docs changelog entries
- Consolidate PR/Issue division into Issue requests
- Remove unused duplicate splitList on changelog authors
- Suppress changelog links for missing Issues
