### PR TITLE
Tests for min/max with `metric_time`

### DIFF
--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -25,7 +25,7 @@ from metricflow.specs.specs import (
 from metricflow.test.dataflow_plan_to_svg import display_graph_if_requested
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.snapshot_utils import assert_plan_snapshot_text_equal
-from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_MONTH, MTD_SPEC_QUARTER
+from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_MONTH, MTD_SPEC_QUARTER, MTD_SPEC_WEEK
 
 logger = logging.getLogger(__name__)
 
@@ -1117,4 +1117,55 @@ def test_min_max_only_time_year(
     )
 
 
-# TODO: add test for min max metric_time (various granularities) when supported
+def test_min_max_metric_time(
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+) -> None:
+    """Tests a plan to get the min & max distinct values of metric_time."""
+    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
+        query_spec=MetricFlowQuerySpec(
+            time_dimension_specs=(MTD_SPEC_DAY,),
+            min_max_only=True,
+        )
+    )
+
+    assert_plan_snapshot_text_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        plan=dataflow_plan,
+        plan_snapshot_text=dataflow_plan.text_structure(),
+    )
+
+    display_graph_if_requested(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dag_graph=dataflow_plan,
+    )
+
+
+def test_min_max_metric_time_week(
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+) -> None:
+    """Tests a plan to get the min & max distinct values of metric_time with non-default granularity."""
+    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
+        query_spec=MetricFlowQuerySpec(
+            time_dimension_specs=(MTD_SPEC_WEEK,),
+            min_max_only=True,
+        )
+    )
+
+    assert_plan_snapshot_text_equal(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        plan=dataflow_plan,
+        plan_snapshot_text=dataflow_plan.text_structure(),
+    )
+
+    display_graph_if_requested(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dag_graph=dataflow_plan,
+    )

--- a/metricflow/test/query_rendering/test_query_rendering.py
+++ b/metricflow/test/query_rendering/test_query_rendering.py
@@ -5,6 +5,7 @@ a MetricFlow query input and end up with a query rendered for execution against 
 target engine. This will depend on test semantic manifests and engine-specific rendering
 logic as propagated via the SqlClient input.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -30,7 +31,7 @@ from metricflow.specs.specs import (
 )
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
 from metricflow.test.query_rendering.compare_rendered_query import convert_and_check
-from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
+from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_WEEK
 
 
 @pytest.mark.sql_engine_snapshot
