### PR TITLE
Update Execution Plan Generation to Use `SqlCreateTableAs`

### DIFF
--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -314,7 +314,7 @@ def query(
                             """
                         ),
                         undefined=jinja2.StrictUndefined,
-                    ).render(plan_text=explain_result.dataflow_plan.text_structure()),
+                    ).render(plan_text=explain_result.dataflow_plan.structure_text()),
                     prefix="-- ",
                 )
             )

--- a/metricflow/dag/mf_dag.py
+++ b/metricflow/dag/mf_dag.py
@@ -111,7 +111,7 @@ class DagNode(ABC):
         """Visit this node."""
         return visitor.visit_node(self)
 
-    def text_structure(self, formatter: MetricFlowDagTextFormatter = MetricFlowDagTextFormatter()) -> str:
+    def structure_text(self, formatter: MetricFlowDagTextFormatter = MetricFlowDagTextFormatter()) -> str:
         """Return a text representation that shows the structure of the DAG component starting from this node."""
         return formatter.dag_component_to_text(self)
 
@@ -193,6 +193,6 @@ class MetricFlowDag(Generic[DagNodeT]):  # noqa: D
     def sink_nodes(self) -> Sequence[DagNodeT]:  # noqa: D
         return self._sink_nodes
 
-    def text_structure(self, formatter: MetricFlowDagTextFormatter = MetricFlowDagTextFormatter()) -> str:
+    def structure_text(self, formatter: MetricFlowDagTextFormatter = MetricFlowDagTextFormatter()) -> str:
         """Return a text representation that shows the structure of this DAG."""
         return formatter.dag_to_text(self)

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -214,7 +214,7 @@ class DataflowPlanBuilder:
                 plan = optimizer.optimize(plan)
                 logger.info(
                     f"After applying {optimizer.__class__.__name__}, the dataflow plan is:\n"
-                    f"{indent(plan.text_structure())}"
+                    f"{indent(plan.structure_text())}"
                 )
             except Exception:
                 logger.exception(f"Got an exception applying {optimizer.__class__.__name__}")
@@ -890,14 +890,14 @@ class DataflowPlanBuilder:
                 if missing_specs:
                     logger.debug(
                         f"Skipping evaluation for:\n"
-                        f"{indent(node.text_structure())}"
+                        f"{indent(node.structure_text())}"
                         f"since it does not have all of the measure specs:\n"
                         f"{indent(mf_pformat(missing_specs))}"
                     )
                     continue
 
             logger.debug(
-                f"Evaluating candidate node for the left side of the join:\n{indent(mf_pformat(node.text_structure()))}"
+                f"Evaluating candidate node for the left side of the join:\n{indent(mf_pformat(node.structure_text()))}"
             )
 
             start_time = time.time()
@@ -910,7 +910,7 @@ class DataflowPlanBuilder:
 
             logger.info(
                 "Evaluation for source node:"
-                + indent(f"\nnode:\n{indent(node.text_structure())}")
+                + indent(f"\nnode:\n{indent(node.structure_text())}")
                 + indent(f"\nevaluation:\n{indent(mf_pformat(evaluation))}")
             )
 
@@ -943,7 +943,7 @@ class DataflowPlanBuilder:
 
             logger.info(
                 "Lowest cost plan is:"
-                + indent(f"\nnode:\n{indent(node_with_lowest_cost_plan.text_structure())}")
+                + indent(f"\nnode:\n{indent(node_with_lowest_cost_plan.structure_text())}")
                 + indent(f"\nevaluation:\n{indent(mf_pformat(evaluation))}")
                 + indent(f"\njoins: {len(node_to_evaluation[node_with_lowest_cost_plan].join_recipes)}")
             )

--- a/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
+++ b/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
@@ -313,9 +313,9 @@ class SourceScanOptimizer(
         logger.log(
             level=self._log_level,
             msg=f"Optimized:\n\n"
-            f"{dataflow_plan.sink_output_node.text_structure()}\n\n"
+            f"{dataflow_plan.sink_output_node.structure_text()}\n\n"
             f"to:\n\n"
-            f"{optimized_result.checked_sink_node.text_structure()}",
+            f"{optimized_result.checked_sink_node.structure_text()}",
         )
 
         if optimized_result.sink_node:

--- a/metricflow/dataset/dataset.py
+++ b/metricflow/dataset/dataset.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import logging
+from abc import ABC, abstractmethod
 from typing import Optional, Sequence
 
-from dbt_semantic_interfaces.references import TimeDimensionReference
+from dbt_semantic_interfaces.references import SemanticModelReference, TimeDimensionReference
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.validations.unique_valid_name import MetricFlowReservedKeywords
@@ -14,7 +15,7 @@ from metricflow.specs.specs import TimeDimensionSpec
 logger = logging.getLogger(__name__)
 
 
-class DataSet:
+class DataSet(ABC):
     """Describes a set of data that a source node in the dataflow plan contains."""
 
     def __init__(self, instance_set: InstanceSet) -> None:  # noqa:
@@ -59,6 +60,12 @@ class DataSet:
             time_granularity=time_granularity,
             date_part=date_part,
         )
+
+    @property
+    @abstractmethod
+    def semantic_model_reference(self) -> Optional[SemanticModelReference]:
+        """If this data set was created from a semantic model, return the reference."""
+        raise NotImplementedError
 
     def __repr__(self) -> str:  # noqa: D
         return f"{self.__class__.__name__}()"

--- a/metricflow/dataset/semantic_model_adapter.py
+++ b/metricflow/dataset/semantic_model_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dbt_semantic_interfaces.references import SemanticModelReference
+from typing_extensions import override
 
 from metricflow.dataset.sql_dataset import SqlDataSet
 from metricflow.instances import InstanceSet
@@ -23,5 +24,6 @@ class SemanticModelDataSet(SqlDataSet):
         return f"{self.__class__.__name__}({repr(self._semantic_model_reference.semantic_model_name)})"
 
     @property
+    @override
     def semantic_model_reference(self) -> SemanticModelReference:  # noqa: D
         return self._semantic_model_reference

--- a/metricflow/dataset/sql_dataset.py
+++ b/metricflow/dataset/sql_dataset.py
@@ -27,7 +27,7 @@ class SqlDataSet(DataSet):
         super().__init__(instance_set=instance_set)
 
     @property
-    def sql_select_node(self) -> SqlSelectStatementNode:
+    def checked_sql_select_node(self) -> SqlSelectStatementNode:
         """Return a SELECT node that can be used to read data from the given SQL table or SQL query."""
         return self._sql_select_node
 

--- a/metricflow/dataset/sql_dataset.py
+++ b/metricflow/dataset/sql_dataset.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Optional, Sequence
 
+from dbt_semantic_interfaces.references import SemanticModelReference
+from typing_extensions import override
+
 from metricflow.assert_one_arg import assert_exactly_one_arg_set
 from metricflow.dataset.dataset import DataSet
 from metricflow.instances import (
@@ -125,3 +128,8 @@ class SqlDataSet(DataSet):
             )
 
         return column_associations_to_return[0]
+
+    @property
+    @override
+    def semantic_model_reference(self) -> Optional[SemanticModelReference]:
+        return None

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -417,7 +417,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
 
         task = execution_plan.tasks[0]
 
-        logger.info(f"Sequentially running tasks in:\n" f"{execution_plan.text_structure()}")
+        logger.info(f"Sequentially running tasks in:\n" f"{execution_plan.structure_text()}")
         execution_results = self._executor.execute_plan(execution_plan)
         logger.info("Finished running tasks in execution plan")
 

--- a/metricflow/execution/execution_plan.py
+++ b/metricflow/execution/execution_plan.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import logging
-import textwrap
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple
 
-import jinja2
 import pandas as pd
 
 from metricflow.dag.id_prefix import IdPrefix, StaticIdPrefix

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -122,10 +122,11 @@ class DataWarehouseTaskBuilder:
         sql_client: SqlClient, plan_converter: DataflowToSqlQueryPlanConverter, plan_id: str, nodes: FilterElementsNode
     ) -> Tuple[str, SqlBindParameters]:
         """Generates a sql query plan and returns the rendered sql and bind_parameters."""
-        sql_plan = plan_converter.convert_to_sql_query_plan(
+        conversion_result = plan_converter.convert_to_sql_query_plan(
             sql_engine_type=sql_client.sql_engine_type,
             dataflow_plan_node=nodes,
         )
+        sql_plan = conversion_result.sql_plan
 
         rendered_plan = sql_client.sql_query_plan_renderer.render_sql_query_plan(sql_plan)
         return (rendered_plan.sql, rendered_plan.bind_parameters)

--- a/metricflow/plan_conversion/convert_to_execution_plan.py
+++ b/metricflow/plan_conversion/convert_to_execution_plan.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from metricflow.execution.execution_plan import ExecutionPlan
+from metricflow.plan_conversion.convert_to_sql_plan import ConvertToSqlPlanResult
+from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderResult
+
+
+@dataclass(frozen=True)
+class ConvertToExecutionPlanResult:
+    """A result object for returning the results of converting a dataflow plan into an execution plan."""
+
+    convert_to_sql_plan_result: ConvertToSqlPlanResult
+    render_sql_result: SqlPlanRenderResult
+    execution_plan: ExecutionPlan

--- a/metricflow/plan_conversion/convert_to_sql_plan.py
+++ b/metricflow/plan_conversion/convert_to_sql_plan.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from metricflow.instances import InstanceSet
+from metricflow.sql.sql_plan import SqlQueryPlan
+
+
+@dataclass(frozen=True)
+class ConvertToSqlPlanResult:
+    """Result object for returning the results of converting to a `SqlQueryPlan`."""
+
+    instance_set: InstanceSet
+    sql_plan: SqlQueryPlan

--- a/metricflow/plan_conversion/dataflow_to_execution.py
+++ b/metricflow/plan_conversion/dataflow_to_execution.py
@@ -45,11 +45,11 @@ class DataflowToExecutionPlanConverter(SinkNodeVisitor[ExecutionPlan]):
         self,
         node: DataflowPlanNode,
     ) -> SqlPlanRenderResult:
-        sql_plan = self._sql_plan_converter.convert_to_sql_query_plan(
+        convert_to_sql_plan_result = self._sql_plan_converter.convert_to_sql_query_plan(
             sql_engine_type=self._sql_client.sql_engine_type,
             dataflow_plan_node=node,
         )
-
+        sql_plan = convert_to_sql_plan_result.sql_plan
         logger.debug(f"Generated SQL query plan is:\n{sql_plan.text_structure()}")
         return self._sql_plan_renderer.render_sql_query_plan(sql_plan)
 

--- a/metricflow/plan_conversion/dataflow_to_execution.py
+++ b/metricflow/plan_conversion/dataflow_to_execution.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 
+from typing_extensions import override
+
 from metricflow.dataflow.dataflow_plan import (
     DataflowPlan,
     DataflowPlanNode,
@@ -14,6 +16,8 @@ from metricflow.execution.execution_plan import (
     SelectSqlQueryToDataFrameTask,
     SelectSqlQueryToTableTask,
 )
+from metricflow.plan_conversion.convert_to_execution_plan import ConvertToExecutionPlanResult
+from metricflow.plan_conversion.convert_to_sql_plan import ConvertToSqlPlanResult
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderResult, SqlQueryPlanRenderer
@@ -21,7 +25,7 @@ from metricflow.sql.render.sql_plan_renderer import SqlPlanRenderResult, SqlQuer
 logger = logging.getLogger(__name__)
 
 
-class DataflowToExecutionPlanConverter(SinkNodeVisitor[ExecutionPlan]):
+class DataflowToExecutionPlanConverter(SinkNodeVisitor[ConvertToExecutionPlanResult]):
     """Converts a dataflow plan to an execution plan."""
 
     def __init__(
@@ -41,46 +45,58 @@ class DataflowToExecutionPlanConverter(SinkNodeVisitor[ExecutionPlan]):
         self._sql_plan_renderer = sql_plan_renderer
         self._sql_client = sql_client
 
-    def _render_sql_plan(  # noqa: D
-        self,
-        node: DataflowPlanNode,
-    ) -> SqlPlanRenderResult:
-        convert_to_sql_plan_result = self._sql_plan_converter.convert_to_sql_query_plan(
+    def _convert_to_sql_plan(self, node: DataflowPlanNode) -> ConvertToSqlPlanResult:
+        logger.info(f"Generating SQL query plan from {node.node_id}")
+        result = self._sql_plan_converter.convert_to_sql_query_plan(
             sql_engine_type=self._sql_client.sql_engine_type,
             dataflow_plan_node=node,
         )
-        sql_plan = convert_to_sql_plan_result.sql_plan
-        logger.debug(f"Generated SQL query plan is:\n{sql_plan.text_structure()}")
-        return self._sql_plan_renderer.render_sql_query_plan(sql_plan)
+        logger.debug(f"Generated SQL query plan is:\n{result.sql_plan.text_structure()}")
+        return result
 
-    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> ExecutionPlan:  # noqa: D
-        logger.info(f"Generating SQL query plan from {node.node_id}")
-        render_result = self._render_sql_plan(node)
-        return ExecutionPlan(
+    def _render_sql(self, convert_to_sql_plan_result: ConvertToSqlPlanResult) -> SqlPlanRenderResult:
+        return self._sql_plan_renderer.render_sql_query_plan(convert_to_sql_plan_result.sql_plan)
+
+    @override
+    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> ConvertToExecutionPlanResult:
+        convert_to_sql_plan_result = self._convert_to_sql_plan(node)
+        render_sql_result = self._render_sql(convert_to_sql_plan_result)
+        execution_plan = ExecutionPlan(
             leaf_tasks=(
                 SelectSqlQueryToDataFrameTask(
                     sql_client=self._sql_client,
-                    sql_query=render_result.sql,
-                    bind_parameters=render_result.bind_parameters,
+                    sql_query=render_sql_result.sql,
+                    bind_parameters=render_sql_result.bind_parameters,
                 ),
             )
         )
+        return ConvertToExecutionPlanResult(
+            convert_to_sql_plan_result=convert_to_sql_plan_result,
+            render_sql_result=render_sql_result,
+            execution_plan=execution_plan,
+        )
 
-    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> ExecutionPlan:  # noqa: D
-        logger.info(f"Generating SQL query plan from {node.node_id}")
-        render_result = self._render_sql_plan(node)
-        return ExecutionPlan(
+    @override
+    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> ConvertToExecutionPlanResult:
+        convert_to_sql_plan_result = self._convert_to_sql_plan(node)
+        render_sql_result = self._render_sql(convert_to_sql_plan_result)
+        execution_plan = ExecutionPlan(
             leaf_tasks=(
                 SelectSqlQueryToTableTask(
                     sql_client=self._sql_client,
-                    sql_query=render_result.sql,
-                    bind_parameters=render_result.bind_parameters,
+                    sql_query=render_sql_result.sql,
+                    bind_parameters=render_sql_result.bind_parameters,
                     output_table=node.output_sql_table,
                 ),
             ),
         )
+        return ConvertToExecutionPlanResult(
+            convert_to_sql_plan_result=convert_to_sql_plan_result,
+            render_sql_result=render_sql_result,
+            execution_plan=execution_plan,
+        )
 
-    def convert_to_execution_plan(self, dataflow_plan: DataflowPlan) -> ExecutionPlan:
+    def convert_to_execution_plan(self, dataflow_plan: DataflowPlan) -> ConvertToExecutionPlanResult:
         """Convert the dataflow plan to an execution plan."""
         assert len(dataflow_plan.sink_output_nodes) == 1, "Only 1 sink node in the plan is currently supported."
         return dataflow_plan.sink_output_nodes[0].accept_sink_node_visitor(self)

--- a/metricflow/plan_conversion/dataflow_to_execution.py
+++ b/metricflow/plan_conversion/dataflow_to_execution.py
@@ -51,7 +51,7 @@ class DataflowToExecutionPlanConverter(SinkNodeVisitor[ConvertToExecutionPlanRes
             sql_engine_type=self._sql_client.sql_engine_type,
             dataflow_plan_node=node,
         )
-        logger.debug(f"Generated SQL query plan is:\n{result.sql_plan.text_structure()}")
+        logger.debug(f"Generated SQL query plan is:\n{result.sql_plan.structure_text()}")
         return result
 
     def _render_sql(self, convert_to_sql_plan_result: ConvertToSqlPlanResult) -> SqlPlanRenderResult:

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -197,7 +197,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             sql_node = optimizer.optimize(sql_node)
             logger.info(
                 f"After applying {optimizer.__class__.__name__}, the SQL query plan is:\n"
-                f"{indent(sql_node.text_structure())}"
+                f"{indent(sql_node.structure_text())}"
             )
 
         return ConvertToSqlPlanResult(

--- a/metricflow/plan_conversion/sql_join_builder.py
+++ b/metricflow/plan_conversion/sql_join_builder.py
@@ -214,7 +214,7 @@ class SqlQueryPlanJoinBuilder:
         )
 
         return SqlQueryPlanJoinBuilder.make_column_equality_sql_join_description(
-            right_source_node=right_data_set.data_set.sql_select_node,
+            right_source_node=right_data_set.data_set.checked_sql_select_node,
             left_source_alias=left_data_set.alias,
             right_source_alias=right_data_set.alias,
             column_equality_descriptions=column_equality_descriptions,
@@ -350,7 +350,7 @@ class SqlQueryPlanJoinBuilder:
                 else equality_exprs[0]
             )
             return SqlJoinDescription(
-                right_source=join_data_set.data_set.sql_select_node,
+                right_source=join_data_set.data_set.checked_sql_select_node,
                 right_source_alias=join_data_set.alias,
                 on_condition=on_condition,
                 join_type=join_type,
@@ -361,7 +361,7 @@ class SqlQueryPlanJoinBuilder:
                 for name in column_names
             ]
             return SqlQueryPlanJoinBuilder.make_column_equality_sql_join_description(
-                right_source_node=join_data_set.data_set.sql_select_node,
+                right_source_node=join_data_set.data_set.checked_sql_select_node,
                 left_source_alias=from_data_set.alias,
                 right_source_alias=join_data_set.alias,
                 column_equality_descriptions=column_equality_descriptions,
@@ -494,7 +494,7 @@ class SqlQueryPlanJoinBuilder:
             window=node.window,
         )
         return SqlQueryPlanJoinBuilder.make_column_equality_sql_join_description(
-            right_source_node=conversion_data_set.data_set.sql_select_node,
+            right_source_node=conversion_data_set.data_set.checked_sql_select_node,
             left_source_alias=base_data_set.alias,
             right_source_alias=conversion_data_set.alias,
             column_equality_descriptions=column_equality_descriptions,
@@ -521,7 +521,7 @@ class SqlQueryPlanJoinBuilder:
         )
 
         return SqlJoinDescription(
-            right_source=metric_data_set.data_set.sql_select_node,
+            right_source=metric_data_set.data_set.checked_sql_select_node,
             right_source_alias=metric_data_set.alias,
             on_condition=cumulative_join_condition,
             join_type=SqlJoinType.INNER,

--- a/metricflow/query/query_resolver.py
+++ b/metricflow/query/query_resolver.py
@@ -216,7 +216,7 @@ class MetricFlowQueryResolver:
             metric_references=metric_references,
             where_filter_intersection=filter_input.where_filter_intersection,
         )
-        logger.info(f"Resolution DAG is:\n{resolution_dag.text_structure()}")
+        logger.info(f"Resolution DAG is:\n{resolution_dag.structure_text()}")
 
         group_by_item_resolver = GroupByItemResolver(
             manifest_lookup=self._manifest_lookup,

--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -692,7 +692,7 @@ class SqlGroupByRewritingVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
                     )
                 )
             else:
-                logger.info(f"Did not find matching select for {group_by} in:\n{indent(node.text_structure())}")
+                logger.info(f"Did not find matching select for {group_by} in:\n{indent(node.structure_text())}")
                 new_group_bys.append(group_by)
 
         return SqlSelectStatementNode(

--- a/metricflow/test/dataflow/builder/test_cyclic_join.py
+++ b/metricflow/test/dataflow/builder/test_cyclic_join.py
@@ -51,7 +51,7 @@ def test_cyclic_join(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(

--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -54,7 +54,7 @@ def test_simple_plan(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -87,7 +87,7 @@ def test_primary_entity_dimension(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -124,7 +124,7 @@ def test_joined_plan(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -162,7 +162,7 @@ def test_order_by_plan(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -191,7 +191,7 @@ def test_limit_rows_plan(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -225,7 +225,7 @@ def test_multiple_metrics_plan(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -259,7 +259,7 @@ def test_single_semantic_model_ratio_metrics_plan(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -293,7 +293,7 @@ def test_multi_semantic_model_ratio_metrics_plan(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -329,7 +329,7 @@ def test_multihop_join_plan(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -359,7 +359,7 @@ def test_where_constrained_plan(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -388,7 +388,7 @@ def test_where_constrained_plan_time_dimension(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -418,7 +418,7 @@ def test_where_constrained_with_common_linkable_plan(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -470,7 +470,7 @@ def test_cumulative_metric_with_window(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -498,7 +498,7 @@ def test_cumulative_metric_no_window_or_grain_with_metric_time(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -526,7 +526,7 @@ def test_cumulative_metric_no_window_or_grain_without_metric_time(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -557,7 +557,7 @@ def test_distinct_values_plan(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -587,7 +587,7 @@ def test_distinct_values_plan_with_join(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -615,7 +615,7 @@ def test_measure_constraint_plan(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -643,7 +643,7 @@ def test_measure_constraint_with_reused_measure_plan(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -674,7 +674,7 @@ def test_common_semantic_model(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -702,7 +702,7 @@ def test_derived_metric_offset_window(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -730,7 +730,7 @@ def test_derived_metric_offset_to_grain(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -757,7 +757,7 @@ def test_derived_metric_offset_with_granularity(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -784,7 +784,7 @@ def test_derived_offset_cumulative_metric(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -810,7 +810,7 @@ def test_join_to_time_spine_with_metric_time(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -836,7 +836,7 @@ def test_join_to_time_spine_derived_metric(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -864,7 +864,7 @@ def test_join_to_time_spine_with_non_metric_time(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -887,7 +887,7 @@ def test_dont_join_to_time_spine_if_no_time_dimension_requested(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -913,7 +913,7 @@ def test_nested_derived_metric_with_outer_offset(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -942,7 +942,7 @@ def test_min_max_only_categorical(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -971,7 +971,7 @@ def test_min_max_only_time(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -994,7 +994,7 @@ def test_metric_time_only(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -1017,7 +1017,7 @@ def test_metric_time_quarter(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -1046,7 +1046,7 @@ def test_metric_time_with_other_dimensions(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -1075,7 +1075,7 @@ def test_dimensions_with_time_constraint(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -1108,7 +1108,7 @@ def test_min_max_only_time_year(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -1135,7 +1135,7 @@ def test_min_max_metric_time(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -1162,7 +1162,7 @@ def test_min_max_metric_time_week(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -1195,7 +1195,7 @@ def test_join_to_time_spine_with_filters(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -1226,7 +1226,7 @@ def test_offset_window_metric_filter_and_query_have_different_granularities(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -1257,7 +1257,7 @@ def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(

--- a/metricflow/test/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
@@ -50,7 +50,7 @@ def test_read_sql_source_combination(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -88,7 +88,7 @@ def test_filter_combination(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(

--- a/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
@@ -126,7 +126,7 @@ def check_optimization(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -145,7 +145,7 @@ def check_optimization(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=optimized_dataflow_plan,
-        plan_snapshot_text=optimized_dataflow_plan.text_structure(),
+        plan_snapshot_text=optimized_dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(

--- a/metricflow/test/dataset/test_convert_semantic_model.py
+++ b/metricflow/test/dataset/test_convert_semantic_model.py
@@ -39,7 +39,7 @@ def test_convert_table_semantic_model_without_measures(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan_id="plan0",
-        sql_plan_node=users_data_set.sql_select_node,
+        sql_plan_node=users_data_set.checked_sql_select_node,
         sql_client=sql_client,
     )
 
@@ -74,7 +74,7 @@ def test_convert_table_semantic_model_with_measures(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan_id="plan0",
-        sql_plan_node=id_verifications_data_set.sql_select_node,
+        sql_plan_node=id_verifications_data_set.checked_sql_select_node,
         sql_client=sql_client,
     )
 
@@ -94,6 +94,6 @@ def test_convert_query_semantic_model(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan_id="plan0",
-        sql_plan_node=bookings_data_set.sql_select_node,
+        sql_plan_node=bookings_data_set.checked_sql_select_node,
         sql_client=sql_client,
     )

--- a/metricflow/test/examples/test_node_sql.py
+++ b/metricflow/test/examples/test_node_sql.py
@@ -51,11 +51,12 @@ def test_view_sql_generated_at_a_node(
     # Show SQL and spec set at a source node.
     bookings_source_data_set = to_data_set_converter.create_sql_source_data_set(bookings_semantic_model)
     read_source_node = ReadSqlSourceNode(bookings_source_data_set)
-    sql_plan_at_read_node = to_sql_plan_converter.convert_to_sql_query_plan(
+    conversion_result = to_sql_plan_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=read_source_node,
         optimization_level=SqlQueryOptimizationLevel.O4,
     )
+    sql_plan_at_read_node = conversion_result.sql_plan
     sql_at_read_node = sql_renderer.render_sql_query_plan(sql_plan_at_read_node).sql
     spec_set_at_read_node = node_output_resolver.get_output_data_set(read_source_node).instance_set.spec_set
     logger.info(f"SQL generated at {read_source_node} is:\n\n{sql_at_read_node}")
@@ -75,11 +76,12 @@ def test_view_sql_generated_at_a_node(
             ),
         ),
     )
-    sql_plan_at_filter_elements_node = to_sql_plan_converter.convert_to_sql_query_plan(
+    conversion_result = to_sql_plan_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=filter_elements_node,
         optimization_level=SqlQueryOptimizationLevel.O4,
     )
+    sql_plan_at_filter_elements_node = conversion_result.sql_plan
     sql_at_filter_elements_node = sql_renderer.render_sql_query_plan(sql_plan_at_filter_elements_node).sql
     spec_set_at_filter_elements_node = node_output_resolver.get_output_data_set(
         filter_elements_node

--- a/metricflow/test/execution/test_tasks.py
+++ b/metricflow/test/execution/test_tasks.py
@@ -41,7 +41,7 @@ def test_write_table_task(mf_test_session_state: MetricFlowTestSessionState, sql
     output_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=f"test_table_{random_id()}")
     task = SelectSqlQueryToTableTask(
         sql_client=sql_client,
-        sql_query="SELECT 1 AS foo",
+        sql_query=f"CREATE TABLE {output_table.sql} AS SELECT 1 AS foo",
         bind_parameters=SqlBindParameters(),
         output_table=output_table,
     )

--- a/metricflow/test/plan_conversion/test_dataflow_to_execution.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_execution.py
@@ -64,7 +64,7 @@ def test_joined_plan(  # noqa: D
         sql_client=sql_client,
     )
 
-    execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan)
+    execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan).execution_plan
 
     assert_execution_plan_text_equal(
         request=request,
@@ -101,7 +101,7 @@ def test_small_combined_metrics_plan(  # noqa: D
         semantic_manifest_lookup=simple_semantic_manifest_lookup,
         sql_client=sql_client,
     )
-    execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan)
+    execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan).execution_plan
 
     assert_execution_plan_text_equal(
         request=request,
@@ -140,7 +140,7 @@ def test_combined_metrics_plan(  # noqa: D
         semantic_manifest_lookup=simple_semantic_manifest_lookup,
         sql_client=sql_client,
     )
-    execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan)
+    execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan).execution_plan
 
     assert_execution_plan_text_equal(
         request=request,
@@ -185,7 +185,7 @@ def test_multihop_joined_plan(  # noqa: D
         sql_client=sql_client,
     )
 
-    execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan)
+    execution_plan = to_execution_plan_converter.convert_to_execution_plan(dataflow_plan).execution_plan
 
     assert_execution_plan_text_equal(
         request=request,

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -67,13 +67,13 @@ def convert_and_check(
 ) -> None:
     """Convert the dataflow plan to SQL and compare with snapshots."""
     # Generate plans w/o optimizers
-    sql_query_plan = dataflow_to_sql_converter.convert_to_sql_query_plan(
+    conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         sql_query_plan_id=DagId.from_str("plan0"),
         dataflow_plan_node=node,
         optimization_level=SqlQueryOptimizationLevel.O0,
     )
-
+    sql_query_plan = conversion_result.sql_plan
     display_graph_if_requested(
         request=request,
         mf_test_session_state=mf_test_session_state,
@@ -94,13 +94,13 @@ def convert_and_check(
     )
 
     # Generate plans with optimizers
-    sql_query_plan = dataflow_to_sql_converter.convert_to_sql_query_plan(
+    conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         sql_query_plan_id=DagId.from_str("plan0_optimized"),
         dataflow_plan_node=node,
         optimization_level=SqlQueryOptimizationLevel.O4,
     )
-
+    sql_query_plan = conversion_result.sql_plan
     display_graph_if_requested(
         request=request,
         mf_test_session_state=mf_test_session_state,

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -519,7 +519,7 @@ def test_compute_metrics_node_simple_expr(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -587,7 +587,7 @@ def test_join_to_time_spine_node_without_offset(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -656,7 +656,7 @@ def test_join_to_time_spine_node_with_offset_window(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
@@ -726,7 +726,7 @@ def test_join_to_time_spine_node_with_offset_to_grain(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(

--- a/metricflow/test/query/group_by_item/resolution_dag/test_resolution_dags.py
+++ b/metricflow/test/query/group_by_item/resolution_dag/test_resolution_dags.py
@@ -29,5 +29,5 @@ def test_snapshot(
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=resolution_dag,
-        plan_snapshot_text=resolution_dag.text_structure(),
+        plan_snapshot_text=resolution_dag.structure_text(),
     )

--- a/metricflow/test/query_rendering/compare_rendered_query.py
+++ b/metricflow/test/query_rendering/compare_rendered_query.py
@@ -25,13 +25,13 @@ def convert_and_check(
     TODO: refine interface once file move operations are complete.
     """
     # Run dataflow -> sql conversion without optimizers
-    sql_query_plan = dataflow_to_sql_converter.convert_to_sql_query_plan(
+    conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=node,
         optimization_level=SqlQueryOptimizationLevel.O0,
         sql_query_plan_id=DagId.from_str("plan0"),
     )
-
+    sql_query_plan = conversion_result.sql_plan
     display_graph_if_requested(
         request=request,
         mf_test_session_state=mf_test_session_state,
@@ -46,13 +46,13 @@ def convert_and_check(
     )
 
     # Run dataflow -> sql conversion with optimizers
-    sql_query_plan = dataflow_to_sql_converter.convert_to_sql_query_plan(
+    conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=node,
         optimization_level=SqlQueryOptimizationLevel.O4,
         sql_query_plan_id=DagId.from_str("plan0_optimized"),
     )
-
+    sql_query_plan = conversion_result.sql_plan
     display_graph_if_requested(
         request=request,
         mf_test_session_state=mf_test_session_state,

--- a/metricflow/test/snapshot_utils.py
+++ b/metricflow/test/snapshot_utils.py
@@ -242,7 +242,7 @@ def assert_execution_plan_text_equal(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=execution_plan,
-        plan_snapshot_text=execution_plan.text_structure(),
+        plan_snapshot_text=execution_plan.structure_text(),
         incomparable_strings_replacement_function=make_schema_replacement_function(
             system_schema=mf_test_session_state.mf_system_schema,
             source_schema=mf_test_session_state.mf_source_schema,
@@ -261,7 +261,7 @@ def assert_dataflow_plan_text_equal(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=dataflow_plan,
-        plan_snapshot_text=dataflow_plan.text_structure(),
+        plan_snapshot_text=dataflow_plan.structure_text(),
         incomparable_strings_replacement_function=replace_dataset_id_hash,
         additional_sub_directories_for_snapshots=(sql_client.sql_engine_type.value,),
     )

--- a/metricflow/test/sql/compare_sql_plan.py
+++ b/metricflow/test/sql/compare_sql_plan.py
@@ -84,7 +84,7 @@ def assert_sql_plan_text_equal(  # noqa: D
         request=request,
         mf_test_session_state=mf_test_session_state,
         plan=sql_query_plan,
-        plan_snapshot_text=sql_query_plan.text_structure(),
+        plan_snapshot_text=sql_query_plan.structure_text(),
         incomparable_strings_replacement_function=make_schema_replacement_function(
             system_schema=mf_test_session_state.mf_system_schema, source_schema=mf_test_session_state.mf_source_schema
         ),


### PR DESCRIPTION
### Description

Once the `SqlCreateTableAs` node is available, generation of the associated statement can be done through the SQL-engine renderer instead of a one-off Jinja template in the executed task.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
