### PR TITLE
Separate method for recursive dataflow plans

### DIFF
--- a/metricflow/naming/naming_scheme.py
+++ b/metricflow/naming/naming_scheme.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from metricflow.specs.patterns.spec_pattern import SpecPattern
-from metricflow.specs.specs import InstanceSpec
+
+if TYPE_CHECKING:
+    from metricflow.specs.specs import InstanceSpec
 
 
 class QueryItemNamingScheme(ABC):

--- a/metricflow/query/group_by_item/filter_spec_resolution/filter_spec_lookup.py
+++ b/metricflow/query/group_by_item/filter_spec_resolution/filter_spec_lookup.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Tuple, Union
 
 from dbt_semantic_interfaces.call_parameter_sets import (
     DimensionCallParameterSet,
@@ -21,7 +21,9 @@ from metricflow.query.group_by_item.path_prefixable import PathPrefixable
 from metricflow.query.group_by_item.resolution_path import MetricFlowQueryResolutionPath
 from metricflow.query.issues.issues_base import MetricFlowQueryResolutionIssueSet
 from metricflow.specs.patterns.spec_pattern import SpecPattern
-from metricflow.specs.specs import LinkableInstanceSpec
+
+if TYPE_CHECKING:
+    from metricflow.specs.specs import LinkableInstanceSpec
 
 logger = logging.getLogger(__name__)
 

--- a/metricflow/specs/patterns/spec_pattern.py
+++ b/metricflow/specs/patterns/spec_pattern.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
-from metricflow.specs.specs import InstanceSpec
+if TYPE_CHECKING:
+    from metricflow.specs.specs import InstanceSpec
 
 
 class SpecPattern(ABC):

--- a/metricflow/specs/specs.py
+++ b/metricflow/specs/specs.py
@@ -39,6 +39,7 @@ from metricflow.aggregation_properties import AggregationState
 from metricflow.collection_helpers.merger import Mergeable
 from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.naming.linkable_spec_name import StructuredLinkableSpecName
+from metricflow.query.group_by_item.filter_spec_resolution.filter_spec_lookup import FilterSpecResolutionLookUp
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql.sql_column_type import SqlColumnType
 from metricflow.sql.sql_plan import SqlJoinType
@@ -47,7 +48,6 @@ from metricflow.visitor import VisitorOutputT
 if TYPE_CHECKING:
     from metricflow.model.semantics.metric_lookup import MetricLookup
     from metricflow.protocols.semantics import SemanticModelAccessor
-    from metricflow.query.group_by_item.filter_spec_resolution.filter_spec_lookup import FilterSpecResolutionLookUp
 
 
 def hash_items(items: Sequence[SqlColumnType]) -> str:
@@ -780,7 +780,7 @@ class MetricFlowQuerySpec(SerializableDataclass):
     time_range_constraint: Optional[TimeRangeConstraint] = None
     limit: Optional[int] = None
     filter_intersection: Optional[WhereFilterIntersection] = None
-    filter_spec_resolution_lookup: Optional[FilterSpecResolutionLookUp] = None
+    filter_spec_resolution_lookup: FilterSpecResolutionLookUp = FilterSpecResolutionLookUp.empty_instance()
     min_max_only: bool = False
 
     @property


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
We will need to build recursive dataflow plans for metrics as dimensions. This PR should not change any output behavior - just separates some DFP logic into a helper method that can be used to build source nodes.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
