### PR TITLE
Improve error message for metrics with no parents

### DIFF
--- a/.changes/unreleased/Fixes-20240229-112831.yaml
+++ b/.changes/unreleased/Fixes-20240229-112831.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Improve error message for metrics/queries with missing inputs
+time: 2024-02-29T11:28:31.939604-08:00
+custom:
+  Author: tlento
+  Issue: "1051"

--- a/metricflow/query/group_by_item/candidate_push_down/group_by_item_candidate.py
+++ b/metricflow/query/group_by_item/candidate_push_down/group_by_item_candidate.py
@@ -49,7 +49,7 @@ class GroupByItemCandidateSet(PathPrefixable):
         where the new candidate set was created.
         """
         specs_as_sets = tuple(set(candidate_set.specs) for candidate_set in candidate_sets)
-        common_specs = set.intersection(*specs_as_sets)
+        common_specs = set.intersection(*specs_as_sets) if specs_as_sets else set()
         if len(common_specs) == 0:
             return GroupByItemCandidateSet.empty_instance()
 

--- a/metricflow/query/group_by_item/candidate_push_down/push_down_visitor.py
+++ b/metricflow/query/group_by_item/candidate_push_down/push_down_visitor.py
@@ -37,6 +37,7 @@ from metricflow.query.issues.group_by_item_resolver.no_matching_items_for_measur
 from metricflow.query.issues.group_by_item_resolver.no_matching_items_for_no_metrics_query import (
     NoMatchingItemsForNoMetricsQuery,
 )
+from metricflow.query.issues.group_by_item_resolver.no_parent_candidates import NoParentCandidates
 from metricflow.query.issues.issues_base import (
     MetricFlowQueryResolutionIssueSet,
 )
@@ -253,6 +254,12 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
         merged_issue_set: MetricFlowQueryResolutionIssueSet = MetricFlowQueryResolutionIssueSet.merge_iterable(
             parent_candidate_set.issue_set for parent_candidate_set in push_down_results_from_parents.values()
         )
+        if len(push_down_results_from_parents) == 0:
+            # If there are no results of any kind from the parents it means there are no parents, which means
+            # something is likely wrong with the semantic manifest or the query construction itself
+            merged_issue_set = merged_issue_set.add_issue(
+                NoParentCandidates.from_parameters(query_resolution_path=current_traversal_path)
+            )
 
         if merged_issue_set.has_errors:
             return PushDownResult(

--- a/metricflow/query/issues/group_by_item_resolver/no_parent_candidates.py
+++ b/metricflow/query/issues/group_by_item_resolver/no_parent_candidates.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from typing_extensions import override
+
+from metricflow.query.group_by_item.resolution_path import MetricFlowQueryResolutionPath
+from metricflow.query.issues.issues_base import (
+    MetricFlowQueryIssueType,
+    MetricFlowQueryResolutionIssue,
+)
+from metricflow.query.resolver_inputs.base_resolver_inputs import MetricFlowQueryResolverInput
+
+
+@dataclass(frozen=True)
+class NoParentCandidates(MetricFlowQueryResolutionIssue):
+    """Describes an issue during group-by-item resolution where parents don't have any candidates that match a pattern.
+
+    This most likely indicates a problem with either the query or the model where a given input is supposed to have
+    parent nodes, but does not. For example, a derived metric with no defined metrics or measures as inputs would not
+    be resolvable since it requires parent resolution, but no parents are given. While these issues should be caught
+    in validation, they may slip through the cracks, and so we raise a more helpful user-facing error in these cases.
+    """
+
+    @staticmethod
+    def from_parameters(  # noqa: D
+        query_resolution_path: MetricFlowQueryResolutionPath,
+    ) -> NoParentCandidates:
+        return NoParentCandidates(
+            issue_type=MetricFlowQueryIssueType.ERROR,
+            query_resolution_path=query_resolution_path,
+            parent_issues=tuple(),
+        )
+
+    @override
+    def ui_description(self, associated_input: MetricFlowQueryResolverInput) -> str:
+        last_path_item = self.query_resolution_path.last_item
+
+        return (
+            f"{last_path_item.ui_description} is a node that requires certain inputs, but none were specified.\n\n"
+            "This most likely indicates a problem with the semantic manifest, such as a derived metric with no "
+            "inputs, or else a missing query input parameter. If this proves to be the case, please open an issue "
+            "for us to improve our input validation processes."
+        )
+
+    @override
+    def with_path_prefix(self, path_prefix: MetricFlowQueryResolutionPath) -> NoParentCandidates:
+        return NoParentCandidates(
+            issue_type=self.issue_type,
+            parent_issues=tuple(),
+            query_resolution_path=self.query_resolution_path.with_path_prefix(path_prefix),
+        )

--- a/metricflow/test/snapshots/test_matching_item_for_querying.py/AvailableGroupByItemsResolution/test_missing_parent_for_metric__result.txt
+++ b/metricflow/test/snapshots/test_matching_item_for_querying.py/AvailableGroupByItemsResolution/test_missing_parent_for_metric__result.txt
@@ -1,0 +1,12 @@
+AvailableGroupByItemsResolution(
+  issue_set=MetricFlowQueryResolutionIssueSet(
+    issues=(
+      NoParentCandidates(
+        issue_type=ERROR,
+        query_resolution_path=MetricFlowQueryResolutionPath(
+          resolution_path_nodes=(MetricGroupByItemResolutionNode(node_id=mtr_0),),
+        ),
+      ),
+    ),
+  ),
+)


### PR DESCRIPTION
Due to a gap in our upstream model validation it is possible for
a user to define a derived metric with no inputs. This causes a
fall-through error to trigger of the form `unbound method
set.intersection needs an argument`.

The root cause of this is our use of the `*` operator for expanding
an iterable into a set of values. If the iterable is empty, Python
will simply pass nothing - not None, but nothing at all. This means
any call like `set.intersection(*input)` will raise this strange error
if `input` is empty.

This change does two things to resolve this issue:

1. It updates the set.intersection(*input) call to a more robust
approach, which will return an empty set if the input is empty
2. It updates the invocation to check for empty input and include
a more refined error issue indicating the root cause.

The reason we do it this way is the offending call is inside of
a more generic helper, so we allow the helper to accept empty
input and return correspondingly empty output, but at the callsite
where we know the input should not be empty and that empty input
indicates a configuration issue we raise the appropriate error.