@@ -522,6 +523,56 @@ def test_min_max_only_time_quarter(
             ),
             min_max_only=True,
         ),
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_min_max_metric_time(
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    sql_client: SqlClient,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+) -> None:
+    """Tests a plan to get the min & max distinct values of metric_time."""
+    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
+        query_spec=MetricFlowQuerySpec(
+            time_dimension_specs=(MTD_SPEC_DAY,),
+            min_max_only=True,
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_session_state=mf_test_session_state,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_output_nodes[0].parent_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_min_max_metric_time_week(
+    request: FixtureRequest,
+    mf_test_session_state: MetricFlowTestSessionState,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    sql_client: SqlClient,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+) -> None:
+    """Tests a plan to get the min & max distinct values of metric_time with non-default granularity."""
+    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
+        query_spec=MetricFlowQuerySpec(
+            time_dimension_specs=(MTD_SPEC_WEEK,),
+            min_max_only=True,
+        )
     )
 
     convert_and_check(

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time__dfp_0.xml
@@ -1,0 +1,26 @@
+<DataflowPlan>
+    <WriteToResultDataframeNode>
+        <!-- description = 'Write to Dataframe' -->
+        <!-- node_id = NodeId(id_str='wrd_0') -->
+        <MinMaxNode>
+            <!-- description = 'Calculate min and max' -->
+            <!-- node_id = NodeId(id_str='mm_0') -->
+            <FilterElementsNode>
+                <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
+                <!-- node_id = NodeId(id_str='pfe_0') -->
+                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                <!-- distinct = True -->
+                <MetricTimeDimensionTransformNode>
+                    <!-- description = "Metric Time Dimension 'ds'" -->
+                    <!-- node_id = NodeId(id_str='sma_28000') -->
+                    <!-- aggregation_time_dimension = 'ds' -->
+                    <ReadSqlSourceNode>
+                        <!-- description = 'Read From SqlDataSet()' -->
+                        <!-- node_id = NodeId(id_str='rss_28012') -->
+                        <!-- data_set = SqlDataSet() -->
+                    </ReadSqlSourceNode>
+                </MetricTimeDimensionTransformNode>
+            </FilterElementsNode>
+        </MinMaxNode>
+    </WriteToResultDataframeNode>
+</DataflowPlan>

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time_week__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time_week__dfp_0.xml
@@ -1,0 +1,26 @@
+<DataflowPlan>
+    <WriteToResultDataframeNode>
+        <!-- description = 'Write to Dataframe' -->
+        <!-- node_id = NodeId(id_str='wrd_0') -->
+        <MinMaxNode>
+            <!-- description = 'Calculate min and max' -->
+            <!-- node_id = NodeId(id_str='mm_0') -->
+            <FilterElementsNode>
+                <!-- description = "Pass Only Elements: ['metric_time__week',]" -->
+                <!-- node_id = NodeId(id_str='pfe_0') -->
+                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=WEEK) -->
+                <!-- distinct = True -->
+                <MetricTimeDimensionTransformNode>
+                    <!-- description = "Metric Time Dimension 'ds'" -->
+                    <!-- node_id = NodeId(id_str='sma_28000') -->
+                    <!-- aggregation_time_dimension = 'ds' -->
+                    <ReadSqlSourceNode>
+                        <!-- description = 'Read From SqlDataSet()' -->
+                        <!-- node_id = NodeId(id_str='rss_28012') -->
+                        <!-- data_set = SqlDataSet() -->
+                    </ReadSqlSourceNode>
+                </MetricTimeDimensionTransformNode>
+            </FilterElementsNode>
+        </MinMaxNode>
+    </WriteToResultDataframeNode>
+</DataflowPlan>

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__day) AS metric_time__day__min
+  , MAX(subq_2.metric_time__day) AS metric_time__day__max
+FROM (
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    subq_1.metric_time__day
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC(time_spine_src_28000.ds, day) AS ds__day
+        , DATE_TRUNC(time_spine_src_28000.ds, isoweek) AS ds__week
+        , DATE_TRUNC(time_spine_src_28000.ds, month) AS ds__month
+        , DATE_TRUNC(time_spine_src_28000.ds, quarter) AS ds__quarter
+        , DATE_TRUNC(time_spine_src_28000.ds, year) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , IF(EXTRACT(dayofweek FROM time_spine_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_28000.ds) - 1) AS ds__extract_dow
+        , EXTRACT(dayofyear FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    metric_time__day
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__day) AS metric_time__day__min
+  , MAX(metric_time__day) AS metric_time__day__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    DATE_TRUNC(ds, day) AS metric_time__day
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    metric_time__day
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time_week__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time_week__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__week) AS metric_time__week__min
+  , MAX(subq_2.metric_time__week) AS metric_time__week__max
+FROM (
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    subq_1.metric_time__week
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC(time_spine_src_28000.ds, day) AS ds__day
+        , DATE_TRUNC(time_spine_src_28000.ds, isoweek) AS ds__week
+        , DATE_TRUNC(time_spine_src_28000.ds, month) AS ds__month
+        , DATE_TRUNC(time_spine_src_28000.ds, quarter) AS ds__quarter
+        , DATE_TRUNC(time_spine_src_28000.ds, year) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , IF(EXTRACT(dayofweek FROM time_spine_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM time_spine_src_28000.ds) - 1) AS ds__extract_dow
+        , EXTRACT(dayofyear FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    metric_time__week
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_min_max_metric_time_week__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__week) AS metric_time__week__min
+  , MAX(metric_time__week) AS metric_time__week__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    DATE_TRUNC(ds, isoweek) AS metric_time__week
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    metric_time__week
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__day) AS metric_time__day__min
+  , MAX(subq_2.metric_time__day) AS metric_time__day__max
+FROM (
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    subq_1.metric_time__day
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_28000.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__day
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__day) AS metric_time__day__min
+  , MAX(metric_time__day) AS metric_time__day__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('day', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time_week__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time_week__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__week) AS metric_time__week__min
+  , MAX(subq_2.metric_time__week) AS metric_time__week__max
+FROM (
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    subq_1.metric_time__week
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , EXTRACT(DAYOFWEEK_ISO FROM time_spine_src_28000.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__week
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_min_max_metric_time_week__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__week) AS metric_time__week__min
+  , MAX(metric_time__week) AS metric_time__week__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    DATE_TRUNC('week', ds) AS metric_time__week
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('week', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__day) AS metric_time__day__min
+  , MAX(subq_2.metric_time__day) AS metric_time__day__max
+FROM (
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    subq_1.metric_time__day
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__day
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__day) AS metric_time__day__min
+  , MAX(metric_time__day) AS metric_time__day__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('day', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time_week__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time_week__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__week) AS metric_time__week__min
+  , MAX(subq_2.metric_time__week) AS metric_time__week__max
+FROM (
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    subq_1.metric_time__week
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__week
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_min_max_metric_time_week__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__week) AS metric_time__week__min
+  , MAX(metric_time__week) AS metric_time__week__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    DATE_TRUNC('week', ds) AS metric_time__week
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('week', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__day) AS metric_time__day__min
+  , MAX(subq_2.metric_time__day) AS metric_time__day__max
+FROM (
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    subq_1.metric_time__day
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__day
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__day) AS metric_time__day__min
+  , MAX(metric_time__day) AS metric_time__day__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('day', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time_week__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time_week__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__week) AS metric_time__week__min
+  , MAX(subq_2.metric_time__week) AS metric_time__week__max
+FROM (
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    subq_1.metric_time__week
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , EXTRACT(isodow FROM time_spine_src_28000.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__week
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_min_max_metric_time_week__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__week) AS metric_time__week__min
+  , MAX(metric_time__week) AS metric_time__week__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    DATE_TRUNC('week', ds) AS metric_time__week
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('week', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__day) AS metric_time__day__min
+  , MAX(subq_2.metric_time__day) AS metric_time__day__max
+FROM (
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    subq_1.metric_time__day
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , CASE WHEN EXTRACT(dow FROM time_spine_src_28000.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_28000.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_28000.ds) END AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__day
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__day) AS metric_time__day__min
+  , MAX(metric_time__day) AS metric_time__day__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('day', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time_week__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time_week__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__week) AS metric_time__week__min
+  , MAX(subq_2.metric_time__week) AS metric_time__week__max
+FROM (
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    subq_1.metric_time__week
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , CASE WHEN EXTRACT(dow FROM time_spine_src_28000.ds) = 0 THEN EXTRACT(dow FROM time_spine_src_28000.ds) + 7 ELSE EXTRACT(dow FROM time_spine_src_28000.ds) END AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__week
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_min_max_metric_time_week__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__week) AS metric_time__week__min
+  , MAX(metric_time__week) AS metric_time__week__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    DATE_TRUNC('week', ds) AS metric_time__week
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('week', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__day) AS metric_time__day__min
+  , MAX(subq_2.metric_time__day) AS metric_time__day__max
+FROM (
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    subq_1.metric_time__day
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , EXTRACT(dayofweekiso FROM time_spine_src_28000.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__day
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__day) AS metric_time__day__min
+  , MAX(metric_time__day) AS metric_time__day__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('day', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time_week__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time_week__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__week) AS metric_time__week__min
+  , MAX(subq_2.metric_time__week) AS metric_time__week__max
+FROM (
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    subq_1.metric_time__week
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , EXTRACT(dayofweekiso FROM time_spine_src_28000.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__week
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_min_max_metric_time_week__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__week) AS metric_time__week__min
+  , MAX(metric_time__week) AS metric_time__week__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    DATE_TRUNC('week', ds) AS metric_time__week
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('week', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__day) AS metric_time__day__min
+  , MAX(subq_2.metric_time__day) AS metric_time__day__max
+FROM (
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    subq_1.metric_time__day
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , EXTRACT(DAY_OF_WEEK FROM time_spine_src_28000.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__day
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__day) AS metric_time__day__min
+  , MAX(metric_time__day) AS metric_time__day__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__day',]
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('day', ds)
+) subq_5

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time_week__plan0.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time_week__plan0.sql
@@ -1,0 +1,53 @@
+-- Calculate min and max
+SELECT
+  MIN(subq_2.metric_time__week) AS metric_time__week__min
+  , MAX(subq_2.metric_time__week) AS metric_time__week__max
+FROM (
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    subq_1.metric_time__week
+  FROM (
+    -- Metric Time Dimension 'ds'
+    SELECT
+      subq_0.ds__day
+      , subq_0.ds__week
+      , subq_0.ds__month
+      , subq_0.ds__quarter
+      , subq_0.ds__year
+      , subq_0.ds__extract_year
+      , subq_0.ds__extract_quarter
+      , subq_0.ds__extract_month
+      , subq_0.ds__extract_day
+      , subq_0.ds__extract_dow
+      , subq_0.ds__extract_doy
+      , subq_0.ds__day AS metric_time__day
+      , subq_0.ds__week AS metric_time__week
+      , subq_0.ds__month AS metric_time__month
+      , subq_0.ds__quarter AS metric_time__quarter
+      , subq_0.ds__year AS metric_time__year
+      , subq_0.ds__extract_year AS metric_time__extract_year
+      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+      , subq_0.ds__extract_month AS metric_time__extract_month
+      , subq_0.ds__extract_day AS metric_time__extract_day
+      , subq_0.ds__extract_dow AS metric_time__extract_dow
+      , subq_0.ds__extract_doy AS metric_time__extract_doy
+    FROM (
+      -- Time Spine
+      SELECT
+        DATE_TRUNC('day', time_spine_src_28000.ds) AS ds__day
+        , DATE_TRUNC('week', time_spine_src_28000.ds) AS ds__week
+        , DATE_TRUNC('month', time_spine_src_28000.ds) AS ds__month
+        , DATE_TRUNC('quarter', time_spine_src_28000.ds) AS ds__quarter
+        , DATE_TRUNC('year', time_spine_src_28000.ds) AS ds__year
+        , EXTRACT(year FROM time_spine_src_28000.ds) AS ds__extract_year
+        , EXTRACT(quarter FROM time_spine_src_28000.ds) AS ds__extract_quarter
+        , EXTRACT(month FROM time_spine_src_28000.ds) AS ds__extract_month
+        , EXTRACT(day FROM time_spine_src_28000.ds) AS ds__extract_day
+        , EXTRACT(DAY_OF_WEEK FROM time_spine_src_28000.ds) AS ds__extract_dow
+        , EXTRACT(doy FROM time_spine_src_28000.ds) AS ds__extract_doy
+      FROM ***************************.mf_time_spine time_spine_src_28000
+    ) subq_0
+  ) subq_1
+  GROUP BY
+    subq_1.metric_time__week
+) subq_2

--- a/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time_week__plan0_optimized.sql
+++ b/metricflow/test/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_min_max_metric_time_week__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Calculate min and max
+SELECT
+  MIN(metric_time__week) AS metric_time__week__min
+  , MAX(metric_time__week) AS metric_time__week__max
+FROM (
+  -- Time Spine
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['metric_time__week',]
+  SELECT
+    DATE_TRUNC('week', ds) AS metric_time__week
+  FROM ***************************.mf_time_spine time_spine_src_28000
+  GROUP BY
+    DATE_TRUNC('week', ds)
+) subq_5


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves SL-1808


### Description
Resolves a #TODO that I left in here a while back. Test cases combining min/max query with `metric_time` only. (These features were worked on in parallel, so I couldn't add tests until they both merged.)
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
