### PR TITLE
Bug fix: For measures using `join_to_timespine`, apply filters after time spine join

### DIFF
--- a/.changes/unreleased/Fixes-20240228-084335.yaml
+++ b/.changes/unreleased/Fixes-20240228-084335.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: 'Bug fix: if measure joins to time spine, apply filters again after that join.'
+time: 2024-02-28T08:43:35.044076-08:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1039"

--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -5,6 +5,7 @@ import logging
 
 import pytest
 from _pytest.fixtures import FixtureRequest
+from dbt_semantic_interfaces.implementations.filters.where_filter import PydanticWhereFilter
 from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
@@ -1117,4 +1118,35 @@ def test_min_max_only_time_year(
     )
 
 
-# TODO: add test for min max metric_time (various granularities) when supported
+@pytest.mark.sql_engine_snapshot
+def test_join_to_time_spine_with_filters(
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    query_parser: MetricFlowQueryParser,
+    create_source_tables: bool,
+) -> None:
+    """Test that filter is not applied until after time spine join."""
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("bookings_fill_nulls_with_0",),
+        group_by_names=("metric_time__day",),
+        where_constraint=PydanticWhereFilter(
+            where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
+        ),
+        time_constraint_start=datetime.datetime(2020, 1, 3),
+        time_constraint_end=datetime.datetime(2020, 1, 5),
+    )
+    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
+
+    assert_plan_snapshot_text_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        plan=dataflow_plan,
+        plan_snapshot_text=dataflow_plan.text_structure(),
+    )
+
+    display_graph_if_requested(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dag_graph=dataflow_plan,
+    )

--- a/metricflow/test/query_rendering/test_fill_nulls_with_rendering.py
+++ b/metricflow/test/query_rendering/test_fill_nulls_with_rendering.py
@@ -1,8 +1,14 @@
 """Tests query rendering for coalescing null measures by comparing rendered output against snapshot files."""
+
 from __future__ import annotations
+
+import datetime
 
 import pytest
 from _pytest.fixtures import FixtureRequest
