### PR TITLE
Switch dbt-metricflow from ~= to >=/< for dependency versions

### DIFF
--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "dbt-core~=1.7.4",
-  "metricflow~=0.204.0"
+  "dbt-core>=1.7.4, <1.8.0",
+  "metricflow>=0.204.0, <0.205.0"
 ]
 
 [project.urls]
@@ -33,25 +33,25 @@ dependencies = [
 
 [project.optional-dependencies]
 bigquery = [
-  "dbt-bigquery~=1.7.0"
+  "dbt-bigquery>=1.7.0, <1.8.0"
 ]
 databricks = [
-  "dbt-databricks~=1.7.0"
+  "dbt-databricks>=1.7.0, <1.8.0"
 ]
 duckdb = [
-  "dbt-duckdb~=1.7.0"
+  "dbt-duckdb>=1.7.0, <1.8.0"
 ]
 postgres = [
-  "dbt-postgres~=1.7.0"
+  "dbt-postgres>=1.7.0, <1.8.0"
 ]
 redshift = [
-  "dbt-redshift~=1.7.0"
+  "dbt-redshift>=1.7.0, <1.8.0"
 ]
 snowflake = [
-  "dbt-snowflake~=1.7.0"
+  "dbt-snowflake>=1.7.0, <1.8.0"
 ]
 trino = [
-  "dbt-trino~=1.7.0"
+  "dbt-trino>=1.7.0, <1.8.0"
 ]
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
Due to some strange inconsitencies in how pip resolves `~=`
dependency version specifications, we are switching all of our
packages to use the more explicit `>=` and `<` notation.