### PR TITLE
Make Dataflow Nodes Immutable

### DIFF
--- a/metricflow/dag/mf_dag.py
+++ b/metricflow/dag/mf_dag.py
@@ -7,7 +7,7 @@ import logging
 import textwrap
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Generic, List, Sequence, TypeVar
+from typing import Any, Generic, Sequence, TypeVar
 
 import jinja2
 
@@ -70,12 +70,12 @@ class DagNode(ABC):
         pass
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:
         """When the node is represented in a visualization, the properties to display with it."""
-        return [
+        return (
             DisplayedProperty("description", self.description),
             DisplayedProperty("node_id", self.node_id),
-        ]
+        )
 
     @property
     def graphviz_label(self) -> str:
@@ -117,7 +117,7 @@ class DagNode(ABC):
 
 
 def make_graphviz_label(
-    title: str, properties: List[DisplayedProperty], title_font_size: int = 12, property_font_size: int = 6
+    title: str, properties: Sequence[DisplayedProperty], title_font_size: int = 12, property_font_size: int = 6
 ) -> str:
     """Make a graphviz label that can be used for rendering to an image.
 
@@ -181,16 +181,16 @@ DagNodeT = TypeVar("DagNodeT", bound=DagNode)
 class MetricFlowDag(Generic[DagNodeT]):  # noqa: D
     """Represents a directed acyclic graph. The sink nodes will have the connected components."""
 
-    def __init__(self, dag_id: DagId, sink_nodes: List[DagNodeT]):  # noqa: D
+    def __init__(self, dag_id: DagId, sink_nodes: Sequence[DagNodeT]):  # noqa: D
         self._dag_id = dag_id
-        self._sink_nodes = sink_nodes
+        self._sink_nodes = tuple(sink_nodes)
 
     @property
     def dag_id(self) -> DagId:  # noqa: D
         return self._dag_id
 
     @property
-    def sink_nodes(self) -> List[DagNodeT]:  # noqa: D
+    def sink_nodes(self) -> Sequence[DagNodeT]:  # noqa: D
         return self._sink_nodes
 
     def text_structure(self, formatter: MetricFlowDagTextFormatter = MetricFlowDagTextFormatter()) -> str:

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -225,9 +225,7 @@ class ReadSqlSourceNode(BaseOutput):
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [
-            DisplayedProperty("data_set", self.data_set),
-        ]
+        return tuple(super().displayed_properties) + (DisplayedProperty("data_set", self.data_set),)
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
         return isinstance(other_node, self.__class__) and other_node.data_set == self.data_set
@@ -309,10 +307,10 @@ class JoinToBaseOutputNode(BaseOutput):
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [
+        return tuple(super().displayed_properties) + tuple(
             DisplayedProperty(f"join{i}_for_node_id_{join_description.join_node.node_id}", join_description)
             for i, join_description in enumerate(self._join_targets)
-        ]
+        )
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
         if not isinstance(other_node, self.__class__) or len(self.join_targets) != len(other_node.join_targets):
@@ -733,14 +731,14 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [
+        return tuple(super().displayed_properties) + (
             DisplayedProperty("requested_agg_time_dimension_specs", self._requested_agg_time_dimension_specs),
             DisplayedProperty("use_custom_agg_time_dimension", self._use_custom_agg_time_dimension),
             DisplayedProperty("time_range_constraint", self._time_range_constraint),
             DisplayedProperty("offset_window", self._offset_window),
             DisplayedProperty("offset_to_grain", self._offset_to_grain),
             DisplayedProperty("join_type", self._join_type),
-        ]
+        )
 
     @property
     def parent_node(self) -> BaseOutput:  # noqa: D
@@ -802,9 +800,9 @@ class ComputeMetricsNode(ComputedMetricsOutput):
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [
+        return tuple(super().displayed_properties) + tuple(
             DisplayedProperty("metric_spec", metric_spec) for metric_spec in self._metric_specs
-        ]
+        )
 
     @property
     def parent_node(self) -> BaseOutput:  # noqa: D
@@ -874,9 +872,9 @@ class OrderByLimitNode(ComputedMetricsOutput):
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
         return (
-            super().displayed_properties
-            + [DisplayedProperty("order_by_spec", order_by_spec) for order_by_spec in self._order_by_specs]
-            + [DisplayedProperty("limit", str(self.limit))]
+            tuple(super().displayed_properties)
+            + tuple(DisplayedProperty("order_by_spec", order_by_spec) for order_by_spec in self._order_by_specs)
+            + (DisplayedProperty("limit", str(self.limit)),)
         )
 
     @property
@@ -938,9 +936,9 @@ class MetricTimeDimensionTransformNode(BaseOutput):
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [
-            DisplayedProperty("aggregation_time_dimension", self.aggregation_time_dimension_reference.element_name)
-        ]
+        return tuple(super().displayed_properties) + (
+            DisplayedProperty("aggregation_time_dimension", self.aggregation_time_dimension_reference.element_name),
+        )
 
     @property
     def parent_node(self) -> BaseOutput:  # noqa: D
@@ -1112,12 +1110,14 @@ class FilterElementsNode(BaseOutput):
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
-        additional_properties = []
+        additional_properties: Tuple[DisplayedProperty, ...] = ()
         if not self._replace_description:
-            additional_properties = [
+            additional_properties = tuple(
                 DisplayedProperty("include_spec", include_spec) for include_spec in self._include_specs.all_specs
-            ] + [DisplayedProperty("distinct", self._distinct)]
-        return super().displayed_properties + additional_properties
+            ) + (
+                DisplayedProperty("distinct", self._distinct),
+            )
+        return tuple(super().displayed_properties) + additional_properties
 
     @property
     def parent_node(self) -> BaseOutput:  # noqa: D
@@ -1172,7 +1172,7 @@ class WhereConstraintNode(AggregatedMeasuresOutput):
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [DisplayedProperty("where_condition", self.where)]
+        return tuple(super().displayed_properties) + (DisplayedProperty("where_condition", self.where),)
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
         return isinstance(other_node, self.__class__) and other_node.where == self.where
@@ -1253,10 +1253,10 @@ class ConstrainTimeRangeNode(AggregatedMeasuresOutput, BaseOutput):
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [
+        return tuple(super().displayed_properties) + (
             DisplayedProperty("time_range_start", self.time_range_constraint.start_time.isoformat()),
             DisplayedProperty("time_range_end", self.time_range_constraint.end_time.isoformat()),
-        ]
+        )
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
         return isinstance(other_node, self.__class__) and self.time_range_constraint == other_node.time_range_constraint
@@ -1429,18 +1429,18 @@ class JoinConversionEventsNode(BaseOutput):
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
         return (
-            super().displayed_properties
-            + [
+            tuple(super().displayed_properties)
+            + (
                 DisplayedProperty("base_time_dimension_spec", self.base_time_dimension_spec),
                 DisplayedProperty("conversion_time_dimension_spec", self.conversion_time_dimension_spec),
                 DisplayedProperty("entity_spec", self.entity_spec),
                 DisplayedProperty("window", self.window),
-            ]
-            + [DisplayedProperty("unique_key_specs", unique_spec) for unique_spec in self.unique_identifier_keys]
-            + [
+            )
+            + tuple(DisplayedProperty("unique_key_specs", unique_spec) for unique_spec in self.unique_identifier_keys)
+            + tuple(
                 DisplayedProperty("constant_property", constant_property)
                 for constant_property in self.constant_properties or []
-            ]
+            )
         )
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
@@ -1478,7 +1478,8 @@ class DataflowPlan(MetricFlowDag[SinkOutput]):
             raise RuntimeError("Can't create a dataflow plan without sink node(s).")
         self._sink_output_nodes = tuple(sink_output_nodes)
         super().__init__(
-            dag_id=plan_id or DagId.from_id_prefix(StaticIdPrefix.DATAFLOW_PLAN_PREFIX), sink_nodes=sink_output_nodes
+            dag_id=plan_id or DagId.from_id_prefix(StaticIdPrefix.DATAFLOW_PLAN_PREFIX),
+            sink_nodes=tuple(sink_output_nodes),
         )
 
     @property

--- a/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
+++ b/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
@@ -291,7 +291,7 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         # Dedupe (preserving order for output consistency) as it's possible for multiple derived metrics to use the same
         # metric.
         unique_metric_specs: List[MetricSpec] = []
-        for metric_spec in self._current_left_node.metric_specs + current_right_node.metric_specs:
+        for metric_spec in tuple(self._current_left_node.metric_specs) + tuple(current_right_node.metric_specs):
             if metric_spec not in unique_metric_specs:
                 unique_metric_specs.append(metric_spec)
 

--- a/metricflow/execution/execution_plan.py
+++ b/metricflow/execution/execution_plan.py
@@ -112,8 +112,8 @@ class SelectSqlQueryToDataFrameTask(ExecutionPlanTask):
         return "Run a query and write the results to a data frame"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [DisplayedProperty(key="sql_query", value=self._sql_query)]
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+        return tuple(super().displayed_properties) + (DisplayedProperty(key="sql_query", value=self._sql_query),)
 
     @property
     def bind_parameters(self) -> SqlBindParameters:  # noqa: D
@@ -169,12 +169,12 @@ class SelectSqlQueryToTableTask(ExecutionPlanTask):
         return "Run a query and write the results to a table"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+        return tuple(super().displayed_properties) + (
             DisplayedProperty(key="sql_query", value=self._sql_query),
             DisplayedProperty(key="output_table", value=self._output_table),
             DisplayedProperty(key="bind_parameters", value=self._bind_parameters),
-        ]
+        )
 
     def execute(self) -> TaskExecutionResult:  # noqa: D
         start_time = time.time()

--- a/metricflow/query/group_by_item/resolution_dag/resolution_nodes/measure_source_node.py
+++ b/metricflow/query/group_by_item/resolution_dag/resolution_nodes/measure_source_node.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Sequence
+from typing import Sequence
 
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from typing_extensions import override
@@ -53,8 +53,8 @@ class MeasureGroupByItemSourceNode(GroupByItemResolutionNode):
 
     @property
     @override
-    def displayed_properties(self) -> List[DisplayedProperty]:
-        return super().displayed_properties + [
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:
+        return tuple(super().displayed_properties) + (
             DisplayedProperty(
                 key="measure_reference",
                 value=str(self._measure_reference),
@@ -63,7 +63,7 @@ class MeasureGroupByItemSourceNode(GroupByItemResolutionNode):
                 key="child_metric_reference",
                 value=str(self._child_metric_reference),
             ),
-        ]
+        )
 
     @property
     def measure_reference(self) -> MeasureReference:  # noqa: D

--- a/metricflow/query/group_by_item/resolution_dag/resolution_nodes/metric_resolution_node.py
+++ b/metricflow/query/group_by_item/resolution_dag/resolution_nodes/metric_resolution_node.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Union
+from typing import Optional, Sequence, Union
 
 from dbt_semantic_interfaces.references import MetricReference
 from typing_extensions import Self, override
@@ -61,13 +61,13 @@ class MetricGroupByItemResolutionNode(GroupByItemResolutionNode):
 
     @property
     @override
-    def displayed_properties(self) -> List[DisplayedProperty]:
-        return super().displayed_properties + [
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:
+        return tuple(super().displayed_properties) + (
             DisplayedProperty(
                 key="metric_reference",
                 value=str(self._metric_reference),
             ),
-        ]
+        )
 
     @property
     def metric_reference(self) -> MetricReference:  # noqa: D

--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -271,8 +271,8 @@ class SqlStringExpression(SqlExpressionNode):
         return f"String SQL Expression: {self._sql_expr}"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [DisplayedProperty("sql_expr", self._sql_expr)]
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+        return tuple(super().displayed_properties) + (DisplayedProperty("sql_expr", self._sql_expr),)
 
     @property
     def sql_expr(self) -> str:  # noqa: D
@@ -340,8 +340,8 @@ class SqlStringLiteralExpression(SqlExpressionNode):
         return f"String Literal: {self._literal_value}"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [DisplayedProperty("value", self._literal_value)]
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+        return tuple(super().displayed_properties) + (DisplayedProperty("value", self._literal_value),)
 
     @property
     def literal_value(self) -> str:  # noqa: D
@@ -417,8 +417,8 @@ class SqlColumnReferenceExpression(SqlExpressionNode):
         return f"Column: {self.col_ref}"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [DisplayedProperty("col_ref", self.col_ref)]
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+        return tuple(super().displayed_properties) + (DisplayedProperty("col_ref", self.col_ref),)
 
     @property
     def requires_parenthesis(self) -> bool:  # noqa: D
@@ -505,8 +505,8 @@ class SqlColumnAliasReferenceExpression(SqlExpressionNode):
         return f"Unqualified Column: {self._column_alias}"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [DisplayedProperty("column_alias", self.column_alias)]
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+        return tuple(super().displayed_properties) + (DisplayedProperty("column_alias", self.column_alias),)
 
     @property
     def requires_parenthesis(self) -> bool:  # noqa: D
@@ -582,12 +582,12 @@ class SqlComparisonExpression(SqlExpressionNode):
         return f"{self._comparison.value} Expression"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+        return tuple(super().displayed_properties) + (
             DisplayedProperty("left_expr", self.left_expr),
             DisplayedProperty("comparison", self.comparison.value),
             DisplayedProperty("right_expr", self.right_expr),
-        ]
+        )
 
     @property
     def requires_parenthesis(self) -> bool:  # noqa: D
@@ -770,11 +770,11 @@ class SqlAggregateFunctionExpression(SqlFunctionExpression):
         return f"{self._sql_function.value} Expression"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
         return (
-            super().displayed_properties
-            + [DisplayedProperty("function", self.sql_function)]
-            + [DisplayedProperty("argument", x) for x in self.sql_function_args]
+            tuple(super().displayed_properties)
+            + (DisplayedProperty("function", self.sql_function),)
+            + tuple(DisplayedProperty("argument", x) for x in self.sql_function_args)
         )
 
     @property
@@ -901,11 +901,11 @@ class SqlPercentileExpression(SqlFunctionExpression):
         return f"{self._percentile_args.function_type.value} Percentile({self._percentile_args.percentile}) Expression"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
         return (
-            super().displayed_properties
-            + [DisplayedProperty("argument", self._order_by_arg)]
-            + [DisplayedProperty("percentile_args", self._percentile_args)]
+            tuple(super().displayed_properties)
+            + (DisplayedProperty("argument", self._order_by_arg),)
+            + (DisplayedProperty("percentile_args", self._percentile_args),)
         )
 
     def __repr__(self) -> str:  # noqa: D
@@ -1015,13 +1015,13 @@ class SqlWindowFunctionExpression(SqlFunctionExpression):
         return f"{self._sql_function.value} Window Function Expression"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
         return (
-            super().displayed_properties
-            + [DisplayedProperty("function", self.sql_function)]
-            + [DisplayedProperty("argument", x) for x in self.sql_function_args]
-            + [DisplayedProperty("partition_by_argument", x) for x in self.partition_by_args]
-            + [DisplayedProperty("order_by_argument", x) for x in self.order_by_args]
+            tuple(super().displayed_properties)
+            + (DisplayedProperty("function", self.sql_function),)
+            + tuple(DisplayedProperty("argument", x) for x in self.sql_function_args)
+            + tuple(DisplayedProperty("partition_by_argument", x) for x in self.partition_by_args)
+            + tuple(DisplayedProperty("order_by_argument", x) for x in self.order_by_args)
         )
 
     @property
@@ -1602,7 +1602,7 @@ class SqlGenerateUuidExpression(SqlExpressionNode):
         return "Generate a universally unique identifier"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
         return super().displayed_properties
 
     @property

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -163,16 +163,16 @@ class SqlSelectStatementNode(SqlQueryPlanNode):
         return self._description
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
         return (
-            super().displayed_properties
-            + [DisplayedProperty(f"col{i}", column) for i, column in enumerate(self._select_columns)]
-            + [DisplayedProperty("from_source", self.from_source)]
-            + [DisplayedProperty(f"join_{i}", join_desc) for i, join_desc in enumerate(self._join_descs)]
-            + [DisplayedProperty(f"group_by{i}", group_by) for i, group_by in enumerate(self._group_bys)]
-            + [DisplayedProperty("where", self._where)]
-            + [DisplayedProperty(f"order_by{i}", order_by) for i, order_by in enumerate(self._order_bys)]
-            + [DisplayedProperty("distinct", self._distinct)]
+            tuple(super().displayed_properties)
+            + tuple(DisplayedProperty(f"col{i}", column) for i, column in enumerate(self._select_columns))
+            + (DisplayedProperty("from_source", self.from_source),)
+            + tuple(DisplayedProperty(f"join_{i}", join_desc) for i, join_desc in enumerate(self._join_descs))
+            + tuple(DisplayedProperty(f"group_by{i}", group_by) for i, group_by in enumerate(self._group_bys))
+            + (DisplayedProperty("where", self._where),)
+            + tuple(DisplayedProperty(f"order_by{i}", order_by) for i, order_by in enumerate(self._order_bys))
+            + (DisplayedProperty("distinct", self._distinct),)
         )
 
     @property
@@ -239,10 +239,8 @@ class SqlTableFromClauseNode(SqlQueryPlanNode):
         return f"Read from {self._sql_table.sql}"
 
     @property
-    def displayed_properties(self) -> List[DisplayedProperty]:  # noqa: D
-        return super().displayed_properties + [
-            DisplayedProperty("table_id", self._sql_table.sql),
-        ]
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+        return tuple(super().displayed_properties) + (DisplayedProperty("table_id", self._sql_table.sql),)
 
     def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
         return visitor.visit_table_from_clause_node(self)

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
@@ -53,7 +53,7 @@
                                 <!-- description = 'Join to Time Spine Dataset' -->
                                 <!-- node_id = NodeId(id_str='jts_0') -->
                                 <!-- requested_agg_time_dimension_specs =                                     -->
-                                <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                                <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                                 <!-- use_custom_agg_time_dimension = False -->
                                 <!-- time_range_constraint = None -->
                                 <!-- offset_window = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -28,7 +28,7 @@
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
                             <!-- requested_agg_time_dimension_specs =                                     -->
-                            <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
@@ -28,7 +28,7 @@
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
                             <!-- requested_agg_time_dimension_specs =                                       -->
-                            <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),] -->
+                            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),) -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -28,7 +28,7 @@
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
                             <!-- requested_agg_time_dimension_specs =                                     -->
-                            <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -17,7 +17,7 @@
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_0') -->
                         <!-- requested_agg_time_dimension_specs =                                     -->
-                        <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                         <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
@@ -59,7 +59,7 @@
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_2') -->
                         <!-- requested_agg_time_dimension_specs =                                     -->
-                        <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                         <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
@@ -78,7 +78,7 @@
                                     <!-- description = 'Join to Time Spine Dataset' -->
                                     <!-- node_id = NodeId(id_str='jts_1') -->
                                     <!-- requested_agg_time_dimension_specs =                                     -->
-                                    <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                                    <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                                     <!-- use_custom_agg_time_dimension = False -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -48,7 +48,7 @@
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_0') -->
                         <!-- requested_agg_time_dimension_specs =                                     -->
-                        <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                         <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint =                             -->
                         <!--   TimeRangeConstraint(                              -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
@@ -10,7 +10,7 @@
                 <!-- description = 'Join to Time Spine Dataset' -->
                 <!-- node_id = NodeId(id_str='jts_0') -->
                 <!-- requested_agg_time_dimension_specs =                                     -->
-                <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                 <!-- use_custom_agg_time_dimension = False -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -10,7 +10,7 @@
                 <!-- description = 'Join to Time Spine Dataset' -->
                 <!-- node_id = NodeId(id_str='jts_1') -->
                 <!-- requested_agg_time_dimension_specs =                                     -->
-                <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                 <!-- use_custom_agg_time_dimension = False -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
@@ -45,7 +45,7 @@
                                     <!-- description = 'Join to Time Spine Dataset' -->
                                     <!-- node_id = NodeId(id_str='jts_0') -->
                                     <!-- requested_agg_time_dimension_specs =                                     -->
-                                    <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+                                    <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                                     <!-- use_custom_agg_time_dimension = False -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -84,7 +84,7 @@
                                     <!-- description = 'Join to Time Spine Dataset' -->
                                     <!-- node_id = NodeId(id_str='jts_0') -->
                                     <!-- requested_agg_time_dimension_specs =                                       -->
-                                    <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),] -->
+                                    <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),) -->
                                     <!-- use_custom_agg_time_dimension = False -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = None -->

--- a/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/metricflow/test/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -88,7 +88,7 @@
                                         <!-- description = 'Join to Time Spine Dataset' -->
                                         <!-- node_id = NodeId(id_str='jts_0') -->
                                         <!-- requested_agg_time_dimension_specs =                                       -->
-                                        <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),] -->
+                                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),) -->
                                         <!-- use_custom_agg_time_dimension = False -->
                                         <!-- time_range_constraint = None -->
                                         <!-- offset_window = PydanticMetricTimeWindow(count=1, granularity=WEEK) -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -6,7 +6,7 @@
             <!-- description = 'Join to Time Spine Dataset' -->
             <!-- node_id = NodeId(id_str='jts_0') -->
             <!-- requested_agg_time_dimension_specs =                                     -->
-            <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
             <!-- use_custom_agg_time_dimension = False -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -6,7 +6,7 @@
             <!-- description = 'Join to Time Spine Dataset' -->
             <!-- node_id = NodeId(id_str='jts_0') -->
             <!-- requested_agg_time_dimension_specs =                                     -->
-            <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
             <!-- use_custom_agg_time_dimension = False -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->

--- a/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/metricflow/test/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -6,7 +6,7 @@
             <!-- description = 'Join to Time Spine Dataset' -->
             <!-- node_id = NodeId(id_str='jts_0') -->
             <!-- requested_agg_time_dimension_specs =                                     -->
-            <!--   [TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),] -->
+            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
             <!-- use_custom_agg_time_dimension = False -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->


### PR DESCRIPTION
### Description

The dataflow plan nodes were intended to be immutable, so this PR updates functions defined in those nodes to use sequences and tuples.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