+from dbt_semantic_interfaces.implementations.filters.where_filter import (
+    PydanticWhereFilter,
+)
 from dbt_semantic_interfaces.references import EntityReference
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
@@ -10,6 +16,7 @@ from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilde
 from metricflow.dataset.dataset import DataSet
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
+from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.specs.specs import (
     DimensionSpec,
     MetricFlowQuerySpec,
@@ -180,6 +187,35 @@ def test_derived_fill_nulls_for_one_input_metric(  # noqa: D
             time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
         )
     )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_join_to_time_spine_with_filters(  # noqa: D
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    query_parser: MetricFlowQueryParser,
+) -> None:
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("bookings_fill_nulls_with_0",),
+        group_by_names=("metric_time__day",),
+        where_constraint=PydanticWhereFilter(
+            where_sql_template="{{ TimeDimension('metric_time') }} > '2020-01-01'",
+        ),
+        time_constraint_start=datetime.datetime(2020, 1, 3),
+        time_constraint_end=datetime.datetime(2020, 1, 5),
+    )
+    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
         request=request,

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -1,0 +1,112 @@
+<DataflowPlan>
+    <WriteToResultDataframeNode>
+        <!-- description = 'Write to Dataframe' -->
+        <!-- node_id = NodeId(id_str='wrd_0') -->
+        <ComputeMetricsNode>
+            <!-- description = 'Compute Metrics via Expressions' -->
+            <!-- node_id = NodeId(id_str='cm_0') -->
+            <!-- metric_spec =                                        -->
+            <!--   MetricSpec(                                        -->
+            <!--     element_name='bookings_fill_nulls_with_0',       -->
+            <!--     filter_specs=(                                   -->
+            <!--       WhereFilterSpec(                               -->
+            <!--         where_sql="metric_time__day = '2020-01-01'", -->
+            <!--         bind_parameters=SqlBindParameters(),         -->
+            <!--         linkable_spec_set=LinkableSpecSet(           -->
+            <!--           time_dimension_specs=(                     -->
+            <!--             TimeDimensionSpec(                       -->
+            <!--               element_name='metric_time',            -->
+            <!--               time_granularity=DAY,                  -->
+            <!--             ),                                       -->
+            <!--           ),                                         -->
+            <!--         ),                                           -->
+            <!--       ),                                             -->
+            <!--     ),                                               -->
+            <!--   )                                                  -->
+            <ConstrainTimeRangeNode>
+                <!-- description = 'Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]' -->
+                <!-- node_id = NodeId(id_str='ctr_1') -->
+                <!-- time_range_start = '2020-01-03T00:00:00' -->
+                <!-- time_range_end = '2020-01-05T00:00:00' -->
+                <WhereConstraintNode>
+                    <!-- description = 'Constrain Output with WHERE' -->
+                    <!-- node_id = NodeId(id_str='wcc_1') -->
+                    <!-- where_condition =                                -->
+                    <!--   WhereFilterSpec(                               -->
+                    <!--     where_sql="metric_time__day = '2020-01-01'", -->
+                    <!--     bind_parameters=SqlBindParameters(),         -->
+                    <!--     linkable_spec_set=LinkableSpecSet(           -->
+                    <!--       time_dimension_specs=(                     -->
+                    <!--         TimeDimensionSpec(                       -->
+                    <!--           element_name='metric_time',            -->
+                    <!--           time_granularity=DAY,                  -->
+                    <!--         ),                                       -->
+                    <!--       ),                                         -->
+                    <!--     ),                                           -->
+                    <!--   )                                              -->
+                    <JoinToTimeSpineNode>
+                        <!-- description = 'Join to Time Spine Dataset' -->
+                        <!-- node_id = NodeId(id_str='jts_0') -->
+                        <!-- requested_agg_time_dimension_specs =                                     -->
+                        <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                        <!-- use_custom_agg_time_dimension = False -->
+                        <!-- time_range_constraint =                             -->
+                        <!--   TimeRangeConstraint(                              -->
+                        <!--     start_time=datetime.datetime(2020, 1, 3, 0, 0), -->
+                        <!--     end_time=datetime.datetime(2020, 1, 5, 0, 0),   -->
+                        <!--   )                                                 -->
+                        <!-- offset_window = None -->
+                        <!-- offset_to_grain = None -->
+                        <!-- join_type = LEFT_OUTER -->
+                        <AggregateMeasuresNode>
+                            <!-- description = 'Aggregate Measures' -->
+                            <!-- node_id = NodeId(id_str='am_0') -->
+                            <WhereConstraintNode>
+                                <!-- description = 'Constrain Output with WHERE' -->
+                                <!-- node_id = NodeId(id_str='wcc_0') -->
+                                <!-- where_condition =                                -->
+                                <!--   WhereFilterSpec(                               -->
+                                <!--     where_sql="metric_time__day = '2020-01-01'", -->
+                                <!--     bind_parameters=SqlBindParameters(),         -->
+                                <!--     linkable_spec_set=LinkableSpecSet(           -->
+                                <!--       time_dimension_specs=(                     -->
+                                <!--         TimeDimensionSpec(                       -->
+                                <!--           element_name='metric_time',            -->
+                                <!--           time_granularity=DAY,                  -->
+                                <!--         ),                                       -->
+                                <!--       ),                                         -->
+                                <!--     ),                                           -->
+                                <!--   )                                              -->
+                                <FilterElementsNode>
+                                    <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
+                                    <!-- node_id = NodeId(id_str='pfe_0') -->
+                                    <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                                    <!-- include_spec =                                                        -->
+                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- distinct = False -->
+                                    <ConstrainTimeRangeNode>
+                                        <!-- description =                                                          -->
+                                        <!--   'Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]' -->
+                                        <!-- node_id = NodeId(id_str='ctr_0') -->
+                                        <!-- time_range_start = '2020-01-03T00:00:00' -->
+                                        <!-- time_range_end = '2020-01-05T00:00:00' -->
+                                        <MetricTimeDimensionTransformNode>
+                                            <!-- description = "Metric Time Dimension 'ds'" -->
+                                            <!-- node_id = NodeId(id_str='sma_28002') -->
+                                            <!-- aggregation_time_dimension = 'ds' -->
+                                            <ReadSqlSourceNode>
+                                                <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                                <!-- node_id = NodeId(id_str='rss_28014') -->
+                                                <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                                            </ReadSqlSourceNode>
+                                        </MetricTimeDimensionTransformNode>
+                                    </ConstrainTimeRangeNode>
+                                </FilterElementsNode>
+                            </WhereConstraintNode>
+                        </AggregateMeasuresNode>
+                    </JoinToTimeSpineNode>
+                </WhereConstraintNode>
+            </ConstrainTimeRangeNode>
+        </ComputeMetricsNode>
+    </WriteToResultDataframeNode>
+</DataflowPlan>

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,0 +1,352 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.bookings
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_8.metric_time__day AS metric_time__day
+        , subq_7.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_9.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_9
+        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_8
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_6.metric_time__day
+          , SUM(subq_6.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.ds_partitioned__day
+                , subq_3.ds_partitioned__week
+                , subq_3.ds_partitioned__month
+                , subq_3.ds_partitioned__quarter
+                , subq_3.ds_partitioned__year
+                , subq_3.ds_partitioned__extract_year
+                , subq_3.ds_partitioned__extract_quarter
+                , subq_3.ds_partitioned__extract_month
+                , subq_3.ds_partitioned__extract_day
+                , subq_3.ds_partitioned__extract_dow
+                , subq_3.ds_partitioned__extract_doy
+                , subq_3.paid_at__day
+                , subq_3.paid_at__week
+                , subq_3.paid_at__month
+                , subq_3.paid_at__quarter
+                , subq_3.paid_at__year
+                , subq_3.paid_at__extract_year
+                , subq_3.paid_at__extract_quarter
+                , subq_3.paid_at__extract_month
+                , subq_3.paid_at__extract_day
+                , subq_3.paid_at__extract_dow
+                , subq_3.paid_at__extract_doy
+                , subq_3.booking__ds__day
+                , subq_3.booking__ds__week
+                , subq_3.booking__ds__month
+                , subq_3.booking__ds__quarter
+                , subq_3.booking__ds__year
+                , subq_3.booking__ds__extract_year
+                , subq_3.booking__ds__extract_quarter
+                , subq_3.booking__ds__extract_month
+                , subq_3.booking__ds__extract_day
+                , subq_3.booking__ds__extract_dow
+                , subq_3.booking__ds__extract_doy
+                , subq_3.booking__ds_partitioned__day
+                , subq_3.booking__ds_partitioned__week
+                , subq_3.booking__ds_partitioned__month
+                , subq_3.booking__ds_partitioned__quarter
+                , subq_3.booking__ds_partitioned__year
+                , subq_3.booking__ds_partitioned__extract_year
+                , subq_3.booking__ds_partitioned__extract_quarter
+                , subq_3.booking__ds_partitioned__extract_month
+                , subq_3.booking__ds_partitioned__extract_day
+                , subq_3.booking__ds_partitioned__extract_dow
+                , subq_3.booking__ds_partitioned__extract_doy
+                , subq_3.booking__paid_at__day
+                , subq_3.booking__paid_at__week
+                , subq_3.booking__paid_at__month
+                , subq_3.booking__paid_at__quarter
+                , subq_3.booking__paid_at__year
+                , subq_3.booking__paid_at__extract_year
+                , subq_3.booking__paid_at__extract_quarter
+                , subq_3.booking__paid_at__extract_month
+                , subq_3.booking__paid_at__extract_day
+                , subq_3.booking__paid_at__extract_dow
+                , subq_3.booking__paid_at__extract_doy
+                , subq_3.metric_time__day
+                , subq_3.metric_time__week
+                , subq_3.metric_time__month
+                , subq_3.metric_time__quarter
+                , subq_3.metric_time__year
+                , subq_3.metric_time__extract_year
+                , subq_3.metric_time__extract_quarter
+                , subq_3.metric_time__extract_month
+                , subq_3.metric_time__extract_day
+                , subq_3.metric_time__extract_dow
+                , subq_3.metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.guest
+                , subq_3.host
+                , subq_3.booking__listing
+                , subq_3.booking__guest
+                , subq_3.booking__host
+                , subq_3.is_instant
+                , subq_3.booking__is_instant
+                , subq_3.bookings
+                , subq_3.instant_bookings
+                , subq_3.booking_value
+                , subq_3.max_booking_value
+                , subq_3.min_booking_value
+                , subq_3.bookers
+                , subq_3.average_booking_value
+                , subq_3.referred_bookings
+                , subq_3.median_booking_value
+                , subq_3.booking_value_p99
+                , subq_3.discrete_booking_value_p99
+                , subq_3.approximate_continuous_booking_value_p99
+                , subq_3.approximate_discrete_booking_value_p99
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_2.ds__day
+                  , subq_2.ds__week
+                  , subq_2.ds__month
+                  , subq_2.ds__quarter
+                  , subq_2.ds__year
+                  , subq_2.ds__extract_year
+                  , subq_2.ds__extract_quarter
+                  , subq_2.ds__extract_month
+                  , subq_2.ds__extract_day
+                  , subq_2.ds__extract_dow
+                  , subq_2.ds__extract_doy
+                  , subq_2.ds_partitioned__day
+                  , subq_2.ds_partitioned__week
+                  , subq_2.ds_partitioned__month
+                  , subq_2.ds_partitioned__quarter
+                  , subq_2.ds_partitioned__year
+                  , subq_2.ds_partitioned__extract_year
+                  , subq_2.ds_partitioned__extract_quarter
+                  , subq_2.ds_partitioned__extract_month
+                  , subq_2.ds_partitioned__extract_day
+                  , subq_2.ds_partitioned__extract_dow
+                  , subq_2.ds_partitioned__extract_doy
+                  , subq_2.paid_at__day
+                  , subq_2.paid_at__week
+                  , subq_2.paid_at__month
+                  , subq_2.paid_at__quarter
+                  , subq_2.paid_at__year
+                  , subq_2.paid_at__extract_year
+                  , subq_2.paid_at__extract_quarter
+                  , subq_2.paid_at__extract_month
+                  , subq_2.paid_at__extract_day
+                  , subq_2.paid_at__extract_dow
+                  , subq_2.paid_at__extract_doy
+                  , subq_2.booking__ds__day
+                  , subq_2.booking__ds__week
+                  , subq_2.booking__ds__month
+                  , subq_2.booking__ds__quarter
+                  , subq_2.booking__ds__year
+                  , subq_2.booking__ds__extract_year
+                  , subq_2.booking__ds__extract_quarter
+                  , subq_2.booking__ds__extract_month
+                  , subq_2.booking__ds__extract_day
+                  , subq_2.booking__ds__extract_dow
+                  , subq_2.booking__ds__extract_doy
+                  , subq_2.booking__ds_partitioned__day
+                  , subq_2.booking__ds_partitioned__week
+                  , subq_2.booking__ds_partitioned__month
+                  , subq_2.booking__ds_partitioned__quarter
+                  , subq_2.booking__ds_partitioned__year
+                  , subq_2.booking__ds_partitioned__extract_year
+                  , subq_2.booking__ds_partitioned__extract_quarter
+                  , subq_2.booking__ds_partitioned__extract_month
+                  , subq_2.booking__ds_partitioned__extract_day
+                  , subq_2.booking__ds_partitioned__extract_dow
+                  , subq_2.booking__ds_partitioned__extract_doy
+                  , subq_2.booking__paid_at__day
+                  , subq_2.booking__paid_at__week
+                  , subq_2.booking__paid_at__month
+                  , subq_2.booking__paid_at__quarter
+                  , subq_2.booking__paid_at__year
+                  , subq_2.booking__paid_at__extract_year
+                  , subq_2.booking__paid_at__extract_quarter
+                  , subq_2.booking__paid_at__extract_month
+                  , subq_2.booking__paid_at__extract_day
+                  , subq_2.booking__paid_at__extract_dow
+                  , subq_2.booking__paid_at__extract_doy
+                  , subq_2.ds__day AS metric_time__day
+                  , subq_2.ds__week AS metric_time__week
+                  , subq_2.ds__month AS metric_time__month
+                  , subq_2.ds__quarter AS metric_time__quarter
+                  , subq_2.ds__year AS metric_time__year
+                  , subq_2.ds__extract_year AS metric_time__extract_year
+                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_2.ds__extract_month AS metric_time__extract_month
+                  , subq_2.ds__extract_day AS metric_time__extract_day
+                  , subq_2.ds__extract_dow AS metric_time__extract_dow
+                  , subq_2.ds__extract_doy AS metric_time__extract_doy
+                  , subq_2.listing
+                  , subq_2.guest
+                  , subq_2.host
+                  , subq_2.booking__listing
+                  , subq_2.booking__guest
+                  , subq_2.booking__host
+                  , subq_2.is_instant
+                  , subq_2.booking__is_instant
+                  , subq_2.bookings
+                  , subq_2.instant_bookings
+                  , subq_2.booking_value
+                  , subq_2.max_booking_value
+                  , subq_2.min_booking_value
+                  , subq_2.bookers
+                  , subq_2.average_booking_value
+                  , subq_2.referred_bookings
+                  , subq_2.median_booking_value
+                  , subq_2.booking_value_p99
+                  , subq_2.discrete_booking_value_p99
+                  , subq_2.approximate_continuous_booking_value_p99
+                  , subq_2.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                    , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                    , DATE_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                    , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                    , DATE_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                    , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                    , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                    , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                    , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                    , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                    , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                    , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                    , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                    , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                    , DATE_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                    , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                    , DATE_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                    , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                    , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                    , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                    , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                    , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                    , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                    , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_2
+              ) subq_3
+              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_4
+          ) subq_5
+          WHERE metric_time__day > '2020-01-01'
+        ) subq_6
+        GROUP BY
+          metric_time__day
+      ) subq_7
+      ON
+        subq_8.metric_time__day = subq_7.metric_time__day
+    ) subq_10
+    WHERE metric_time__day > '2020-01-01'
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_12

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -1,0 +1,52 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    metric_time__day
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_19.metric_time__day AS metric_time__day
+      , subq_18.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_20
+      WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_19
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          DATE_TRUNC(ds, day) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+        WHERE DATE_TRUNC(ds, day) BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_16
+      WHERE metric_time__day > '2020-01-01'
+      GROUP BY
+        metric_time__day
+    ) subq_18
+    ON
+      subq_19.metric_time__day = subq_18.metric_time__day
+  ) subq_21
+  WHERE (
+    metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+  ) AND (
+    metric_time__day > '2020-01-01'
+  )
+) subq_23

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,0 +1,352 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.bookings
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_8.metric_time__day AS metric_time__day
+        , subq_7.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_9.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_9
+        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_8
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_6.metric_time__day
+          , SUM(subq_6.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.ds_partitioned__day
+                , subq_3.ds_partitioned__week
+                , subq_3.ds_partitioned__month
+                , subq_3.ds_partitioned__quarter
+                , subq_3.ds_partitioned__year
+                , subq_3.ds_partitioned__extract_year
+                , subq_3.ds_partitioned__extract_quarter
+                , subq_3.ds_partitioned__extract_month
+                , subq_3.ds_partitioned__extract_day
+                , subq_3.ds_partitioned__extract_dow
+                , subq_3.ds_partitioned__extract_doy
+                , subq_3.paid_at__day
+                , subq_3.paid_at__week
+                , subq_3.paid_at__month
+                , subq_3.paid_at__quarter
+                , subq_3.paid_at__year
+                , subq_3.paid_at__extract_year
+                , subq_3.paid_at__extract_quarter
+                , subq_3.paid_at__extract_month
+                , subq_3.paid_at__extract_day
+                , subq_3.paid_at__extract_dow
+                , subq_3.paid_at__extract_doy
+                , subq_3.booking__ds__day
+                , subq_3.booking__ds__week
+                , subq_3.booking__ds__month
+                , subq_3.booking__ds__quarter
+                , subq_3.booking__ds__year
+                , subq_3.booking__ds__extract_year
+                , subq_3.booking__ds__extract_quarter
+                , subq_3.booking__ds__extract_month
+                , subq_3.booking__ds__extract_day
+                , subq_3.booking__ds__extract_dow
+                , subq_3.booking__ds__extract_doy
+                , subq_3.booking__ds_partitioned__day
+                , subq_3.booking__ds_partitioned__week
+                , subq_3.booking__ds_partitioned__month
+                , subq_3.booking__ds_partitioned__quarter
+                , subq_3.booking__ds_partitioned__year
+                , subq_3.booking__ds_partitioned__extract_year
+                , subq_3.booking__ds_partitioned__extract_quarter
+                , subq_3.booking__ds_partitioned__extract_month
+                , subq_3.booking__ds_partitioned__extract_day
+                , subq_3.booking__ds_partitioned__extract_dow
+                , subq_3.booking__ds_partitioned__extract_doy
+                , subq_3.booking__paid_at__day
+                , subq_3.booking__paid_at__week
+                , subq_3.booking__paid_at__month
+                , subq_3.booking__paid_at__quarter
+                , subq_3.booking__paid_at__year
+                , subq_3.booking__paid_at__extract_year
+                , subq_3.booking__paid_at__extract_quarter
+                , subq_3.booking__paid_at__extract_month
+                , subq_3.booking__paid_at__extract_day
+                , subq_3.booking__paid_at__extract_dow
+                , subq_3.booking__paid_at__extract_doy
+                , subq_3.metric_time__day
+                , subq_3.metric_time__week
+                , subq_3.metric_time__month
+                , subq_3.metric_time__quarter
+                , subq_3.metric_time__year
+                , subq_3.metric_time__extract_year
+                , subq_3.metric_time__extract_quarter
+                , subq_3.metric_time__extract_month
+                , subq_3.metric_time__extract_day
+                , subq_3.metric_time__extract_dow
+                , subq_3.metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.guest
+                , subq_3.host
+                , subq_3.booking__listing
+                , subq_3.booking__guest
+                , subq_3.booking__host
+                , subq_3.is_instant
+                , subq_3.booking__is_instant
+                , subq_3.bookings
+                , subq_3.instant_bookings
+                , subq_3.booking_value
+                , subq_3.max_booking_value
+                , subq_3.min_booking_value
+                , subq_3.bookers
+                , subq_3.average_booking_value
+                , subq_3.referred_bookings
+                , subq_3.median_booking_value
+                , subq_3.booking_value_p99
+                , subq_3.discrete_booking_value_p99
+                , subq_3.approximate_continuous_booking_value_p99
+                , subq_3.approximate_discrete_booking_value_p99
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_2.ds__day
+                  , subq_2.ds__week
+                  , subq_2.ds__month
+                  , subq_2.ds__quarter
+                  , subq_2.ds__year
+                  , subq_2.ds__extract_year
+                  , subq_2.ds__extract_quarter
+                  , subq_2.ds__extract_month
+                  , subq_2.ds__extract_day
+                  , subq_2.ds__extract_dow
+                  , subq_2.ds__extract_doy
+                  , subq_2.ds_partitioned__day
+                  , subq_2.ds_partitioned__week
+                  , subq_2.ds_partitioned__month
+                  , subq_2.ds_partitioned__quarter
+                  , subq_2.ds_partitioned__year
+                  , subq_2.ds_partitioned__extract_year
+                  , subq_2.ds_partitioned__extract_quarter
+                  , subq_2.ds_partitioned__extract_month
+                  , subq_2.ds_partitioned__extract_day
+                  , subq_2.ds_partitioned__extract_dow
+                  , subq_2.ds_partitioned__extract_doy
+                  , subq_2.paid_at__day
+                  , subq_2.paid_at__week
+                  , subq_2.paid_at__month
+                  , subq_2.paid_at__quarter
+                  , subq_2.paid_at__year
+                  , subq_2.paid_at__extract_year
+                  , subq_2.paid_at__extract_quarter
+                  , subq_2.paid_at__extract_month
+                  , subq_2.paid_at__extract_day
+                  , subq_2.paid_at__extract_dow
+                  , subq_2.paid_at__extract_doy
+                  , subq_2.booking__ds__day
+                  , subq_2.booking__ds__week
+                  , subq_2.booking__ds__month
+                  , subq_2.booking__ds__quarter
+                  , subq_2.booking__ds__year
+                  , subq_2.booking__ds__extract_year
+                  , subq_2.booking__ds__extract_quarter
+                  , subq_2.booking__ds__extract_month
+                  , subq_2.booking__ds__extract_day
+                  , subq_2.booking__ds__extract_dow
+                  , subq_2.booking__ds__extract_doy
+                  , subq_2.booking__ds_partitioned__day
+                  , subq_2.booking__ds_partitioned__week
+                  , subq_2.booking__ds_partitioned__month
+                  , subq_2.booking__ds_partitioned__quarter
+                  , subq_2.booking__ds_partitioned__year
+                  , subq_2.booking__ds_partitioned__extract_year
+                  , subq_2.booking__ds_partitioned__extract_quarter
+                  , subq_2.booking__ds_partitioned__extract_month
+                  , subq_2.booking__ds_partitioned__extract_day
+                  , subq_2.booking__ds_partitioned__extract_dow
+                  , subq_2.booking__ds_partitioned__extract_doy
+                  , subq_2.booking__paid_at__day
+                  , subq_2.booking__paid_at__week
+                  , subq_2.booking__paid_at__month
+                  , subq_2.booking__paid_at__quarter
+                  , subq_2.booking__paid_at__year
+                  , subq_2.booking__paid_at__extract_year
+                  , subq_2.booking__paid_at__extract_quarter
+                  , subq_2.booking__paid_at__extract_month
+                  , subq_2.booking__paid_at__extract_day
+                  , subq_2.booking__paid_at__extract_dow
+                  , subq_2.booking__paid_at__extract_doy
+                  , subq_2.ds__day AS metric_time__day
+                  , subq_2.ds__week AS metric_time__week
+                  , subq_2.ds__month AS metric_time__month
+                  , subq_2.ds__quarter AS metric_time__quarter
+                  , subq_2.ds__year AS metric_time__year
+                  , subq_2.ds__extract_year AS metric_time__extract_year
+                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_2.ds__extract_month AS metric_time__extract_month
+                  , subq_2.ds__extract_day AS metric_time__extract_day
+                  , subq_2.ds__extract_dow AS metric_time__extract_dow
+                  , subq_2.ds__extract_doy AS metric_time__extract_doy
+                  , subq_2.listing
+                  , subq_2.guest
+                  , subq_2.host
+                  , subq_2.booking__listing
+                  , subq_2.booking__guest
+                  , subq_2.booking__host
+                  , subq_2.is_instant
+                  , subq_2.booking__is_instant
+                  , subq_2.bookings
+                  , subq_2.instant_bookings
+                  , subq_2.booking_value
+                  , subq_2.max_booking_value
+                  , subq_2.min_booking_value
+                  , subq_2.bookers
+                  , subq_2.average_booking_value
+                  , subq_2.referred_bookings
+                  , subq_2.median_booking_value
+                  , subq_2.booking_value_p99
+                  , subq_2.discrete_booking_value_p99
+                  , subq_2.approximate_continuous_booking_value_p99
+                  , subq_2.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_2
+              ) subq_3
+              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_4
+          ) subq_5
+          WHERE metric_time__day > '2020-01-01'
+        ) subq_6
+        GROUP BY
+          subq_6.metric_time__day
+      ) subq_7
+      ON
+        subq_8.metric_time__day = subq_7.metric_time__day
+    ) subq_10
+    WHERE metric_time__day > '2020-01-01'
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_12

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -1,0 +1,52 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    metric_time__day
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_19.metric_time__day AS metric_time__day
+      , subq_18.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_20
+      WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_19
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+        WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_16
+      WHERE metric_time__day > '2020-01-01'
+      GROUP BY
+        metric_time__day
+    ) subq_18
+    ON
+      subq_19.metric_time__day = subq_18.metric_time__day
+  ) subq_21
+  WHERE (
+    metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+  ) AND (
+    metric_time__day > '2020-01-01'
+  )
+) subq_23

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,0 +1,352 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.bookings
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_8.metric_time__day AS metric_time__day
+        , subq_7.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_9.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_9
+        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_8
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_6.metric_time__day
+          , SUM(subq_6.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.ds_partitioned__day
+                , subq_3.ds_partitioned__week
+                , subq_3.ds_partitioned__month
+                , subq_3.ds_partitioned__quarter
+                , subq_3.ds_partitioned__year
+                , subq_3.ds_partitioned__extract_year
+                , subq_3.ds_partitioned__extract_quarter
+                , subq_3.ds_partitioned__extract_month
+                , subq_3.ds_partitioned__extract_day
+                , subq_3.ds_partitioned__extract_dow
+                , subq_3.ds_partitioned__extract_doy
+                , subq_3.paid_at__day
+                , subq_3.paid_at__week
+                , subq_3.paid_at__month
+                , subq_3.paid_at__quarter
+                , subq_3.paid_at__year
+                , subq_3.paid_at__extract_year
+                , subq_3.paid_at__extract_quarter
+                , subq_3.paid_at__extract_month
+                , subq_3.paid_at__extract_day
+                , subq_3.paid_at__extract_dow
+                , subq_3.paid_at__extract_doy
+                , subq_3.booking__ds__day
+                , subq_3.booking__ds__week
+                , subq_3.booking__ds__month
+                , subq_3.booking__ds__quarter
+                , subq_3.booking__ds__year
+                , subq_3.booking__ds__extract_year
+                , subq_3.booking__ds__extract_quarter
+                , subq_3.booking__ds__extract_month
+                , subq_3.booking__ds__extract_day
+                , subq_3.booking__ds__extract_dow
+                , subq_3.booking__ds__extract_doy
+                , subq_3.booking__ds_partitioned__day
+                , subq_3.booking__ds_partitioned__week
+                , subq_3.booking__ds_partitioned__month
+                , subq_3.booking__ds_partitioned__quarter
+                , subq_3.booking__ds_partitioned__year
+                , subq_3.booking__ds_partitioned__extract_year
+                , subq_3.booking__ds_partitioned__extract_quarter
+                , subq_3.booking__ds_partitioned__extract_month
+                , subq_3.booking__ds_partitioned__extract_day
+                , subq_3.booking__ds_partitioned__extract_dow
+                , subq_3.booking__ds_partitioned__extract_doy
+                , subq_3.booking__paid_at__day
+                , subq_3.booking__paid_at__week
+                , subq_3.booking__paid_at__month
+                , subq_3.booking__paid_at__quarter
+                , subq_3.booking__paid_at__year
+                , subq_3.booking__paid_at__extract_year
+                , subq_3.booking__paid_at__extract_quarter
+                , subq_3.booking__paid_at__extract_month
+                , subq_3.booking__paid_at__extract_day
+                , subq_3.booking__paid_at__extract_dow
+                , subq_3.booking__paid_at__extract_doy
+                , subq_3.metric_time__day
+                , subq_3.metric_time__week
+                , subq_3.metric_time__month
+                , subq_3.metric_time__quarter
+                , subq_3.metric_time__year
+                , subq_3.metric_time__extract_year
+                , subq_3.metric_time__extract_quarter
+                , subq_3.metric_time__extract_month
+                , subq_3.metric_time__extract_day
+                , subq_3.metric_time__extract_dow
+                , subq_3.metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.guest
+                , subq_3.host
+                , subq_3.booking__listing
+                , subq_3.booking__guest
+                , subq_3.booking__host
+                , subq_3.is_instant
+                , subq_3.booking__is_instant
+                , subq_3.bookings
+                , subq_3.instant_bookings
+                , subq_3.booking_value
+                , subq_3.max_booking_value
+                , subq_3.min_booking_value
+                , subq_3.bookers
+                , subq_3.average_booking_value
+                , subq_3.referred_bookings
+                , subq_3.median_booking_value
+                , subq_3.booking_value_p99
+                , subq_3.discrete_booking_value_p99
+                , subq_3.approximate_continuous_booking_value_p99
+                , subq_3.approximate_discrete_booking_value_p99
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_2.ds__day
+                  , subq_2.ds__week
+                  , subq_2.ds__month
+                  , subq_2.ds__quarter
+                  , subq_2.ds__year
+                  , subq_2.ds__extract_year
+                  , subq_2.ds__extract_quarter
+                  , subq_2.ds__extract_month
+                  , subq_2.ds__extract_day
+                  , subq_2.ds__extract_dow
+                  , subq_2.ds__extract_doy
+                  , subq_2.ds_partitioned__day
+                  , subq_2.ds_partitioned__week
+                  , subq_2.ds_partitioned__month
+                  , subq_2.ds_partitioned__quarter
+                  , subq_2.ds_partitioned__year
+                  , subq_2.ds_partitioned__extract_year
+                  , subq_2.ds_partitioned__extract_quarter
+                  , subq_2.ds_partitioned__extract_month
+                  , subq_2.ds_partitioned__extract_day
+                  , subq_2.ds_partitioned__extract_dow
+                  , subq_2.ds_partitioned__extract_doy
+                  , subq_2.paid_at__day
+                  , subq_2.paid_at__week
+                  , subq_2.paid_at__month
+                  , subq_2.paid_at__quarter
+                  , subq_2.paid_at__year
+                  , subq_2.paid_at__extract_year
+                  , subq_2.paid_at__extract_quarter
+                  , subq_2.paid_at__extract_month
+                  , subq_2.paid_at__extract_day
+                  , subq_2.paid_at__extract_dow
+                  , subq_2.paid_at__extract_doy
+                  , subq_2.booking__ds__day
+                  , subq_2.booking__ds__week
+                  , subq_2.booking__ds__month
+                  , subq_2.booking__ds__quarter
+                  , subq_2.booking__ds__year
+                  , subq_2.booking__ds__extract_year
+                  , subq_2.booking__ds__extract_quarter
+                  , subq_2.booking__ds__extract_month
+                  , subq_2.booking__ds__extract_day
+                  , subq_2.booking__ds__extract_dow
+                  , subq_2.booking__ds__extract_doy
+                  , subq_2.booking__ds_partitioned__day
+                  , subq_2.booking__ds_partitioned__week
+                  , subq_2.booking__ds_partitioned__month
+                  , subq_2.booking__ds_partitioned__quarter
+                  , subq_2.booking__ds_partitioned__year
+                  , subq_2.booking__ds_partitioned__extract_year
+                  , subq_2.booking__ds_partitioned__extract_quarter
+                  , subq_2.booking__ds_partitioned__extract_month
+                  , subq_2.booking__ds_partitioned__extract_day
+                  , subq_2.booking__ds_partitioned__extract_dow
+                  , subq_2.booking__ds_partitioned__extract_doy
+                  , subq_2.booking__paid_at__day
+                  , subq_2.booking__paid_at__week
+                  , subq_2.booking__paid_at__month
+                  , subq_2.booking__paid_at__quarter
+                  , subq_2.booking__paid_at__year
+                  , subq_2.booking__paid_at__extract_year
+                  , subq_2.booking__paid_at__extract_quarter
+                  , subq_2.booking__paid_at__extract_month
+                  , subq_2.booking__paid_at__extract_day
+                  , subq_2.booking__paid_at__extract_dow
+                  , subq_2.booking__paid_at__extract_doy
+                  , subq_2.ds__day AS metric_time__day
+                  , subq_2.ds__week AS metric_time__week
+                  , subq_2.ds__month AS metric_time__month
+                  , subq_2.ds__quarter AS metric_time__quarter
+                  , subq_2.ds__year AS metric_time__year
+                  , subq_2.ds__extract_year AS metric_time__extract_year
+                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_2.ds__extract_month AS metric_time__extract_month
+                  , subq_2.ds__extract_day AS metric_time__extract_day
+                  , subq_2.ds__extract_dow AS metric_time__extract_dow
+                  , subq_2.ds__extract_doy AS metric_time__extract_doy
+                  , subq_2.listing
+                  , subq_2.guest
+                  , subq_2.host
+                  , subq_2.booking__listing
+                  , subq_2.booking__guest
+                  , subq_2.booking__host
+                  , subq_2.is_instant
+                  , subq_2.booking__is_instant
+                  , subq_2.bookings
+                  , subq_2.instant_bookings
+                  , subq_2.booking_value
+                  , subq_2.max_booking_value
+                  , subq_2.min_booking_value
+                  , subq_2.bookers
+                  , subq_2.average_booking_value
+                  , subq_2.referred_bookings
+                  , subq_2.median_booking_value
+                  , subq_2.booking_value_p99
+                  , subq_2.discrete_booking_value_p99
+                  , subq_2.approximate_continuous_booking_value_p99
+                  , subq_2.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_2
+              ) subq_3
+              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_4
+          ) subq_5
+          WHERE metric_time__day > '2020-01-01'
+        ) subq_6
+        GROUP BY
+          subq_6.metric_time__day
+      ) subq_7
+      ON
+        subq_8.metric_time__day = subq_7.metric_time__day
+    ) subq_10
+    WHERE metric_time__day > '2020-01-01'
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_12

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -1,0 +1,52 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    metric_time__day
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_19.metric_time__day AS metric_time__day
+      , subq_18.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_20
+      WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_19
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+        WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_16
+      WHERE metric_time__day > '2020-01-01'
+      GROUP BY
+        metric_time__day
+    ) subq_18
+    ON
+      subq_19.metric_time__day = subq_18.metric_time__day
+  ) subq_21
+  WHERE (
+    metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+  ) AND (
+    metric_time__day > '2020-01-01'
+  )
+) subq_23

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,0 +1,352 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.bookings
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_8.metric_time__day AS metric_time__day
+        , subq_7.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_9.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_9
+        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_8
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_6.metric_time__day
+          , SUM(subq_6.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.ds_partitioned__day
+                , subq_3.ds_partitioned__week
+                , subq_3.ds_partitioned__month
+                , subq_3.ds_partitioned__quarter
+                , subq_3.ds_partitioned__year
+                , subq_3.ds_partitioned__extract_year
+                , subq_3.ds_partitioned__extract_quarter
+                , subq_3.ds_partitioned__extract_month
+                , subq_3.ds_partitioned__extract_day
+                , subq_3.ds_partitioned__extract_dow
+                , subq_3.ds_partitioned__extract_doy
+                , subq_3.paid_at__day
+                , subq_3.paid_at__week
+                , subq_3.paid_at__month
+                , subq_3.paid_at__quarter
+                , subq_3.paid_at__year
+                , subq_3.paid_at__extract_year
+                , subq_3.paid_at__extract_quarter
+                , subq_3.paid_at__extract_month
+                , subq_3.paid_at__extract_day
+                , subq_3.paid_at__extract_dow
+                , subq_3.paid_at__extract_doy
+                , subq_3.booking__ds__day
+                , subq_3.booking__ds__week
+                , subq_3.booking__ds__month
+                , subq_3.booking__ds__quarter
+                , subq_3.booking__ds__year
+                , subq_3.booking__ds__extract_year
+                , subq_3.booking__ds__extract_quarter
+                , subq_3.booking__ds__extract_month
+                , subq_3.booking__ds__extract_day
+                , subq_3.booking__ds__extract_dow
+                , subq_3.booking__ds__extract_doy
+                , subq_3.booking__ds_partitioned__day
+                , subq_3.booking__ds_partitioned__week
+                , subq_3.booking__ds_partitioned__month
+                , subq_3.booking__ds_partitioned__quarter
+                , subq_3.booking__ds_partitioned__year
+                , subq_3.booking__ds_partitioned__extract_year
+                , subq_3.booking__ds_partitioned__extract_quarter
+                , subq_3.booking__ds_partitioned__extract_month
+                , subq_3.booking__ds_partitioned__extract_day
+                , subq_3.booking__ds_partitioned__extract_dow
+                , subq_3.booking__ds_partitioned__extract_doy
+                , subq_3.booking__paid_at__day
+                , subq_3.booking__paid_at__week
+                , subq_3.booking__paid_at__month
+                , subq_3.booking__paid_at__quarter
+                , subq_3.booking__paid_at__year
+                , subq_3.booking__paid_at__extract_year
+                , subq_3.booking__paid_at__extract_quarter
+                , subq_3.booking__paid_at__extract_month
+                , subq_3.booking__paid_at__extract_day
+                , subq_3.booking__paid_at__extract_dow
+                , subq_3.booking__paid_at__extract_doy
+                , subq_3.metric_time__day
+                , subq_3.metric_time__week
+                , subq_3.metric_time__month
+                , subq_3.metric_time__quarter
+                , subq_3.metric_time__year
+                , subq_3.metric_time__extract_year
+                , subq_3.metric_time__extract_quarter
+                , subq_3.metric_time__extract_month
+                , subq_3.metric_time__extract_day
+                , subq_3.metric_time__extract_dow
+                , subq_3.metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.guest
+                , subq_3.host
+                , subq_3.booking__listing
+                , subq_3.booking__guest
+                , subq_3.booking__host
+                , subq_3.is_instant
+                , subq_3.booking__is_instant
+                , subq_3.bookings
+                , subq_3.instant_bookings
+                , subq_3.booking_value
+                , subq_3.max_booking_value
+                , subq_3.min_booking_value
+                , subq_3.bookers
+                , subq_3.average_booking_value
+                , subq_3.referred_bookings
+                , subq_3.median_booking_value
+                , subq_3.booking_value_p99
+                , subq_3.discrete_booking_value_p99
+                , subq_3.approximate_continuous_booking_value_p99
+                , subq_3.approximate_discrete_booking_value_p99
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_2.ds__day
+                  , subq_2.ds__week
+                  , subq_2.ds__month
+                  , subq_2.ds__quarter
+                  , subq_2.ds__year
+                  , subq_2.ds__extract_year
+                  , subq_2.ds__extract_quarter
+                  , subq_2.ds__extract_month
+                  , subq_2.ds__extract_day
+                  , subq_2.ds__extract_dow
+                  , subq_2.ds__extract_doy
+                  , subq_2.ds_partitioned__day
+                  , subq_2.ds_partitioned__week
+                  , subq_2.ds_partitioned__month
+                  , subq_2.ds_partitioned__quarter
+                  , subq_2.ds_partitioned__year
+                  , subq_2.ds_partitioned__extract_year
+                  , subq_2.ds_partitioned__extract_quarter
+                  , subq_2.ds_partitioned__extract_month
+                  , subq_2.ds_partitioned__extract_day
+                  , subq_2.ds_partitioned__extract_dow
+                  , subq_2.ds_partitioned__extract_doy
+                  , subq_2.paid_at__day
+                  , subq_2.paid_at__week
+                  , subq_2.paid_at__month
+                  , subq_2.paid_at__quarter
+                  , subq_2.paid_at__year
+                  , subq_2.paid_at__extract_year
+                  , subq_2.paid_at__extract_quarter
+                  , subq_2.paid_at__extract_month
+                  , subq_2.paid_at__extract_day
+                  , subq_2.paid_at__extract_dow
+                  , subq_2.paid_at__extract_doy
+                  , subq_2.booking__ds__day
+                  , subq_2.booking__ds__week
+                  , subq_2.booking__ds__month
+                  , subq_2.booking__ds__quarter
+                  , subq_2.booking__ds__year
+                  , subq_2.booking__ds__extract_year
+                  , subq_2.booking__ds__extract_quarter
+                  , subq_2.booking__ds__extract_month
+                  , subq_2.booking__ds__extract_day
+                  , subq_2.booking__ds__extract_dow
+                  , subq_2.booking__ds__extract_doy
+                  , subq_2.booking__ds_partitioned__day
+                  , subq_2.booking__ds_partitioned__week
+                  , subq_2.booking__ds_partitioned__month
+                  , subq_2.booking__ds_partitioned__quarter
+                  , subq_2.booking__ds_partitioned__year
+                  , subq_2.booking__ds_partitioned__extract_year
+                  , subq_2.booking__ds_partitioned__extract_quarter
+                  , subq_2.booking__ds_partitioned__extract_month
+                  , subq_2.booking__ds_partitioned__extract_day
+                  , subq_2.booking__ds_partitioned__extract_dow
+                  , subq_2.booking__ds_partitioned__extract_doy
+                  , subq_2.booking__paid_at__day
+                  , subq_2.booking__paid_at__week
+                  , subq_2.booking__paid_at__month
+                  , subq_2.booking__paid_at__quarter
+                  , subq_2.booking__paid_at__year
+                  , subq_2.booking__paid_at__extract_year
+                  , subq_2.booking__paid_at__extract_quarter
+                  , subq_2.booking__paid_at__extract_month
+                  , subq_2.booking__paid_at__extract_day
+                  , subq_2.booking__paid_at__extract_dow
+                  , subq_2.booking__paid_at__extract_doy
+                  , subq_2.ds__day AS metric_time__day
+                  , subq_2.ds__week AS metric_time__week
+                  , subq_2.ds__month AS metric_time__month
+                  , subq_2.ds__quarter AS metric_time__quarter
+                  , subq_2.ds__year AS metric_time__year
+                  , subq_2.ds__extract_year AS metric_time__extract_year
+                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_2.ds__extract_month AS metric_time__extract_month
+                  , subq_2.ds__extract_day AS metric_time__extract_day
+                  , subq_2.ds__extract_dow AS metric_time__extract_dow
+                  , subq_2.ds__extract_doy AS metric_time__extract_doy
+                  , subq_2.listing
+                  , subq_2.guest
+                  , subq_2.host
+                  , subq_2.booking__listing
+                  , subq_2.booking__guest
+                  , subq_2.booking__host
+                  , subq_2.is_instant
+                  , subq_2.booking__is_instant
+                  , subq_2.bookings
+                  , subq_2.instant_bookings
+                  , subq_2.booking_value
+                  , subq_2.max_booking_value
+                  , subq_2.min_booking_value
+                  , subq_2.bookers
+                  , subq_2.average_booking_value
+                  , subq_2.referred_bookings
+                  , subq_2.median_booking_value
+                  , subq_2.booking_value_p99
+                  , subq_2.discrete_booking_value_p99
+                  , subq_2.approximate_continuous_booking_value_p99
+                  , subq_2.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_2
+              ) subq_3
+              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_4
+          ) subq_5
+          WHERE metric_time__day > '2020-01-01'
+        ) subq_6
+        GROUP BY
+          subq_6.metric_time__day
+      ) subq_7
+      ON
+        subq_8.metric_time__day = subq_7.metric_time__day
+    ) subq_10
+    WHERE metric_time__day > '2020-01-01'
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_12

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -1,0 +1,52 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    metric_time__day
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_19.metric_time__day AS metric_time__day
+      , subq_18.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_20
+      WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_19
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+        WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_16
+      WHERE metric_time__day > '2020-01-01'
+      GROUP BY
+        metric_time__day
+    ) subq_18
+    ON
+      subq_19.metric_time__day = subq_18.metric_time__day
+  ) subq_21
+  WHERE (
+    metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+  ) AND (
+    metric_time__day > '2020-01-01'
+  )
+) subq_23

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,0 +1,352 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.bookings
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_8.metric_time__day AS metric_time__day
+        , subq_7.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_9.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_9
+        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_8
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_6.metric_time__day
+          , SUM(subq_6.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.ds_partitioned__day
+                , subq_3.ds_partitioned__week
+                , subq_3.ds_partitioned__month
+                , subq_3.ds_partitioned__quarter
+                , subq_3.ds_partitioned__year
+                , subq_3.ds_partitioned__extract_year
+                , subq_3.ds_partitioned__extract_quarter
+                , subq_3.ds_partitioned__extract_month
+                , subq_3.ds_partitioned__extract_day
+                , subq_3.ds_partitioned__extract_dow
+                , subq_3.ds_partitioned__extract_doy
+                , subq_3.paid_at__day
+                , subq_3.paid_at__week
+                , subq_3.paid_at__month
+                , subq_3.paid_at__quarter
+                , subq_3.paid_at__year
+                , subq_3.paid_at__extract_year
+                , subq_3.paid_at__extract_quarter
+                , subq_3.paid_at__extract_month
+                , subq_3.paid_at__extract_day
+                , subq_3.paid_at__extract_dow
+                , subq_3.paid_at__extract_doy
+                , subq_3.booking__ds__day
+                , subq_3.booking__ds__week
+                , subq_3.booking__ds__month
+                , subq_3.booking__ds__quarter
+                , subq_3.booking__ds__year
+                , subq_3.booking__ds__extract_year
+                , subq_3.booking__ds__extract_quarter
+                , subq_3.booking__ds__extract_month
+                , subq_3.booking__ds__extract_day
+                , subq_3.booking__ds__extract_dow
+                , subq_3.booking__ds__extract_doy
+                , subq_3.booking__ds_partitioned__day
+                , subq_3.booking__ds_partitioned__week
+                , subq_3.booking__ds_partitioned__month
+                , subq_3.booking__ds_partitioned__quarter
+                , subq_3.booking__ds_partitioned__year
+                , subq_3.booking__ds_partitioned__extract_year
+                , subq_3.booking__ds_partitioned__extract_quarter
+                , subq_3.booking__ds_partitioned__extract_month
+                , subq_3.booking__ds_partitioned__extract_day
+                , subq_3.booking__ds_partitioned__extract_dow
+                , subq_3.booking__ds_partitioned__extract_doy
+                , subq_3.booking__paid_at__day
+                , subq_3.booking__paid_at__week
+                , subq_3.booking__paid_at__month
+                , subq_3.booking__paid_at__quarter
+                , subq_3.booking__paid_at__year
+                , subq_3.booking__paid_at__extract_year
+                , subq_3.booking__paid_at__extract_quarter
+                , subq_3.booking__paid_at__extract_month
+                , subq_3.booking__paid_at__extract_day
+                , subq_3.booking__paid_at__extract_dow
+                , subq_3.booking__paid_at__extract_doy
+                , subq_3.metric_time__day
+                , subq_3.metric_time__week
+                , subq_3.metric_time__month
+                , subq_3.metric_time__quarter
+                , subq_3.metric_time__year
+                , subq_3.metric_time__extract_year
+                , subq_3.metric_time__extract_quarter
+                , subq_3.metric_time__extract_month
+                , subq_3.metric_time__extract_day
+                , subq_3.metric_time__extract_dow
+                , subq_3.metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.guest
+                , subq_3.host
+                , subq_3.booking__listing
+                , subq_3.booking__guest
+                , subq_3.booking__host
+                , subq_3.is_instant
+                , subq_3.booking__is_instant
+                , subq_3.bookings
+                , subq_3.instant_bookings
+                , subq_3.booking_value
+                , subq_3.max_booking_value
+                , subq_3.min_booking_value
+                , subq_3.bookers
+                , subq_3.average_booking_value
+                , subq_3.referred_bookings
+                , subq_3.median_booking_value
+                , subq_3.booking_value_p99
+                , subq_3.discrete_booking_value_p99
+                , subq_3.approximate_continuous_booking_value_p99
+                , subq_3.approximate_discrete_booking_value_p99
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_2.ds__day
+                  , subq_2.ds__week
+                  , subq_2.ds__month
+                  , subq_2.ds__quarter
+                  , subq_2.ds__year
+                  , subq_2.ds__extract_year
+                  , subq_2.ds__extract_quarter
+                  , subq_2.ds__extract_month
+                  , subq_2.ds__extract_day
+                  , subq_2.ds__extract_dow
+                  , subq_2.ds__extract_doy
+                  , subq_2.ds_partitioned__day
+                  , subq_2.ds_partitioned__week
+                  , subq_2.ds_partitioned__month
+                  , subq_2.ds_partitioned__quarter
+                  , subq_2.ds_partitioned__year
+                  , subq_2.ds_partitioned__extract_year
+                  , subq_2.ds_partitioned__extract_quarter
+                  , subq_2.ds_partitioned__extract_month
+                  , subq_2.ds_partitioned__extract_day
+                  , subq_2.ds_partitioned__extract_dow
+                  , subq_2.ds_partitioned__extract_doy
+                  , subq_2.paid_at__day
+                  , subq_2.paid_at__week
+                  , subq_2.paid_at__month
+                  , subq_2.paid_at__quarter
+                  , subq_2.paid_at__year
+                  , subq_2.paid_at__extract_year
+                  , subq_2.paid_at__extract_quarter
+                  , subq_2.paid_at__extract_month
+                  , subq_2.paid_at__extract_day
+                  , subq_2.paid_at__extract_dow
+                  , subq_2.paid_at__extract_doy
+                  , subq_2.booking__ds__day
+                  , subq_2.booking__ds__week
+                  , subq_2.booking__ds__month
+                  , subq_2.booking__ds__quarter
+                  , subq_2.booking__ds__year
+                  , subq_2.booking__ds__extract_year
+                  , subq_2.booking__ds__extract_quarter
+                  , subq_2.booking__ds__extract_month
+                  , subq_2.booking__ds__extract_day
+                  , subq_2.booking__ds__extract_dow
+                  , subq_2.booking__ds__extract_doy
+                  , subq_2.booking__ds_partitioned__day
+                  , subq_2.booking__ds_partitioned__week
+                  , subq_2.booking__ds_partitioned__month
+                  , subq_2.booking__ds_partitioned__quarter
+                  , subq_2.booking__ds_partitioned__year
+                  , subq_2.booking__ds_partitioned__extract_year
+                  , subq_2.booking__ds_partitioned__extract_quarter
+                  , subq_2.booking__ds_partitioned__extract_month
+                  , subq_2.booking__ds_partitioned__extract_day
+                  , subq_2.booking__ds_partitioned__extract_dow
+                  , subq_2.booking__ds_partitioned__extract_doy
+                  , subq_2.booking__paid_at__day
+                  , subq_2.booking__paid_at__week
+                  , subq_2.booking__paid_at__month
+                  , subq_2.booking__paid_at__quarter
+                  , subq_2.booking__paid_at__year
+                  , subq_2.booking__paid_at__extract_year
+                  , subq_2.booking__paid_at__extract_quarter
+                  , subq_2.booking__paid_at__extract_month
+                  , subq_2.booking__paid_at__extract_day
+                  , subq_2.booking__paid_at__extract_dow
+                  , subq_2.booking__paid_at__extract_doy
+                  , subq_2.ds__day AS metric_time__day
+                  , subq_2.ds__week AS metric_time__week
+                  , subq_2.ds__month AS metric_time__month
+                  , subq_2.ds__quarter AS metric_time__quarter
+                  , subq_2.ds__year AS metric_time__year
+                  , subq_2.ds__extract_year AS metric_time__extract_year
+                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_2.ds__extract_month AS metric_time__extract_month
+                  , subq_2.ds__extract_day AS metric_time__extract_day
+                  , subq_2.ds__extract_dow AS metric_time__extract_dow
+                  , subq_2.ds__extract_doy AS metric_time__extract_doy
+                  , subq_2.listing
+                  , subq_2.guest
+                  , subq_2.host
+                  , subq_2.booking__listing
+                  , subq_2.booking__guest
+                  , subq_2.booking__host
+                  , subq_2.is_instant
+                  , subq_2.booking__is_instant
+                  , subq_2.bookings
+                  , subq_2.instant_bookings
+                  , subq_2.booking_value
+                  , subq_2.max_booking_value
+                  , subq_2.min_booking_value
+                  , subq_2.bookers
+                  , subq_2.average_booking_value
+                  , subq_2.referred_bookings
+                  , subq_2.median_booking_value
+                  , subq_2.booking_value_p99
+                  , subq_2.discrete_booking_value_p99
+                  , subq_2.approximate_continuous_booking_value_p99
+                  , subq_2.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_2
+              ) subq_3
+              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_4
+          ) subq_5
+          WHERE metric_time__day > '2020-01-01'
+        ) subq_6
+        GROUP BY
+          subq_6.metric_time__day
+      ) subq_7
+      ON
+        subq_8.metric_time__day = subq_7.metric_time__day
+    ) subq_10
+    WHERE metric_time__day > '2020-01-01'
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_12

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -1,0 +1,52 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    metric_time__day
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_19.metric_time__day AS metric_time__day
+      , subq_18.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_20
+      WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_19
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+        WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_16
+      WHERE metric_time__day > '2020-01-01'
+      GROUP BY
+        metric_time__day
+    ) subq_18
+    ON
+      subq_19.metric_time__day = subq_18.metric_time__day
+  ) subq_21
+  WHERE (
+    metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+  ) AND (
+    metric_time__day > '2020-01-01'
+  )
+) subq_23

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,0 +1,352 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.bookings
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_8.metric_time__day AS metric_time__day
+        , subq_7.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_9.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_9
+        WHERE subq_9.ds BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_8
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_6.metric_time__day
+          , SUM(subq_6.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.ds_partitioned__day
+                , subq_3.ds_partitioned__week
+                , subq_3.ds_partitioned__month
+                , subq_3.ds_partitioned__quarter
+                , subq_3.ds_partitioned__year
+                , subq_3.ds_partitioned__extract_year
+                , subq_3.ds_partitioned__extract_quarter
+                , subq_3.ds_partitioned__extract_month
+                , subq_3.ds_partitioned__extract_day
+                , subq_3.ds_partitioned__extract_dow
+                , subq_3.ds_partitioned__extract_doy
+                , subq_3.paid_at__day
+                , subq_3.paid_at__week
+                , subq_3.paid_at__month
+                , subq_3.paid_at__quarter
+                , subq_3.paid_at__year
+                , subq_3.paid_at__extract_year
+                , subq_3.paid_at__extract_quarter
+                , subq_3.paid_at__extract_month
+                , subq_3.paid_at__extract_day
+                , subq_3.paid_at__extract_dow
+                , subq_3.paid_at__extract_doy
+                , subq_3.booking__ds__day
+                , subq_3.booking__ds__week
+                , subq_3.booking__ds__month
+                , subq_3.booking__ds__quarter
+                , subq_3.booking__ds__year
+                , subq_3.booking__ds__extract_year
+                , subq_3.booking__ds__extract_quarter
+                , subq_3.booking__ds__extract_month
+                , subq_3.booking__ds__extract_day
+                , subq_3.booking__ds__extract_dow
+                , subq_3.booking__ds__extract_doy
+                , subq_3.booking__ds_partitioned__day
+                , subq_3.booking__ds_partitioned__week
+                , subq_3.booking__ds_partitioned__month
+                , subq_3.booking__ds_partitioned__quarter
+                , subq_3.booking__ds_partitioned__year
+                , subq_3.booking__ds_partitioned__extract_year
+                , subq_3.booking__ds_partitioned__extract_quarter
+                , subq_3.booking__ds_partitioned__extract_month
+                , subq_3.booking__ds_partitioned__extract_day
+                , subq_3.booking__ds_partitioned__extract_dow
+                , subq_3.booking__ds_partitioned__extract_doy
+                , subq_3.booking__paid_at__day
+                , subq_3.booking__paid_at__week
+                , subq_3.booking__paid_at__month
+                , subq_3.booking__paid_at__quarter
+                , subq_3.booking__paid_at__year
+                , subq_3.booking__paid_at__extract_year
+                , subq_3.booking__paid_at__extract_quarter
+                , subq_3.booking__paid_at__extract_month
+                , subq_3.booking__paid_at__extract_day
+                , subq_3.booking__paid_at__extract_dow
+                , subq_3.booking__paid_at__extract_doy
+                , subq_3.metric_time__day
+                , subq_3.metric_time__week
+                , subq_3.metric_time__month
+                , subq_3.metric_time__quarter
+                , subq_3.metric_time__year
+                , subq_3.metric_time__extract_year
+                , subq_3.metric_time__extract_quarter
+                , subq_3.metric_time__extract_month
+                , subq_3.metric_time__extract_day
+                , subq_3.metric_time__extract_dow
+                , subq_3.metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.guest
+                , subq_3.host
+                , subq_3.booking__listing
+                , subq_3.booking__guest
+                , subq_3.booking__host
+                , subq_3.is_instant
+                , subq_3.booking__is_instant
+                , subq_3.bookings
+                , subq_3.instant_bookings
+                , subq_3.booking_value
+                , subq_3.max_booking_value
+                , subq_3.min_booking_value
+                , subq_3.bookers
+                , subq_3.average_booking_value
+                , subq_3.referred_bookings
+                , subq_3.median_booking_value
+                , subq_3.booking_value_p99
+                , subq_3.discrete_booking_value_p99
+                , subq_3.approximate_continuous_booking_value_p99
+                , subq_3.approximate_discrete_booking_value_p99
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_2.ds__day
+                  , subq_2.ds__week
+                  , subq_2.ds__month
+                  , subq_2.ds__quarter
+                  , subq_2.ds__year
+                  , subq_2.ds__extract_year
+                  , subq_2.ds__extract_quarter
+                  , subq_2.ds__extract_month
+                  , subq_2.ds__extract_day
+                  , subq_2.ds__extract_dow
+                  , subq_2.ds__extract_doy
+                  , subq_2.ds_partitioned__day
+                  , subq_2.ds_partitioned__week
+                  , subq_2.ds_partitioned__month
+                  , subq_2.ds_partitioned__quarter
+                  , subq_2.ds_partitioned__year
+                  , subq_2.ds_partitioned__extract_year
+                  , subq_2.ds_partitioned__extract_quarter
+                  , subq_2.ds_partitioned__extract_month
+                  , subq_2.ds_partitioned__extract_day
+                  , subq_2.ds_partitioned__extract_dow
+                  , subq_2.ds_partitioned__extract_doy
+                  , subq_2.paid_at__day
+                  , subq_2.paid_at__week
+                  , subq_2.paid_at__month
+                  , subq_2.paid_at__quarter
+                  , subq_2.paid_at__year
+                  , subq_2.paid_at__extract_year
+                  , subq_2.paid_at__extract_quarter
+                  , subq_2.paid_at__extract_month
+                  , subq_2.paid_at__extract_day
+                  , subq_2.paid_at__extract_dow
+                  , subq_2.paid_at__extract_doy
+                  , subq_2.booking__ds__day
+                  , subq_2.booking__ds__week
+                  , subq_2.booking__ds__month
+                  , subq_2.booking__ds__quarter
+                  , subq_2.booking__ds__year
+                  , subq_2.booking__ds__extract_year
+                  , subq_2.booking__ds__extract_quarter
+                  , subq_2.booking__ds__extract_month
+                  , subq_2.booking__ds__extract_day
+                  , subq_2.booking__ds__extract_dow
+                  , subq_2.booking__ds__extract_doy
+                  , subq_2.booking__ds_partitioned__day
+                  , subq_2.booking__ds_partitioned__week
+                  , subq_2.booking__ds_partitioned__month
+                  , subq_2.booking__ds_partitioned__quarter
+                  , subq_2.booking__ds_partitioned__year
+                  , subq_2.booking__ds_partitioned__extract_year
+                  , subq_2.booking__ds_partitioned__extract_quarter
+                  , subq_2.booking__ds_partitioned__extract_month
+                  , subq_2.booking__ds_partitioned__extract_day
+                  , subq_2.booking__ds_partitioned__extract_dow
+                  , subq_2.booking__ds_partitioned__extract_doy
+                  , subq_2.booking__paid_at__day
+                  , subq_2.booking__paid_at__week
+                  , subq_2.booking__paid_at__month
+                  , subq_2.booking__paid_at__quarter
+                  , subq_2.booking__paid_at__year
+                  , subq_2.booking__paid_at__extract_year
+                  , subq_2.booking__paid_at__extract_quarter
+                  , subq_2.booking__paid_at__extract_month
+                  , subq_2.booking__paid_at__extract_day
+                  , subq_2.booking__paid_at__extract_dow
+                  , subq_2.booking__paid_at__extract_doy
+                  , subq_2.ds__day AS metric_time__day
+                  , subq_2.ds__week AS metric_time__week
+                  , subq_2.ds__month AS metric_time__month
+                  , subq_2.ds__quarter AS metric_time__quarter
+                  , subq_2.ds__year AS metric_time__year
+                  , subq_2.ds__extract_year AS metric_time__extract_year
+                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_2.ds__extract_month AS metric_time__extract_month
+                  , subq_2.ds__extract_day AS metric_time__extract_day
+                  , subq_2.ds__extract_dow AS metric_time__extract_dow
+                  , subq_2.ds__extract_doy AS metric_time__extract_doy
+                  , subq_2.listing
+                  , subq_2.guest
+                  , subq_2.host
+                  , subq_2.booking__listing
+                  , subq_2.booking__guest
+                  , subq_2.booking__host
+                  , subq_2.is_instant
+                  , subq_2.booking__is_instant
+                  , subq_2.bookings
+                  , subq_2.instant_bookings
+                  , subq_2.booking_value
+                  , subq_2.max_booking_value
+                  , subq_2.min_booking_value
+                  , subq_2.bookers
+                  , subq_2.average_booking_value
+                  , subq_2.referred_bookings
+                  , subq_2.median_booking_value
+                  , subq_2.booking_value_p99
+                  , subq_2.discrete_booking_value_p99
+                  , subq_2.approximate_continuous_booking_value_p99
+                  , subq_2.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_2
+              ) subq_3
+              WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+            ) subq_4
+          ) subq_5
+          WHERE metric_time__day > '2020-01-01'
+        ) subq_6
+        GROUP BY
+          subq_6.metric_time__day
+      ) subq_7
+      ON
+        subq_8.metric_time__day = subq_7.metric_time__day
+    ) subq_10
+    WHERE metric_time__day > '2020-01-01'
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_12

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -1,0 +1,52 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    metric_time__day
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_19.metric_time__day AS metric_time__day
+      , subq_18.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_20
+      WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_19
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+        WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+      ) subq_16
+      WHERE metric_time__day > '2020-01-01'
+      GROUP BY
+        metric_time__day
+    ) subq_18
+    ON
+      subq_19.metric_time__day = subq_18.metric_time__day
+  ) subq_21
+  WHERE (
+    metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+  ) AND (
+    metric_time__day > '2020-01-01'
+  )
+) subq_23

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0.sql
@@ -1,0 +1,352 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_12.metric_time__day
+  , COALESCE(subq_12.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_11.metric_time__day
+    , subq_11.bookings
+  FROM (
+    -- Constrain Output with WHERE
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.bookings
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_8.metric_time__day AS metric_time__day
+        , subq_7.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_9.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_9
+        WHERE subq_9.ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+      ) subq_8
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_6.metric_time__day
+          , SUM(subq_6.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.bookings
+            FROM (
+              -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.ds_partitioned__day
+                , subq_3.ds_partitioned__week
+                , subq_3.ds_partitioned__month
+                , subq_3.ds_partitioned__quarter
+                , subq_3.ds_partitioned__year
+                , subq_3.ds_partitioned__extract_year
+                , subq_3.ds_partitioned__extract_quarter
+                , subq_3.ds_partitioned__extract_month
+                , subq_3.ds_partitioned__extract_day
+                , subq_3.ds_partitioned__extract_dow
+                , subq_3.ds_partitioned__extract_doy
+                , subq_3.paid_at__day
+                , subq_3.paid_at__week
+                , subq_3.paid_at__month
+                , subq_3.paid_at__quarter
+                , subq_3.paid_at__year
+                , subq_3.paid_at__extract_year
+                , subq_3.paid_at__extract_quarter
+                , subq_3.paid_at__extract_month
+                , subq_3.paid_at__extract_day
+                , subq_3.paid_at__extract_dow
+                , subq_3.paid_at__extract_doy
+                , subq_3.booking__ds__day
+                , subq_3.booking__ds__week
+                , subq_3.booking__ds__month
+                , subq_3.booking__ds__quarter
+                , subq_3.booking__ds__year
+                , subq_3.booking__ds__extract_year
+                , subq_3.booking__ds__extract_quarter
+                , subq_3.booking__ds__extract_month
+                , subq_3.booking__ds__extract_day
+                , subq_3.booking__ds__extract_dow
+                , subq_3.booking__ds__extract_doy
+                , subq_3.booking__ds_partitioned__day
+                , subq_3.booking__ds_partitioned__week
+                , subq_3.booking__ds_partitioned__month
+                , subq_3.booking__ds_partitioned__quarter
+                , subq_3.booking__ds_partitioned__year
+                , subq_3.booking__ds_partitioned__extract_year
+                , subq_3.booking__ds_partitioned__extract_quarter
+                , subq_3.booking__ds_partitioned__extract_month
+                , subq_3.booking__ds_partitioned__extract_day
+                , subq_3.booking__ds_partitioned__extract_dow
+                , subq_3.booking__ds_partitioned__extract_doy
+                , subq_3.booking__paid_at__day
+                , subq_3.booking__paid_at__week
+                , subq_3.booking__paid_at__month
+                , subq_3.booking__paid_at__quarter
+                , subq_3.booking__paid_at__year
+                , subq_3.booking__paid_at__extract_year
+                , subq_3.booking__paid_at__extract_quarter
+                , subq_3.booking__paid_at__extract_month
+                , subq_3.booking__paid_at__extract_day
+                , subq_3.booking__paid_at__extract_dow
+                , subq_3.booking__paid_at__extract_doy
+                , subq_3.metric_time__day
+                , subq_3.metric_time__week
+                , subq_3.metric_time__month
+                , subq_3.metric_time__quarter
+                , subq_3.metric_time__year
+                , subq_3.metric_time__extract_year
+                , subq_3.metric_time__extract_quarter
+                , subq_3.metric_time__extract_month
+                , subq_3.metric_time__extract_day
+                , subq_3.metric_time__extract_dow
+                , subq_3.metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.guest
+                , subq_3.host
+                , subq_3.booking__listing
+                , subq_3.booking__guest
+                , subq_3.booking__host
+                , subq_3.is_instant
+                , subq_3.booking__is_instant
+                , subq_3.bookings
+                , subq_3.instant_bookings
+                , subq_3.booking_value
+                , subq_3.max_booking_value
+                , subq_3.min_booking_value
+                , subq_3.bookers
+                , subq_3.average_booking_value
+                , subq_3.referred_bookings
+                , subq_3.median_booking_value
+                , subq_3.booking_value_p99
+                , subq_3.discrete_booking_value_p99
+                , subq_3.approximate_continuous_booking_value_p99
+                , subq_3.approximate_discrete_booking_value_p99
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_2.ds__day
+                  , subq_2.ds__week
+                  , subq_2.ds__month
+                  , subq_2.ds__quarter
+                  , subq_2.ds__year
+                  , subq_2.ds__extract_year
+                  , subq_2.ds__extract_quarter
+                  , subq_2.ds__extract_month
+                  , subq_2.ds__extract_day
+                  , subq_2.ds__extract_dow
+                  , subq_2.ds__extract_doy
+                  , subq_2.ds_partitioned__day
+                  , subq_2.ds_partitioned__week
+                  , subq_2.ds_partitioned__month
+                  , subq_2.ds_partitioned__quarter
+                  , subq_2.ds_partitioned__year
+                  , subq_2.ds_partitioned__extract_year
+                  , subq_2.ds_partitioned__extract_quarter
+                  , subq_2.ds_partitioned__extract_month
+                  , subq_2.ds_partitioned__extract_day
+                  , subq_2.ds_partitioned__extract_dow
+                  , subq_2.ds_partitioned__extract_doy
+                  , subq_2.paid_at__day
+                  , subq_2.paid_at__week
+                  , subq_2.paid_at__month
+                  , subq_2.paid_at__quarter
+                  , subq_2.paid_at__year
+                  , subq_2.paid_at__extract_year
+                  , subq_2.paid_at__extract_quarter
+                  , subq_2.paid_at__extract_month
+                  , subq_2.paid_at__extract_day
+                  , subq_2.paid_at__extract_dow
+                  , subq_2.paid_at__extract_doy
+                  , subq_2.booking__ds__day
+                  , subq_2.booking__ds__week
+                  , subq_2.booking__ds__month
+                  , subq_2.booking__ds__quarter
+                  , subq_2.booking__ds__year
+                  , subq_2.booking__ds__extract_year
+                  , subq_2.booking__ds__extract_quarter
+                  , subq_2.booking__ds__extract_month
+                  , subq_2.booking__ds__extract_day
+                  , subq_2.booking__ds__extract_dow
+                  , subq_2.booking__ds__extract_doy
+                  , subq_2.booking__ds_partitioned__day
+                  , subq_2.booking__ds_partitioned__week
+                  , subq_2.booking__ds_partitioned__month
+                  , subq_2.booking__ds_partitioned__quarter
+                  , subq_2.booking__ds_partitioned__year
+                  , subq_2.booking__ds_partitioned__extract_year
+                  , subq_2.booking__ds_partitioned__extract_quarter
+                  , subq_2.booking__ds_partitioned__extract_month
+                  , subq_2.booking__ds_partitioned__extract_day
+                  , subq_2.booking__ds_partitioned__extract_dow
+                  , subq_2.booking__ds_partitioned__extract_doy
+                  , subq_2.booking__paid_at__day
+                  , subq_2.booking__paid_at__week
+                  , subq_2.booking__paid_at__month
+                  , subq_2.booking__paid_at__quarter
+                  , subq_2.booking__paid_at__year
+                  , subq_2.booking__paid_at__extract_year
+                  , subq_2.booking__paid_at__extract_quarter
+                  , subq_2.booking__paid_at__extract_month
+                  , subq_2.booking__paid_at__extract_day
+                  , subq_2.booking__paid_at__extract_dow
+                  , subq_2.booking__paid_at__extract_doy
+                  , subq_2.ds__day AS metric_time__day
+                  , subq_2.ds__week AS metric_time__week
+                  , subq_2.ds__month AS metric_time__month
+                  , subq_2.ds__quarter AS metric_time__quarter
+                  , subq_2.ds__year AS metric_time__year
+                  , subq_2.ds__extract_year AS metric_time__extract_year
+                  , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_2.ds__extract_month AS metric_time__extract_month
+                  , subq_2.ds__extract_day AS metric_time__extract_day
+                  , subq_2.ds__extract_dow AS metric_time__extract_dow
+                  , subq_2.ds__extract_doy AS metric_time__extract_doy
+                  , subq_2.listing
+                  , subq_2.guest
+                  , subq_2.host
+                  , subq_2.booking__listing
+                  , subq_2.booking__guest
+                  , subq_2.booking__host
+                  , subq_2.is_instant
+                  , subq_2.booking__is_instant
+                  , subq_2.bookings
+                  , subq_2.instant_bookings
+                  , subq_2.booking_value
+                  , subq_2.max_booking_value
+                  , subq_2.min_booking_value
+                  , subq_2.bookers
+                  , subq_2.average_booking_value
+                  , subq_2.referred_bookings
+                  , subq_2.median_booking_value
+                  , subq_2.booking_value_p99
+                  , subq_2.discrete_booking_value_p99
+                  , subq_2.approximate_continuous_booking_value_p99
+                  , subq_2.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_2
+              ) subq_3
+              WHERE subq_3.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+            ) subq_4
+          ) subq_5
+          WHERE metric_time__day > '2020-01-01'
+        ) subq_6
+        GROUP BY
+          subq_6.metric_time__day
+      ) subq_7
+      ON
+        subq_8.metric_time__day = subq_7.metric_time__day
+    ) subq_10
+    WHERE metric_time__day > '2020-01-01'
+  ) subq_11
+  WHERE subq_11.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+) subq_12

--- a/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -1,0 +1,52 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    metric_time__day
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_19.metric_time__day AS metric_time__day
+      , subq_18.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_20
+      WHERE ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+    ) subq_19
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+        WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+      ) subq_16
+      WHERE metric_time__day > '2020-01-01'
+      GROUP BY
+        metric_time__day
+    ) subq_18
+    ON
+      subq_19.metric_time__day = subq_18.metric_time__day
+  ) subq_21
+  WHERE (
+    metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+  ) AND (
+    metric_time__day > '2020-01-01'
+  )
+) subq_23


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves #1039 
Completes SL-1732

### Description
For queries using measures that join to time spine, filters were being applied before the time spine join, but not after. This means that there might be additional rows added from the time spine join that should be removed by the filters, resulting in unexpected rows in the output data. Here, we update the DataFlow Plan to apply those filters again after the time spine join, ensuring there will be no unexpected rows in the result.
Note: this means the filters are applied multiple times, which is redundant for the final output but ideally results in a more efficient query.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
