### PR TITLE
Change use of ~= to >=, < in dependency version specifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,21 +26,21 @@ classifiers = [
 ]
 dependencies = [
   "Jinja2>=3.1.3",
-  "PyYAML~=6.0",
+  "PyYAML>=6.0, <7.0.0",
   "click>=7.1.2",
-  "dbt-core~=1.7.0",
-  "dbt-semantic-interfaces~=0.4.2",
+  "dbt-core>=1.7.0, <1.8.0",
+  "dbt-semantic-interfaces>=0.4.2, <0.5.0",
   "graphviz>=0.18.2, <0.21",
-  "halo~=0.0.31",
+  "halo>=0.0.31, <0.1.0",
   "more-itertools>=8.10.0, <10.2.0",
-  "pandas~=1.5.0",
-  "pydantic~=1.10.0",
-  "python-dateutil~=2.8.2",
-  "rapidfuzz~=3.0",
-  "ruamel.yaml~=0.17.21",
+  "pandas>=1.5.0, <1.6.0",
+  "pydantic>=1.10.0, <1.11.0",
+  "python-dateutil>=2.8.2, <2.9.0",
+  "rapidfuzz>=3.0, <4.0",
+  "ruamel.yaml>=0.17.21, <0.18.0",
   "tabulate>=0.8.9",
-  "typing_extensions~=4.4",
-  "update-checker~=0.18.0",
+  "typing_extensions>=4.4, <5.0",
+  "update-checker>=0.18.0, <0.19.0",
 ]
 
 [project.urls]
@@ -52,13 +52,13 @@ mf = 'metricflow.cli.main:cli'
 
 [project.optional-dependencies]
 dev-packages = [
-  "mypy~=1.7.0",
-  "pre-commit~=3.2.2",
+  "mypy>=1.7.0, <1.8.0",
+  "pre-commit>=3.2.2, <3.3.0",
   # Bug with mypy: https://github.com/pallets/click/issues/2558#issuecomment-1656546003
   "click>=8.1.6",
-  "pytest-mock~=3.7.0",
-  "pytest-xdist~=3.2.1",
-  "pytest~=7.1.1",
+  "pytest-mock>=3.7.0, <3.8.0",
+  "pytest-xdist>=3.2.1, <3.3.0",
+  "pytest>=7.1.1, < 7.2.0",
   "types-PyYAML",
   "types-python-dateutil",
   "types-tabulate",
@@ -67,39 +67,39 @@ dev-packages = [
 # These are currently separate for ease of removal, but due to the way Python
 # handles import statements they are required in all test environments
 sql-client-packages = [
-  "SQLAlchemy~=1.4.42",
-  "sqlalchemy2-stubs~=0.0.2a21",
+  "SQLAlchemy>=1.4.42, <1.5.0",
+  "sqlalchemy2-stubs>=0.0.2a21, <0.0.3",
 ]
 trino-sql-client-packages = [
-  "trino~=0.327.0",
+  "trino>=0.327.0, <0.328.0",
 ]
 
 dbt-postgres = [
-  "dbt-postgres~=1.7.0",
+  "dbt-postgres>=1.7.0, <1.8.0",
 ]
 
 dbt-bigquery = [
-  "dbt-bigquery~=1.7.0",
+  "dbt-bigquery>=1.7.0, <1.8.0",
 ]
 
 dbt-databricks = [
-  "dbt-databricks~=1.7.0",
+  "dbt-databricks>=1.7.0, <1.8.0",
 ]
 
 dbt-redshift = [
-  "dbt-redshift~=1.7.0",
+  "dbt-redshift>=1.7.0, <1.8.0",
 ]
 
 dbt-snowflake = [
-  "dbt-snowflake~=1.7.0",
+  "dbt-snowflake>=1.7.0, <1.8.0",
 ]
 
 dbt-duckdb = [
-  "dbt-duckdb~=1.7.0",
+  "dbt-duckdb>=1.7.0, <1.8.0",
 ]
 
 dbt-trino = [
-  "dbt-trino~=1.7.0",
+  "dbt-trino>=1.7.0, <1.8.0",
 ]
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
Due to some inconsistencies in dependency resolution for Python
package versions listed using the ~= syntax, we are switching
everything to explicit ranges using >=, < for all dependency
version range specifications in our package configuration.