### PR TITLE
 Support `CREATE TABLE ... AS SELECT` in SQL Object Model

### DIFF
--- a/metricflow/dag/id_prefix.py
+++ b/metricflow/dag/id_prefix.py
@@ -75,6 +75,7 @@ class StaticIdPrefix(IdPrefix, Enum, metaclass=EnumMetaClassHelper):
     SQL_PLAN_SELECT_STATEMENT_ID_PREFIX = "ss"
     SQL_PLAN_TABLE_FROM_CLAUSE_ID_PREFIX = "tfc"
     SQL_PLAN_QUERY_FROM_CLAUSE_ID_PREFIX = "qfc"
+    SQL_PLAN_CREATE_TABLE_AS_ID_PREFIX = "cta"
 
     EXEC_NODE_READ_SQL_QUERY = "rsq"
     EXEC_NODE_NOOP = "noop"

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -9,6 +9,7 @@ from metricflow.sql.sql_exprs import (
     SqlExpressionTreeLineage,
 )
 from metricflow.sql.sql_plan import (
+    SqlCreateTableAsNode,
     SqlJoinDescription,
     SqlQueryPlanNode,
     SqlQueryPlanNodeVisitor,
@@ -197,6 +198,12 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
         """Pruning cannot be done here since this is an arbitrary user-provided SQL query."""
         return node
+
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D
+        return SqlCreateTableAsNode(
+            sql_table=node.sql_table,
+            parent_node=node.parent_node.accept(self),
+        )
 
 
 class SqlColumnPrunerOptimizer(SqlQueryPlanOptimizer):

--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -16,6 +16,7 @@ from metricflow.sql.sql_exprs import (
     SqlLogicalOperator,
 )
 from metricflow.sql.sql_plan import (
+    SqlCreateTableAsNode,
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlQueryPlanNode,
@@ -657,6 +658,12 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
         return node
 
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D
+        return SqlCreateTableAsNode(
+            sql_table=node.sql_table,
+            parent_node=node.parent_node.accept(self),
+        )
+
 
 class SqlGroupByRewritingVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
     """Re-writes the GROUP BY to use a SqlColumnAliasReferenceExpression."""
@@ -714,6 +721,12 @@ class SqlGroupByRewritingVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
 
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
         return node
+
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D
+        return SqlCreateTableAsNode(
+            sql_table=node.sql_table,
+            parent_node=node.parent_node.accept(self),
+        )
 
 
 class SqlRewritingSubQueryReducer(SqlQueryPlanOptimizer):

--- a/metricflow/sql/optimizer/sub_query_reducer.py
+++ b/metricflow/sql/optimizer/sub_query_reducer.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
 from metricflow.sql.sql_exprs import SqlColumnReference, SqlColumnReferenceExpression
 from metricflow.sql.sql_plan import (
+    SqlCreateTableAsNode,
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlQueryPlanNode,
@@ -192,6 +193,12 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
 
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
         return node
+
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D
+        return SqlCreateTableAsNode(
+            sql_table=node.sql_table,
+            parent_node=node.parent_node.accept(self),
+        )
 
 
 class SqlSubQueryReducer(SqlQueryPlanOptimizer):

--- a/metricflow/sql/optimizer/table_alias_simplifier.py
+++ b/metricflow/sql/optimizer/table_alias_simplifier.py
@@ -4,6 +4,7 @@ import logging
 
 from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
 from metricflow.sql.sql_plan import (
+    SqlCreateTableAsNode,
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlQueryPlanNode,
@@ -73,6 +74,12 @@ class SqlTableAliasSimplifierVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
 
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
         return node
+
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D
+        return SqlCreateTableAsNode(
+            sql_table=node.sql_table,
+            parent_node=node.parent_node.accept(self),
+        )
 
 
 class SqlTableAliasSimplifier(SqlQueryPlanOptimizer):

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Generic, List, Optional, Sequence, Tuple
 
+from typing_extensions import override
+
 from metricflow.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow.dag.mf_dag import DagId, DagNode, DisplayedProperty, MetricFlowDag, NodeId
 from metricflow.sql.sql_exprs import SqlExpressionNode
@@ -287,6 +289,48 @@ class SqlSelectQueryFromClauseNode(SqlQueryPlanNode):
     @property
     def as_select_node(self) -> Optional[SqlSelectStatementNode]:  # noqa: D
         return None
+
+
+class SqlCreateTableAsNode(SqlQueryPlanNode):
+    """An SQL select query that can go in the FROM clause."""
+
+    def __init__(self, sql_table: SqlTable, parent_node: SqlQueryPlanNode) -> None:  # noqa: D
+        self._sql_table = sql_table
+        self._parent_node = parent_node
+        super().__init__(node_id=self.create_unique_id(), parent_nodes=(self._parent_node,))
+
+    @override
+    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
+        raise NotImplementedError
+
+    @property
+    @override
+    def is_table(self) -> bool:
+        return False
+
+    @property
+    @override
+    def as_select_node(self) -> Optional[SqlSelectStatementNode]:
+        return None
+
+    @property
+    @override
+    def description(self) -> str:
+        return f"Create table {repr(self.sql_table.sql)}"
+
+    @classmethod
+    @override
+    def id_prefix(cls) -> IdPrefix:
+        return StaticIdPrefix.SQL_PLAN_CREATE_TABLE_AS_ID_PREFIX
+
+    @property
+    def sql_table(self) -> SqlTable:
+        """Return the table that this statement would create."""
+        return self._sql_table
+
+    @property
+    def parent_node(self) -> SqlQueryPlanNode:  # noqa: D
+        return self._parent_node
 
 
 class SqlQueryPlan(MetricFlowDag[SqlQueryPlanNode]):  # noqa: D

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -77,6 +77,10 @@ class SqlQueryPlanNodeVisitor(Generic[VisitorOutputT], ABC):
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> VisitorOutputT:  # noqa: D
         raise NotImplementedError
 
+    @abstractmethod
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> VisitorOutputT:  # noqa: D
+        raise NotImplementedError
+
 
 @dataclass(frozen=True)
 class SqlSelectColumn:
@@ -301,7 +305,7 @@ class SqlCreateTableAsNode(SqlQueryPlanNode):
 
     @override
     def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
-        raise NotImplementedError
+        return visitor.visit_create_table_as_node(self)
 
     @property
     @override

--- a/metricflow/sql/sql_table.py
+++ b/metricflow/sql/sql_table.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Optional, Tuple, Union
+
+
+class SqlTableType(Enum):  # noqa: D
+    TABLE = "table"
+    VIEW = "view"
 
 
 @dataclass(frozen=True, order=True)
@@ -11,6 +17,7 @@ class SqlTable:
     schema_name: str
     table_name: str
     db_name: Optional[str] = None
+    table_type: SqlTableType = SqlTableType.TABLE
 
     @staticmethod
     def from_string(sql_str: str) -> SqlTable:  # noqa: D

--- a/metricflow/test/dataset/test_convert_semantic_model.py
+++ b/metricflow/test/dataset/test_convert_semantic_model.py
@@ -39,7 +39,7 @@ def test_convert_table_semantic_model_without_measures(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan_id="plan0",
-        select_node=users_data_set.sql_select_node,
+        sql_plan_node=users_data_set.sql_select_node,
         sql_client=sql_client,
     )
 
@@ -74,7 +74,7 @@ def test_convert_table_semantic_model_with_measures(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan_id="plan0",
-        select_node=id_verifications_data_set.sql_select_node,
+        sql_plan_node=id_verifications_data_set.sql_select_node,
         sql_client=sql_client,
     )
 
@@ -94,6 +94,6 @@ def test_convert_query_semantic_model(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan_id="plan0",
-        select_node=bookings_data_set.sql_select_node,
+        sql_plan_node=bookings_data_set.sql_select_node,
         sql_client=sql_client,
     )

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/BigQuery/test_render_create_table_as__create_table_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/BigQuery/test_render_create_table_as__create_table_as.sql
@@ -1,0 +1,7 @@
+CREATE TABLE schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/BigQuery/test_render_create_table_as__create_view_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/BigQuery/test_render_create_table_as__create_view_as.sql
@@ -1,0 +1,7 @@
+CREATE VIEW schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Databricks/test_render_create_table_as__create_table_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Databricks/test_render_create_table_as__create_table_as.sql
@@ -1,0 +1,7 @@
+CREATE TABLE schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Databricks/test_render_create_table_as__create_view_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Databricks/test_render_create_table_as__create_view_as.sql
@@ -1,0 +1,7 @@
+CREATE VIEW schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDB/test_render_create_table_as__create_table_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDB/test_render_create_table_as__create_table_as.sql
@@ -1,0 +1,7 @@
+CREATE TABLE schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDB/test_render_create_table_as__create_view_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/DuckDB/test_render_create_table_as__create_view_as.sql
@@ -1,0 +1,7 @@
+CREATE VIEW schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Postgres/test_render_create_table_as__create_table_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Postgres/test_render_create_table_as__create_table_as.sql
@@ -1,0 +1,7 @@
+CREATE TABLE schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Postgres/test_render_create_table_as__create_view_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Postgres/test_render_create_table_as__create_view_as.sql
@@ -1,0 +1,7 @@
+CREATE VIEW schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Redshift/test_render_create_table_as__create_table_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Redshift/test_render_create_table_as__create_table_as.sql
@@ -1,0 +1,7 @@
+CREATE TABLE schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Redshift/test_render_create_table_as__create_view_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Redshift/test_render_create_table_as__create_view_as.sql
@@ -1,0 +1,7 @@
+CREATE VIEW schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Snowflake/test_render_create_table_as__create_table_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Snowflake/test_render_create_table_as__create_table_as.sql
@@ -1,0 +1,7 @@
+CREATE TABLE schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Snowflake/test_render_create_table_as__create_view_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Snowflake/test_render_create_table_as__create_view_as.sql
@@ -1,0 +1,7 @@
+CREATE VIEW schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Trino/test_render_create_table_as__create_table_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Trino/test_render_create_table_as__create_table_as.sql
@@ -1,0 +1,7 @@
+CREATE TABLE schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Trino/test_render_create_table_as__create_view_as.sql
+++ b/metricflow/test/snapshots/test_sql_plan_render.py/SqlQueryPlan/Trino/test_render_create_table_as__create_view_as.sql
@@ -1,0 +1,7 @@
+CREATE VIEW schema_name.table_name AS (
+  -- select_0
+  SELECT
+    a.bookings
+  FROM demo.fct_bookings a
+  LIMIT 1
+)

--- a/metricflow/test/sql/compare_sql_plan.py
+++ b/metricflow/test/sql/compare_sql_plan.py
@@ -5,7 +5,7 @@ from _pytest.fixtures import FixtureRequest
 from metricflow.dag.mf_dag import DagId
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
-from metricflow.sql.sql_plan import SqlQueryPlan, SqlQueryPlanNode, SqlSelectStatementNode
+from metricflow.sql.sql_plan import SqlQueryPlan, SqlQueryPlanNode
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState, check_sql_engine_snapshot_marker
 from metricflow.test.snapshot_utils import (
     assert_plan_snapshot_text_equal,
@@ -37,11 +37,11 @@ def assert_rendered_sql_equal(  # noqa: D
     request: FixtureRequest,
     mf_test_session_state: MetricFlowTestSessionState,
     plan_id: str,
-    select_node: SqlSelectStatementNode,
+    sql_plan_node: SqlQueryPlanNode,
     sql_client: SqlClient,
 ) -> None:
     """Helper function to render a select statement and compare with the one saved as a file."""
-    sql_query_plan = SqlQueryPlan(render_node=select_node, plan_id=DagId.from_str(plan_id))
+    sql_query_plan = SqlQueryPlan(render_node=sql_plan_node, plan_id=DagId.from_str(plan_id))
 
     assert_rendered_sql_from_plan_equal(
         request=request,

--- a/metricflow/test/sql/test_engine_specific_rendering.py
+++ b/metricflow/test/sql/test_engine_specific_rendering.py
@@ -56,7 +56,7 @@ def test_cast_to_timestamp(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="Test Cast to Timestamp Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -90,7 +90,7 @@ def test_generate_uuid(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="Test Generate UUID Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -139,7 +139,7 @@ def test_continuous_percentile_expr(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="Test Continuous Percentile Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -188,7 +188,7 @@ def test_discrete_percentile_expr(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="Test Discrete Percentile Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -237,7 +237,7 @@ def test_approximate_continuous_percentile_expr(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="Test Approximate Continuous Percentile Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -286,7 +286,7 @@ def test_approximate_discrete_percentile_expr(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="Test Approximate Discrete Percentile Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,

--- a/metricflow/test/sql/test_sql_plan_render.py
+++ b/metricflow/test/sql/test_sql_plan_render.py
@@ -60,7 +60,7 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="test0",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -91,7 +91,7 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="test1",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -122,7 +122,7 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="test2",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -153,7 +153,7 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="test3",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -178,7 +178,7 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="test4",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -203,7 +203,7 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="test5",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -227,7 +227,7 @@ def test_render_where(  # noqa: D
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="test0",
             select_columns=(
                 SqlSelectColumn(
@@ -268,7 +268,7 @@ def test_render_order_by(  # noqa: D
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="test0",
             select_columns=(
                 SqlSelectColumn(
@@ -318,7 +318,7 @@ def test_render_limit(  # noqa: D
     assert_rendered_sql_equal(
         request=request,
         mf_test_session_state=mf_test_session_state,
-        select_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode(
             description="test0",
             select_columns=(
                 SqlSelectColumn(


### PR DESCRIPTION
### Description

When generating the tasks for the execution plan, the `CREATE TABLE ... AS SELECT` statement was not generated through the SQL object model. Instead, it was generated when the associated task ran. For better consistency and to support potential SQL-engine differences, this PR adds the appropriate SQL node to model that statement. The execution task updates will be done in a separate PR.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
