### PR TITLE
Update `MetricFlowTestSessionState` / `pytest` Flags for Displaying Graphs / Snapshots

### DIFF
--- a/metricflow/test/api/test_metricflow_client.py
+++ b/metricflow/test/api/test_metricflow_client.py
@@ -6,10 +6,10 @@ from metricflow.api.metricflow_client import MetricFlowClient
 from metricflow.engine.models import Dimension, Metric
 from metricflow.random_id import random_id
 from metricflow.sql.sql_table import SqlTable
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 
 
-def test_query(mf_client: MetricFlowClient, mf_test_session_state: MetricFlowTestSessionState) -> None:  # noqa: D
+def test_query(mf_client: MetricFlowClient, mf_test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D
     result = mf_client.query(
         ["bookings"],
         ["metric_time"],
@@ -24,7 +24,7 @@ def test_query(mf_client: MetricFlowClient, mf_test_session_state: MetricFlowTes
     assert len(result.result_df) == 2
     assert result.result_table is None
 
-    output_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=f"test_table_{random_id()}")
+    output_table = SqlTable(schema_name=mf_test_configuration.mf_system_schema, table_name=f"test_table_{random_id()}")
     result = mf_client.query(
         ["bookings"],
         ["metric_time"],
@@ -40,7 +40,7 @@ def test_query(mf_client: MetricFlowClient, mf_test_session_state: MetricFlowTes
     assert result.result_table == output_table
 
 
-def test_explain(mf_client: MetricFlowClient, mf_test_session_state: MetricFlowTestSessionState) -> None:  # noqa: D
+def test_explain(mf_client: MetricFlowClient, mf_test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D
     result = mf_client.explain(
         ["bookings"],
         ["metric_time"],
@@ -53,7 +53,7 @@ def test_explain(mf_client: MetricFlowClient, mf_test_session_state: MetricFlowT
     assert result.execution_plan
     assert result.output_table is None
 
-    output_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=f"test_table_{random_id()}")
+    output_table = SqlTable(schema_name=mf_test_configuration.mf_system_schema, table_name=f"test_table_{random_id()}")
     result = mf_client.explain(
         ["bookings"],
         ["metric_time"],

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -28,7 +28,7 @@ from metricflow.cli.main import (
 )
 from metricflow.protocols.sql_client import SqlClient, SqlEngine
 from metricflow.test.fixtures.cli_fixtures import MetricFlowCliRunner
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.model.example_project_configuration import EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE
 from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 
@@ -167,7 +167,7 @@ def test_list_entities(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
 def test_saved_query(  # noqa: D
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     cli_runner: MetricFlowCliRunner,
     sql_client: SqlClient,
 ) -> None:
@@ -180,7 +180,7 @@ def test_saved_query(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="cli_output",
         snapshot_str=resp.output,
         sql_engine=sql_client.sql_engine_type,
@@ -191,7 +191,7 @@ def test_saved_query(  # noqa: D
 def test_saved_query_with_where(  # noqa: D
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     cli_runner: MetricFlowCliRunner,
     sql_client: SqlClient,
 ) -> None:
@@ -211,7 +211,7 @@ def test_saved_query_with_where(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="cli_output",
         snapshot_str=resp.output,
         sql_engine=sql_client.sql_engine_type,
@@ -222,7 +222,7 @@ def test_saved_query_with_where(  # noqa: D
 def test_saved_query_with_limit(  # noqa: D
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     cli_runner: MetricFlowCliRunner,
     sql_client: SqlClient,
 ) -> None:
@@ -242,7 +242,7 @@ def test_saved_query_with_limit(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="cli_output",
         snapshot_str=resp.output,
         sql_engine=sql_client.sql_engine_type,
@@ -251,7 +251,7 @@ def test_saved_query_with_limit(  # noqa: D
 
 def test_saved_query_explain(  # noqa: D
     capsys: pytest.CaptureFixture,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     cli_runner: MetricFlowCliRunner,
 ) -> None:
     resp = cli_runner.run(
@@ -267,7 +267,7 @@ def test_saved_query_explain(  # noqa: D
 def test_saved_query_with_cumulative_metric(  # noqa: D
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     cli_runner: MetricFlowCliRunner,
     sql_client: SqlClient,
 ) -> None:
@@ -287,7 +287,7 @@ def test_saved_query_with_cumulative_metric(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="cli_output",
         snapshot_str=resp.output,
         sql_engine=sql_client.sql_engine_type,

--- a/metricflow/test/dataflow/builder/test_cyclic_join.py
+++ b/metricflow/test/dataflow/builder/test_cyclic_join.py
@@ -15,7 +15,7 @@ from metricflow.specs.specs import (
 )
 from metricflow.test.dataflow_plan_to_svg import display_graph_if_requested
 from metricflow.test.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.fixtures.sql_client_fixtures import sql_client  # noqa: F401, F403
 from metricflow.test.snapshot_utils import assert_plan_snapshot_text_equal
 
@@ -31,7 +31,7 @@ def cyclic_join_manifest_dataflow_plan_builder(  # noqa: D
 
 def test_cyclic_join(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     cyclic_join_manifest_dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests that sources with the same joinable keys don't cause cycle issues."""
@@ -49,13 +49,13 @@ def test_cyclic_join(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )

--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -24,7 +24,7 @@ from metricflow.specs.specs import (
     TimeDimensionSpec,
 )
 from metricflow.test.dataflow_plan_to_svg import display_graph_if_requested
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_plan_snapshot_text_equal
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_MONTH, MTD_SPEC_QUARTER, MTD_SPEC_WEEK
 
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.sql_engine_snapshot
 def test_simple_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a simple plan getting a metric and a local dimension."""
@@ -52,14 +52,14 @@ def test_simple_plan(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -67,7 +67,7 @@ def test_simple_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_primary_entity_dimension(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a simple plan getting a metric and a local dimension."""
@@ -85,14 +85,14 @@ def test_primary_entity_dimension(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -100,7 +100,7 @@ def test_primary_entity_dimension(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_joined_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan getting a measure and a joined dimension."""
@@ -122,14 +122,14 @@ def test_joined_plan(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -137,7 +137,7 @@ def test_joined_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_order_by_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan with an order by."""
@@ -160,14 +160,14 @@ def test_order_by_plan(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -175,7 +175,7 @@ def test_order_by_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_limit_rows_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan with a limit to the number of rows returned."""
@@ -189,14 +189,14 @@ def test_limit_rows_plan(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -204,7 +204,7 @@ def test_limit_rows_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_multiple_metrics_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan to retrieve multiple metrics."""
@@ -223,14 +223,14 @@ def test_multiple_metrics_plan(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -238,7 +238,7 @@ def test_multiple_metrics_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_single_semantic_model_ratio_metrics_plan(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan to retrieve a ratio where both measures come from one semantic model."""
@@ -257,14 +257,14 @@ def test_single_semantic_model_ratio_metrics_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -272,7 +272,7 @@ def test_single_semantic_model_ratio_metrics_plan(
 @pytest.mark.sql_engine_snapshot
 def test_multi_semantic_model_ratio_metrics_plan(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan to retrieve a ratio where both measures come from one semantic model."""
@@ -291,14 +291,14 @@ def test_multi_semantic_model_ratio_metrics_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -306,7 +306,7 @@ def test_multi_semantic_model_ratio_metrics_plan(
 @pytest.mark.sql_engine_snapshot
 def test_multihop_join_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     multihop_dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan with an order by."""
@@ -327,14 +327,14 @@ def test_multihop_join_plan(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -342,7 +342,7 @@ def test_multihop_join_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_where_constrained_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
@@ -357,14 +357,14 @@ def test_where_constrained_plan(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -372,7 +372,7 @@ def test_where_constrained_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_where_constrained_plan_time_dimension(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -386,14 +386,14 @@ def test_where_constrained_plan_time_dimension(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -401,7 +401,7 @@ def test_where_constrained_plan_time_dimension(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_where_constrained_with_common_linkable_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
@@ -416,21 +416,21 @@ def test_where_constrained_with_common_linkable_plan(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 @pytest.mark.sql_engine_snapshot
 def test_multihop_join_plan_ambiguous_dim(  # noqa: D
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Checks that an exception is thrown when trying to build a plan with an ambiguous dimension."""
@@ -454,7 +454,7 @@ def test_multihop_join_plan_ambiguous_dim(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_with_window(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan to compute a cumulative metric."""
@@ -468,14 +468,14 @@ def test_cumulative_metric_with_window(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -483,7 +483,7 @@ def test_cumulative_metric_with_window(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_no_window_or_grain_with_metric_time(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan(
@@ -496,14 +496,14 @@ def test_cumulative_metric_no_window_or_grain_with_metric_time(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -511,7 +511,7 @@ def test_cumulative_metric_no_window_or_grain_with_metric_time(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_no_window_or_grain_without_metric_time(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan(
@@ -524,14 +524,14 @@ def test_cumulative_metric_no_window_or_grain_without_metric_time(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -539,7 +539,7 @@ def test_cumulative_metric_no_window_or_grain_without_metric_time(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_distinct_values_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -555,14 +555,14 @@ def test_distinct_values_plan(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -570,7 +570,7 @@ def test_distinct_values_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_distinct_values_plan_with_join(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
 ) -> None:
@@ -585,14 +585,14 @@ def test_distinct_values_plan_with_join(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -600,7 +600,7 @@ def test_distinct_values_plan_with_join(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_measure_constraint_plan(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
@@ -613,14 +613,14 @@ def test_measure_constraint_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -628,7 +628,7 @@ def test_measure_constraint_plan(
 @pytest.mark.sql_engine_snapshot
 def test_measure_constraint_with_reused_measure_plan(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
@@ -641,14 +641,14 @@ def test_measure_constraint_with_reused_measure_plan(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -656,7 +656,7 @@ def test_measure_constraint_with_reused_measure_plan(
 @pytest.mark.sql_engine_snapshot
 def test_common_semantic_model(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a simple plan getting a metric and a local dimension."""
@@ -672,14 +672,14 @@ def test_common_semantic_model(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -687,7 +687,7 @@ def test_common_semantic_model(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_offset_window(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a simple plan getting a metric and a local dimension."""
@@ -700,14 +700,14 @@ def test_derived_metric_offset_window(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -715,7 +715,7 @@ def test_derived_metric_offset_window(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_offset_to_grain(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a simple plan getting a metric and a local dimension."""
@@ -728,14 +728,14 @@ def test_derived_metric_offset_to_grain(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -743,7 +743,7 @@ def test_derived_metric_offset_to_grain(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_offset_with_granularity(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan(
@@ -755,14 +755,14 @@ def test_derived_metric_offset_with_granularity(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -770,7 +770,7 @@ def test_derived_metric_offset_with_granularity(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_offset_cumulative_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan(
@@ -782,21 +782,21 @@ def test_derived_offset_cumulative_metric(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_join_to_time_spine_with_metric_time(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan(
@@ -808,21 +808,21 @@ def test_join_to_time_spine_with_metric_time(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_join_to_time_spine_derived_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan(
@@ -834,21 +834,21 @@ def test_join_to_time_spine_derived_metric(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_join_to_time_spine_with_non_metric_time(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan(
@@ -862,21 +862,21 @@ def test_join_to_time_spine_with_non_metric_time(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_dont_join_to_time_spine_if_no_time_dimension_requested(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan(
@@ -885,21 +885,21 @@ def test_dont_join_to_time_spine_if_no_time_dimension_requested(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_nested_derived_metric_with_outer_offset(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan(
@@ -911,21 +911,21 @@ def test_nested_derived_metric_with_outer_offset(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_min_max_only_categorical(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan to get the min & max distinct values of a categorical dimension."""
@@ -940,21 +940,21 @@ def test_min_max_only_categorical(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_min_max_only_time(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan to get the min & max distinct values of a time dimension."""
@@ -969,21 +969,21 @@ def test_min_max_only_time(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_metric_time_only(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
@@ -992,21 +992,21 @@ def test_metric_time_only(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_metric_time_quarter(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
@@ -1015,21 +1015,21 @@ def test_metric_time_quarter(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_metric_time_with_other_dimensions(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
@@ -1044,21 +1044,21 @@ def test_metric_time_with_other_dimensions(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_dimensions_with_time_constraint(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
@@ -1073,21 +1073,21 @@ def test_dimensions_with_time_constraint(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_min_max_only_time_year(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan to get the min & max distinct values of a time dimension with year granularity."""
@@ -1106,21 +1106,21 @@ def test_min_max_only_time_year(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_min_max_metric_time(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan to get the min & max distinct values of metric_time."""
@@ -1133,21 +1133,21 @@ def test_min_max_metric_time(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_min_max_metric_time_week(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a plan to get the min & max distinct values of metric_time with non-default granularity."""
@@ -1160,21 +1160,21 @@ def test_min_max_metric_time_week(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_join_to_time_spine_with_filters(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -1193,21 +1193,21 @@ def test_join_to_time_spine_with_filters(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_offset_window_metric_filter_and_query_have_different_granularities(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -1224,21 +1224,21 @@ def test_offset_window_metric_filter_and_query_have_different_granularities(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
 
 def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
     create_source_tables: bool,
@@ -1255,13 +1255,13 @@ def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )

--- a/metricflow/test/dataflow/builder/test_node_data_set.py
+++ b/metricflow/test/dataflow/builder/test_node_data_set.py
@@ -27,7 +27,7 @@ from metricflow.sql.sql_exprs import SqlColumnReference, SqlColumnReferenceExpre
 from metricflow.sql.sql_plan import SqlJoinType, SqlSelectColumn, SqlSelectStatementNode, SqlTableFromClauseNode
 from metricflow.sql.sql_table import SqlTable
 from metricflow.test.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_spec_set_snapshot_equal
 
 logger = logging.getLogger(__name__)
@@ -91,7 +91,7 @@ def test_no_parent_node_data_set(
 
 def test_joined_node_data_set(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     simple_semantic_manifest_lookup: SemanticManifestLookup,
     time_spine_source: TimeSpineSource,
@@ -122,7 +122,7 @@ def test_joined_node_data_set(  # noqa: D
 
     assert_spec_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="result0",
         spec_set=join_node_output_data_set.instance_set.spec_set,
     )

--- a/metricflow/test/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
@@ -20,7 +20,7 @@ from metricflow.dataflow.optimizer.source_scan.cm_branch_combiner import (
 from metricflow.specs.specs import InstanceSpecSet, MeasureSpec
 from metricflow.test.dataflow_plan_to_svg import display_graph_if_requested
 from metricflow.test.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_plan_snapshot_text_equal
 
 
@@ -34,7 +34,7 @@ def make_dataflow_plan(node: BaseOutput) -> DataflowPlan:  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_read_sql_source_combination(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
 ) -> None:
     """Tests combining a single node."""
@@ -48,14 +48,14 @@ def test_read_sql_source_combination(  # noqa: D
     dataflow_plan = make_dataflow_plan(result.combined_branch)
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -63,7 +63,7 @@ def test_read_sql_source_combination(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_filter_combination(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
 ) -> None:
     """Tests combining a single node."""
@@ -86,13 +86,13 @@ def test_filter_combination(  # noqa: D
     dataflow_plan = make_dataflow_plan(result.combined_branch)
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )

--- a/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
@@ -42,7 +42,7 @@ from metricflow.specs.specs import (
     MetricSpec,
 )
 from metricflow.test.dataflow_plan_to_svg import display_graph_if_requested
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_plan_snapshot_text_equal
 
 logger = logging.getLogger(__name__)
@@ -114,7 +114,7 @@ class ReadSqlSourceNodeCounter(DataflowPlanNodeVisitor[int]):
 
 def check_optimization(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_spec: MetricFlowQuerySpec,
     expected_num_sources_in_unoptimized: int,
@@ -124,14 +124,14 @@ def check_optimization(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
@@ -143,14 +143,14 @@ def check_optimization(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=optimized_dataflow_plan,
         plan_snapshot_text=optimized_dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=optimized_dataflow_plan,
     )
     assert source_counter.count_source_nodes(optimized_dataflow_plan) == expected_num_sources_in_optimized
@@ -159,7 +159,7 @@ def check_optimization(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_2_metrics_from_1_semantic_model(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests that optimizing the plan for 2 metrics from 2 measure semantic models results in half the number of scans.
@@ -168,7 +168,7 @@ def test_2_metrics_from_1_semantic_model(  # noqa: D
     """
     check_optimization(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="bookings"), MetricSpec(element_name="booking_value")),
@@ -185,13 +185,13 @@ def test_2_metrics_from_1_semantic_model(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_2_metrics_from_2_semantic_models(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests that 2 metrics from the 2 semantic models results in 2 scans."""
     check_optimization(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="bookings"), MetricSpec(element_name="listings")),
@@ -205,13 +205,13 @@ def test_2_metrics_from_2_semantic_models(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_3_metrics_from_2_semantic_models(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests that 3 metrics from the 2 semantic models results in 2 scans."""
     check_optimization(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=MetricFlowQuerySpec(
             metric_specs=(
@@ -229,7 +229,7 @@ def test_3_metrics_from_2_semantic_models(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_constrained_metric_not_combined(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
@@ -245,7 +245,7 @@ def test_constrained_metric_not_combined(  # noqa: D
     )
     check_optimization(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=query_spec,
         expected_num_sources_in_unoptimized=2,
@@ -256,7 +256,7 @@ def test_constrained_metric_not_combined(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests optimization of a query that use a derived metrics with measures coming from a single semantic model.
@@ -265,7 +265,7 @@ def test_derived_metric(  # noqa: D
     """
     check_optimization(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="non_referred_bookings_pct"),),
@@ -279,7 +279,7 @@ def test_derived_metric(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_nested_derived_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests optimization of a query that use a nested derived metric from a single semantic model.
@@ -289,7 +289,7 @@ def test_nested_derived_metric(  # noqa: D
     """
     check_optimization(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="instant_plus_non_referred_bookings_pct"),),
@@ -303,7 +303,7 @@ def test_nested_derived_metric(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_non_derived_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests optimization of queries that use derived metrics and non-derived metrics.
@@ -318,7 +318,7 @@ def test_derived_metric_with_non_derived_metric(  # noqa: D
     """
     check_optimization(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=MetricFlowQuerySpec(
             metric_specs=(
@@ -335,13 +335,13 @@ def test_derived_metric_with_non_derived_metric(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_2_ratio_metrics_from_1_semantic_model(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests that 2 ratio metrics with measures from a 1 semantic model result in 1 scan."""
     check_optimization(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=MetricFlowQuerySpec(
             metric_specs=(
@@ -358,13 +358,13 @@ def test_2_ratio_metrics_from_1_semantic_model(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_duplicate_measures(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
     """Tests a case where derived metrics in a query use the same measure (in the same form e.g. filters)."""
     check_optimization(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=MetricFlowQuerySpec(
             metric_specs=(

--- a/metricflow/test/dataflow_plan_to_svg.py
+++ b/metricflow/test/dataflow_plan_to_svg.py
@@ -15,7 +15,7 @@ def display_graph_if_requested(
     dag_graph: DagGraphT,
 ) -> None:
     """Create and display the plan as an SVG, if requested to do so."""
-    if not mf_test_session_state.display_plans:
+    if not mf_test_session_state.display_snapshots:
         return
 
     if len(request.session.items) > 1:

--- a/metricflow/test/dataflow_plan_to_svg.py
+++ b/metricflow/test/dataflow_plan_to_svg.py
@@ -18,6 +18,9 @@ def display_graph_if_requested(
     if not mf_test_session_state.display_plans:
         return
 
+    if len(request.session.items) > 1:
+        raise ValueError("Displaying graphs is only supported when there's a single item in a testing session.")
+
     plan_svg_output_path_prefix = snapshot_path_prefix(
         request=request, snapshot_group=dag_graph.__class__.__name__, snapshot_id=str(dag_graph.dag_id)
     )
@@ -25,9 +28,4 @@ def display_graph_if_requested(
     # Create parent directory since it might not exist
     os.makedirs(os.path.dirname(plan_svg_output_path_prefix), exist_ok=True)
 
-    if mf_test_session_state.plans_displayed >= mf_test_session_state.max_plans_displayed:
-        raise RuntimeError(
-            f"Can't display plan - hit limit of {mf_test_session_state.max_plans_displayed} plans displayed."
-        )
     render_via_graphviz(dag_graph=dag_graph, file_path_without_svg_suffix=plan_svg_output_path_prefix)
-    mf_test_session_state.plans_displayed += 1

--- a/metricflow/test/dataflow_plan_to_svg.py
+++ b/metricflow/test/dataflow_plan_to_svg.py
@@ -5,17 +5,17 @@ import os
 from _pytest.fixtures import FixtureRequest
 
 from metricflow.dag.dag_visualization import DagGraphT, render_via_graphviz
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import snapshot_path_prefix
 
 
 def display_graph_if_requested(
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     request: FixtureRequest,
     dag_graph: DagGraphT,
 ) -> None:
     """Create and display the plan as an SVG, if requested to do so."""
-    if not mf_test_session_state.display_graphs:
+    if not mf_test_configuration.display_graphs:
         return
 
     if len(request.session.items) > 1:

--- a/metricflow/test/dataflow_plan_to_svg.py
+++ b/metricflow/test/dataflow_plan_to_svg.py
@@ -15,7 +15,7 @@ def display_graph_if_requested(
     dag_graph: DagGraphT,
 ) -> None:
     """Create and display the plan as an SVG, if requested to do so."""
-    if not mf_test_session_state.display_snapshots:
+    if not mf_test_session_state.display_graphs:
         return
 
     if len(request.session.items) > 1:

--- a/metricflow/test/dataset/test_convert_semantic_model.py
+++ b/metricflow/test/dataset/test_convert_semantic_model.py
@@ -9,7 +9,7 @@ from dbt_semantic_interfaces.references import SemanticModelReference
 
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.test.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_spec_set_snapshot_equal
 from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_equal
 
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.sql_engine_snapshot
 def test_convert_table_semantic_model_without_measures(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
 ) -> None:
@@ -30,14 +30,14 @@ def test_convert_table_semantic_model_without_measures(  # noqa: D
 
     assert_spec_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="result0",
         spec_set=users_data_set.instance_set.spec_set,
     )
     assert users_data_set.semantic_model_reference == SemanticModelReference(semantic_model_name="users_latest")
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan_id="plan0",
         sql_plan_node=users_data_set.checked_sql_select_node,
         sql_client=sql_client,
@@ -47,7 +47,7 @@ def test_convert_table_semantic_model_without_measures(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_convert_table_semantic_model_with_measures(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
 ) -> None:
@@ -62,7 +62,7 @@ def test_convert_table_semantic_model_with_measures(  # noqa: D
 
     assert_spec_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="result0",
         spec_set=id_verifications_data_set.instance_set.spec_set,
     )
@@ -72,7 +72,7 @@ def test_convert_table_semantic_model_with_measures(  # noqa: D
     )
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan_id="plan0",
         sql_plan_node=id_verifications_data_set.checked_sql_select_node,
         sql_client=sql_client,
@@ -82,7 +82,7 @@ def test_convert_table_semantic_model_with_measures(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_convert_query_semantic_model(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
 ) -> None:
@@ -92,7 +92,7 @@ def test_convert_query_semantic_model(  # noqa: D
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan_id="plan0",
         sql_plan_node=bookings_data_set.checked_sql_select_node,
         sql_client=sql_client,

--- a/metricflow/test/execution/test_tasks.py
+++ b/metricflow/test/execution/test_tasks.py
@@ -14,7 +14,7 @@ from metricflow.random_id import random_id
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql.sql_table import SqlTable
 from metricflow.test.compare_df import assert_dataframes_equal
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 
 
 def test_read_sql_task(sql_client: SqlClient) -> None:  # noqa: D
@@ -37,8 +37,8 @@ def test_read_sql_task(sql_client: SqlClient) -> None:  # noqa: D
     )
 
 
-def test_write_table_task(mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient) -> None:  # noqa: D
-    output_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=f"test_table_{random_id()}")
+def test_write_table_task(mf_test_configuration: MetricFlowTestConfiguration, sql_client: SqlClient) -> None:  # noqa: D
+    output_table = SqlTable(schema_name=mf_test_configuration.mf_system_schema, table_name=f"test_table_{random_id()}")
     task = SelectSqlQueryToTableTask(
         sql_client=sql_client,
         sql_query=f"CREATE TABLE {output_table.sql} AS SELECT 1 AS foo",

--- a/metricflow/test/fixtures/dataflow_fixtures.py
+++ b/metricflow/test/fixtures/dataflow_fixtures.py
@@ -10,7 +10,7 @@ from metricflow.protocols.sql_client import SqlClient
 from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.specs.column_assoc import ColumnAssociationResolver
 from metricflow.test.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.fixtures.sql_client_fixtures import sql_client  # noqa: F401, F403
 
 """
@@ -84,6 +84,6 @@ def scd_query_parser(  # noqa: D
 
 @pytest.fixture(scope="session")
 def time_spine_source(  # noqa: D
-    sql_client: SqlClient, mf_test_session_state: MetricFlowTestSessionState  # noqa: F811
+    sql_client: SqlClient, mf_test_configuration: MetricFlowTestConfiguration  # noqa: F811
 ) -> TimeSpineSource:
-    return TimeSpineSource(schema_name=mf_test_session_state.mf_source_schema, table_name="mf_time_spine")
+    return TimeSpineSource(schema_name=mf_test_configuration.mf_source_schema, table_name="mf_time_spine")

--- a/metricflow/test/fixtures/manifest_fixtures.py
+++ b/metricflow/test/fixtures/manifest_fixtures.py
@@ -31,7 +31,7 @@ from metricflow.protocols.sql_client import SqlClient
 from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.specs.column_assoc import ColumnAssociationResolver
 from metricflow.test.fixtures.id_fixtures import IdNumberSpace, patch_id_generators_helper
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
 
 logger = logging.getLogger(__name__)
@@ -251,9 +251,9 @@ def load_semantic_manifest(
 
 
 @pytest.fixture(scope="session")
-def template_mapping(mf_test_session_state: MetricFlowTestSessionState) -> Dict[str, str]:
+def template_mapping(mf_test_configuration: MetricFlowTestConfiguration) -> Dict[str, str]:
     """Mapping for template variables in the model YAML files."""
-    return {"source_schema": mf_test_session_state.mf_source_schema}
+    return {"source_schema": mf_test_configuration.mf_source_schema}
 
 
 @pytest.fixture(scope="session")

--- a/metricflow/test/fixtures/setup_fixtures.py
+++ b/metricflow/test/fixtures/setup_fixtures.py
@@ -20,7 +20,7 @@ from metricflow.test.table_snapshot.table_snapshots import SqlTableSnapshotHash,
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class MetricFlowTestSessionState:
     """State that is shared between tests during a testing session."""
 
@@ -35,12 +35,6 @@ class MetricFlowTestSessionState:
     display_plans: bool
     # Whether to overwrite any text files that were generated.
     overwrite_snapshots: bool
-    # Number of plans that were displayed to the user.
-    plans_displayed: int
-    # Maximum number of plans to display to the user. If this is exceeded, an exception should be thrown. This is to
-    # help avoid a case where an excessive number of plans are displayed. This could happen if the user accidentally
-    # runs all tests when they were just looking to run one test and visualize the associated plan.
-    max_plans_displayed: int
 
     # The source schema contains tables that are used for running tests. If this is set, a source schema in the SQL
     # is created and persisted between runs. The source schema name includes a hash of the tables that should be in
@@ -155,8 +149,6 @@ def mf_test_session_state(  # noqa: D
         mf_source_schema=mf_source_schema,
         display_plans=bool(request.config.getoption(DISPLAY_PLANS_CLI_FLAG, default=False)),
         overwrite_snapshots=bool(request.config.getoption(OVERWRITE_SNAPSHOTS_CLI_FLAG, default=False)),
-        plans_displayed=0,
-        max_plans_displayed=6,
         use_persistent_source_schema=bool(
             request.config.getoption(USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG, default=False)
         ),

--- a/metricflow/test/fixtures/setup_fixtures.py
+++ b/metricflow/test/fixtures/setup_fixtures.py
@@ -33,6 +33,8 @@ class MetricFlowTestSessionState:
 
     # Whether to display the snapshot associated with a test session in a browser window.
     display_snapshots: bool
+    # Whether to display the graph associated with a test session in a browser window.
+    display_graphs: bool
     # Whether to overwrite any text files that were generated.
     overwrite_snapshots: bool
 
@@ -43,6 +45,7 @@ class MetricFlowTestSessionState:
 
 
 DISPLAY_SNAPSHOTS_CLI_FLAG = "--display-snapshots"
+DISPLAY_GRAPHS_CLI_FLAG = "--display-graphs"
 OVERWRITE_SNAPSHOTS_CLI_FLAG = "--overwrite-snapshots"
 USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG = "--use-persistent-source-schema"
 
@@ -50,6 +53,11 @@ USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG = "--use-persistent-source-schema"
 def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
     """Add options for running pytest through the CLI."""
     parser.addoption(DISPLAY_SNAPSHOTS_CLI_FLAG, action="store_true", help="Displays snapshots in a browser if set")
+    parser.addoption(
+        DISPLAY_GRAPHS_CLI_FLAG,
+        action="store_true",
+        help="Allow display of graphs in a browser window when triggered in a test",
+    )
     parser.addoption(
         OVERWRITE_SNAPSHOTS_CLI_FLAG,
         action="store_true",
@@ -148,6 +156,7 @@ def mf_test_session_state(  # noqa: D
         mf_system_schema=mf_system_schema,
         mf_source_schema=mf_source_schema,
         display_snapshots=bool(request.config.getoption(DISPLAY_SNAPSHOTS_CLI_FLAG, default=False)),
+        display_graphs=bool(request.config.getoption(DISPLAY_GRAPHS_CLI_FLAG, default=False)),
         overwrite_snapshots=bool(request.config.getoption(OVERWRITE_SNAPSHOTS_CLI_FLAG, default=False)),
         use_persistent_source_schema=bool(
             request.config.getoption(USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG, default=False)

--- a/metricflow/test/fixtures/setup_fixtures.py
+++ b/metricflow/test/fixtures/setup_fixtures.py
@@ -50,25 +50,41 @@ OVERWRITE_SNAPSHOTS_CLI_FLAG = "--overwrite-snapshots"
 USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG = "--use-persistent-source-schema"
 
 
-def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
-    """Add options for running pytest through the CLI."""
+def add_display_snapshots_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D
     parser.addoption(DISPLAY_SNAPSHOTS_CLI_FLAG, action="store_true", help="Displays snapshots in a browser if set")
-    parser.addoption(
-        DISPLAY_GRAPHS_CLI_FLAG,
-        action="store_true",
-        help="Allow display of graphs in a browser window when triggered in a test",
-    )
+
+
+def add_overwrite_snapshots_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D
     parser.addoption(
         OVERWRITE_SNAPSHOTS_CLI_FLAG,
         action="store_true",
         help="Overwrites existing snapshots by ones generated during this testing session",
     )
+
+
+def add_display_graphs_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D
+    parser.addoption(
+        DISPLAY_GRAPHS_CLI_FLAG,
+        action="store_true",
+        help="Allow display of graphs in a browser window when triggered in a test",
+    )
+
+
+def add_use_persistent_source_schema_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D
     parser.addoption(
         USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG,
         action="store_true",
         help="Use a source schema that is persisted between testing sessions. The name of the schema is generated from"
         "a hash of the source data, and the schema is created / populated if it does not exist.",
     )
+
+
+def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
+    """Add options for running pytest through the CLI."""
+    add_overwrite_snapshots_cli_flag(parser)
+    add_display_snapshots_cli_flag(parser)
+    add_display_graphs_cli_flag(parser)
+    add_use_persistent_source_schema_cli_flag(parser)
 
 
 # Name of the pytest marker for tests that generate SQL-engine specific snapshots.

--- a/metricflow/test/fixtures/setup_fixtures.py
+++ b/metricflow/test/fixtures/setup_fixtures.py
@@ -31,8 +31,8 @@ class MetricFlowTestSessionState:
     # Where tables for test data sets should be stored.
     mf_source_schema: str
 
-    # Number of plans that were displayed to the user.
-    display_plans: bool
+    # Whether to display the snapshot associated with a test session in a browser window.
+    display_snapshots: bool
     # Whether to overwrite any text files that were generated.
     overwrite_snapshots: bool
 
@@ -42,14 +42,14 @@ class MetricFlowTestSessionState:
     use_persistent_source_schema: bool
 
 
-DISPLAY_PLANS_CLI_FLAG = "--display-plans"
+DISPLAY_SNAPSHOTS_CLI_FLAG = "--display-snapshots"
 OVERWRITE_SNAPSHOTS_CLI_FLAG = "--overwrite-snapshots"
 USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG = "--use-persistent-source-schema"
 
 
 def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
     """Add options for running pytest through the CLI."""
-    parser.addoption(DISPLAY_PLANS_CLI_FLAG, action="store_true", help="Displays plans as SVGs in a browser tab if set")
+    parser.addoption(DISPLAY_SNAPSHOTS_CLI_FLAG, action="store_true", help="Displays snapshots in a browser if set")
     parser.addoption(
         OVERWRITE_SNAPSHOTS_CLI_FLAG,
         action="store_true",
@@ -147,7 +147,7 @@ def mf_test_session_state(  # noqa: D
         sql_engine_password=engine_password,
         mf_system_schema=mf_system_schema,
         mf_source_schema=mf_source_schema,
-        display_plans=bool(request.config.getoption(DISPLAY_PLANS_CLI_FLAG, default=False)),
+        display_snapshots=bool(request.config.getoption(DISPLAY_SNAPSHOTS_CLI_FLAG, default=False)),
         overwrite_snapshots=bool(request.config.getoption(OVERWRITE_SNAPSHOTS_CLI_FLAG, default=False)),
         use_persistent_source_schema=bool(
             request.config.getoption(USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG, default=False)

--- a/metricflow/test/fixtures/setup_fixtures.py
+++ b/metricflow/test/fixtures/setup_fixtures.py
@@ -21,7 +21,17 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class MetricFlowTestConfiguration:
+class SnapshotConfiguration:
+    """Configuration for handling snapshots in a test session."""
+
+    # Whether to display the snapshot associated with a test session in a browser window.
+    display_snapshots: bool
+    # Whether to overwrite any text files that were generated.
+    overwrite_snapshots: bool
+
+
+@dataclass(frozen=True)
+class MetricFlowTestConfiguration(SnapshotConfiguration):
     """State that is shared between tests during a testing session."""
 
     sql_engine_url: str
@@ -31,12 +41,8 @@ class MetricFlowTestConfiguration:
     # Where tables for test data sets should be stored.
     mf_source_schema: str
 
-    # Whether to display the snapshot associated with a test session in a browser window.
-    display_snapshots: bool
     # Whether to display the graph associated with a test session in a browser window.
     display_graphs: bool
-    # Whether to overwrite any text files that were generated.
-    overwrite_snapshots: bool
 
     # The source schema contains tables that are used for running tests. If this is set, a source schema in the SQL
     # is created and persisted between runs. The source schema name includes a hash of the tables that should be in

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.fixtures.sql_clients.ddl_sql_client import SqlClientWithDDLMethods
 from metricflow.test.source_schema_tools import create_tables_listed_in_table_snapshot_repository
 from metricflow.test.table_snapshot.table_snapshots import (
@@ -31,7 +31,7 @@ def source_table_snapshot_repository() -> SqlTableSnapshotRepository:  # noqa: D
 
 @pytest.fixture(scope="session", autouse=True)
 def check_time_spine_source(
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     source_table_snapshot_repository: SqlTableSnapshotRepository,
     simple_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> None:
@@ -42,7 +42,7 @@ def check_time_spine_source(
     """
     time_spine_source = simple_semantic_manifest_lookup.time_spine_source
     assert (
-        time_spine_source.schema_name == mf_test_session_state.mf_source_schema
+        time_spine_source.schema_name == mf_test_configuration.mf_source_schema
     ), "The time spine source table should be in the source schema"
 
     time_spine_snapshot_candidates = tuple(
@@ -65,7 +65,7 @@ def check_time_spine_source(
 
 @pytest.fixture(scope="session")
 def create_source_tables(
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ddl_sql_client: SqlClientWithDDLMethods,
     source_table_snapshot_repository: SqlTableSnapshotRepository,
 ) -> None:
@@ -73,7 +73,7 @@ def create_source_tables(
 
     If a table with a given name already exists in the source schema, it's assumed to have the expected schema / data.
     """
-    if mf_test_session_state.use_persistent_source_schema:
+    if mf_test_configuration.use_persistent_source_schema:
         logger.info(
             "This session was configured to use a persistent source schema, so this fixture won't create new tables. "
             "See populate_source_schema() for more details."
@@ -82,6 +82,6 @@ def create_source_tables(
 
     create_tables_listed_in_table_snapshot_repository(
         ddl_sql_client=ddl_sql_client,
-        schema_name=mf_test_session_state.mf_source_schema,
+        schema_name=mf_test_configuration.mf_source_schema,
         table_snapshot_repository=source_table_snapshot_repository,
     )

--- a/metricflow/test/integration/conftest.py
+++ b/metricflow/test/integration/conftest.py
@@ -10,7 +10,7 @@ from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.plan_conversion.column_resolver import DunderColumnAssociationResolver
 from metricflow.plan_conversion.time_spine import TimeSpineSource
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
 
 
@@ -30,7 +30,7 @@ def it_helpers(  # noqa: D
     create_source_tables: bool,
     simple_semantic_manifest_lookup: SemanticManifestLookup,
     time_spine_source: TimeSpineSource,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
 ) -> IntegrationTestHelpers:
     return IntegrationTestHelpers(
         mf_engine=MetricFlowEngine(
@@ -41,7 +41,7 @@ def it_helpers(  # noqa: D
             ),
             time_source=ConfigurableTimeSource(as_datetime("2020-01-01")),
         ),
-        mf_system_schema=mf_test_session_state.mf_system_schema,
-        source_schema=mf_test_session_state.mf_source_schema,
+        mf_system_schema=mf_test_configuration.mf_system_schema,
+        source_schema=mf_test_configuration.mf_source_schema,
         sql_client=sql_client,
     )

--- a/metricflow/test/integration/query_output/test_cumulative_metrics.py
+++ b/metricflow/test/integration/query_output/test_cumulative_metrics.py
@@ -8,7 +8,7 @@ from dbt_semantic_interfaces.test_utils import as_datetime
 
 from metricflow.engine.metricflow_engine import MetricFlowQueryRequest
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.integration.conftest import IntegrationTestHelpers
 from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 
@@ -16,7 +16,7 @@ from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 @pytest.mark.sql_engine_snapshot
 def test_simple_cumulative_metric(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -34,7 +34,7 @@ def test_simple_cumulative_metric(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,
@@ -44,7 +44,7 @@ def test_simple_cumulative_metric(
 @pytest.mark.sql_engine_snapshot
 def test_multiple_cumulative_metrics(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -62,7 +62,7 @@ def test_multiple_cumulative_metrics(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,
@@ -72,7 +72,7 @@ def test_multiple_cumulative_metrics(
 @pytest.mark.sql_engine_snapshot
 def test_non_additive_cumulative_metric(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -90,7 +90,7 @@ def test_non_additive_cumulative_metric(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,
@@ -100,7 +100,7 @@ def test_non_additive_cumulative_metric(
 @pytest.mark.sql_engine_snapshot
 def test_grain_to_date_cumulative_metric(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -118,7 +118,7 @@ def test_grain_to_date_cumulative_metric(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,
@@ -128,7 +128,7 @@ def test_grain_to_date_cumulative_metric(
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_with_non_adjustable_filter(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -152,7 +152,7 @@ def test_cumulative_metric_with_non_adjustable_filter(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,

--- a/metricflow/test/integration/query_output/test_fill_nulls_with_0.py
+++ b/metricflow/test/integration/query_output/test_fill_nulls_with_0.py
@@ -7,7 +7,7 @@ from _pytest.fixtures import FixtureRequest
 
 from metricflow.engine.metricflow_engine import MetricFlowQueryRequest
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.integration.conftest import IntegrationTestHelpers
 from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 
@@ -15,7 +15,7 @@ from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 @pytest.mark.sql_engine_snapshot
 def test_simple_fill_nulls_with_0_metric_time(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -32,7 +32,7 @@ def test_simple_fill_nulls_with_0_metric_time(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,
@@ -42,7 +42,7 @@ def test_simple_fill_nulls_with_0_metric_time(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_simple_fill_nulls_with_0_month(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -59,7 +59,7 @@ def test_simple_fill_nulls_with_0_month(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,
@@ -69,7 +69,7 @@ def test_simple_fill_nulls_with_0_month(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_simple_join_to_time_spine(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -86,7 +86,7 @@ def test_simple_join_to_time_spine(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,
@@ -96,7 +96,7 @@ def test_simple_join_to_time_spine(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_fill_nulls_with_0_multi_metric_query(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -113,7 +113,7 @@ def test_fill_nulls_with_0_multi_metric_query(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,
@@ -123,7 +123,7 @@ def test_fill_nulls_with_0_multi_metric_query(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_fill_nulls_with_0_multi_metric_query_with_categorical_dimension(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -138,7 +138,7 @@ def test_fill_nulls_with_0_multi_metric_query_with_categorical_dimension(  # noq
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,

--- a/metricflow/test/integration/query_output/test_offset_metrics.py
+++ b/metricflow/test/integration/query_output/test_offset_metrics.py
@@ -5,7 +5,7 @@ from _pytest.fixtures import FixtureRequest
 
 from metricflow.engine.metricflow_engine import MetricFlowQueryRequest
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.integration.conftest import IntegrationTestHelpers
 from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 
@@ -13,7 +13,7 @@ from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 @pytest.mark.sql_engine_snapshot
 def test_offset_to_grain_with_single_granularity(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -28,7 +28,7 @@ def test_offset_to_grain_with_single_granularity(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,
@@ -38,7 +38,7 @@ def test_offset_to_grain_with_single_granularity(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_offset_to_grain_with_multiple_granularities(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     it_helpers: IntegrationTestHelpers,
 ) -> None:
@@ -53,7 +53,7 @@ def test_offset_to_grain_with_multiple_granularities(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query_output",
         snapshot_str=query_result.result_df.to_string(),
         sql_engine=sql_client.sql_engine_type,

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -36,7 +36,7 @@ from metricflow.sql.sql_exprs import (
     SqlSubtractTimeIntervalExpression,
 )
 from metricflow.test.compare_df import assert_dataframes_equal
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.integration.configured_test_case import (
     CONFIGURED_INTEGRATION_TESTS_REPOSITORY,
     IntegrationTestModel,
@@ -235,7 +235,7 @@ def filter_not_supported_features(
 )
 def test_case(
     name: str,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     simple_semantic_manifest_lookup: SemanticManifestLookup,
     simple_semantic_manifest_lookup_non_ds: SemanticManifestLookup,
     multi_hop_join_semantic_manifest_lookup: SemanticManifestLookup,
@@ -305,7 +305,7 @@ def test_case(
                 case.where_filter,
                 undefined=jinja2.StrictUndefined,
             ).render(
-                source_schema=mf_test_session_state.mf_source_schema,
+                source_schema=mf_test_configuration.mf_source_schema,
                 render_time_constraint=check_query_helpers.render_time_constraint,
                 render_between_time_constraint=check_query_helpers.render_between_time_constraint,
                 TimeGranularity=TimeGranularity,
@@ -336,7 +336,7 @@ def test_case(
             case.check_query,
             undefined=jinja2.StrictUndefined,
         ).render(
-            source_schema=mf_test_session_state.mf_source_schema,
+            source_schema=mf_test_configuration.mf_source_schema,
             render_time_constraint=check_query_helpers.render_time_constraint,
             render_between_time_constraint=check_query_helpers.render_between_time_constraint,
             TimeGranularity=TimeGranularity,

--- a/metricflow/test/integration/test_rendered_query.py
+++ b/metricflow/test/integration/test_rendered_query.py
@@ -9,7 +9,7 @@ from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.plan_conversion.column_resolver import DunderColumnAssociationResolver
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.sql_table import SqlTable
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.integration.conftest import IntegrationTestHelpers
 from metricflow.test.snapshot_utils import (
     assert_sql_snapshot_equal,
@@ -19,7 +19,7 @@ from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
 
 @pytest.mark.sql_engine_snapshot
 def test_render_query(  # noqa: D
-    request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, it_helpers: IntegrationTestHelpers
+    request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, it_helpers: IntegrationTestHelpers
 ) -> None:
     result = it_helpers.mf_engine.explain(
         MetricFlowQueryRequest.create_with_random_request_id(
@@ -30,7 +30,7 @@ def test_render_query(  # noqa: D
 
     assert_sql_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query0",
         sql=result.rendered_sql.sql_query,
         sql_engine=it_helpers.sql_client.sql_engine_type,
@@ -39,7 +39,7 @@ def test_render_query(  # noqa: D
 
 @pytest.mark.sql_engine_snapshot
 def test_render_write_to_table_query(  # noqa: D
-    request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, it_helpers: IntegrationTestHelpers
+    request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, it_helpers: IntegrationTestHelpers
 ) -> None:
     output_table = SqlTable(schema_name=it_helpers.mf_system_schema, table_name="test_table")
 
@@ -51,7 +51,7 @@ def test_render_write_to_table_query(  # noqa: D
 
     assert_sql_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query0",
         sql=result.rendered_sql.sql_query,
         sql_engine=it_helpers.sql_client.sql_engine_type,
@@ -61,7 +61,7 @@ def test_render_write_to_table_query(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_id_enumeration(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     simple_semantic_manifest_lookup: SemanticManifestLookup,
     sql_client: SqlClient,
 ) -> None:
@@ -84,7 +84,7 @@ def test_id_enumeration(  # noqa: D
 
     assert_sql_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query",
         sql=result.rendered_sql.sql_query,
         sql_engine=sql_client.sql_engine_type,
@@ -100,7 +100,7 @@ def test_id_enumeration(  # noqa: D
 
     assert_sql_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query",
         sql=result.rendered_sql.sql_query,
         sql_engine=sql_client.sql_engine_type,

--- a/metricflow/test/model/semantics/test_linkable_spec_resolver.py
+++ b/metricflow/test/model/semantics/test_linkable_spec_resolver.py
@@ -12,7 +12,7 @@ from metricflow.model.semantics.linkable_spec_resolver import (
     ValidLinkableSpecResolver,
 )
 from metricflow.model.semantics.semantic_model_join_evaluator import MAX_JOIN_HOPS
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_linkable_element_set_snapshot_equal
 
 logger = logging.getLogger(__name__)
@@ -42,12 +42,12 @@ def cyclic_join_manifest_spec_resolver(  # noqa: D
 
 def test_all_properties(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     simple_model_spec_resolver: ValidLinkableSpecResolver,
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="views")],
@@ -59,12 +59,12 @@ def test_all_properties(  # noqa: D
 
 def test_one_property(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     simple_model_spec_resolver: ValidLinkableSpecResolver,
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="views")],
@@ -76,12 +76,12 @@ def test_one_property(  # noqa: D
 
 def test_metric_time_property_for_cumulative_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     simple_model_spec_resolver: ValidLinkableSpecResolver,
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="trailing_2_months_revenue")],
@@ -93,12 +93,12 @@ def test_metric_time_property_for_cumulative_metric(  # noqa: D
 
 def test_metric_time_property_for_derived_metrics(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     simple_model_spec_resolver: ValidLinkableSpecResolver,
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings_per_view")],
@@ -110,12 +110,12 @@ def test_metric_time_property_for_derived_metrics(  # noqa: D
 
 def test_cyclic_join_manifest(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     cyclic_join_manifest_spec_resolver: ValidLinkableSpecResolver,
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=cyclic_join_manifest_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="listings")],

--- a/metricflow/test/model/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/test_data_warehouse_tasks.py
@@ -22,7 +22,7 @@ from metricflow.model.data_warehouse_model_validator import (
 )
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import (
     assert_sql_snapshot_equal,
 )
@@ -51,7 +51,7 @@ def test_build_semantic_model_tasks(  # noqa:D
     assert len(tasks) == len(data_warehouse_validation_model.semantic_models)
 
 
-def test_task_runner(sql_client: SqlClient, mf_test_session_state: MetricFlowTestSessionState) -> None:  # noqa: D
+def test_task_runner(sql_client: SqlClient, mf_test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D
     dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
 
     def good_query() -> Tuple[str, SqlBindParameters]:
@@ -80,7 +80,7 @@ def test_task_runner(sql_client: SqlClient, mf_test_session_state: MetricFlowTes
 def test_validate_semantic_models(  # noqa: D
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
@@ -119,7 +119,7 @@ def test_build_dimension_tasks(  # noqa: D
 def test_validate_dimensions(  # noqa: D
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
@@ -153,7 +153,7 @@ def test_build_entities_tasks(  # noqa: D
 def test_validate_entities(  # noqa: D
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
@@ -187,7 +187,7 @@ def test_build_measure_tasks(  # noqa: D
 def test_validate_measures(  # noqa: D
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
 
@@ -211,7 +211,7 @@ def test_build_metric_tasks(  # noqa: D
     request: FixtureRequest,
     data_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_metric_tasks(
         manifest=data_warehouse_validation_model,
@@ -222,7 +222,7 @@ def test_build_metric_tasks(  # noqa: D
 
     assert_sql_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="query0",
         sql=query_string,
         sql_engine=sql_client.sql_engine_type,
@@ -232,7 +232,7 @@ def test_build_metric_tasks(  # noqa: D
 def test_validate_metrics(  # noqa: D
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:
     model = deepcopy(dw_backed_warehouse_validation_model)
     dw_validator = DataWarehouseModelValidator(sql_client=sql_client)

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -10,7 +10,7 @@ from dbt_semantic_interfaces.references import EntityReference, MeasureReference
 from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
 from metricflow.model.semantics.metric_lookup import MetricLookup
 from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_linkable_element_set_snapshot_equal, assert_object_snapshot_equal
 
 logger = logging.getLogger(__name__)
@@ -32,12 +32,12 @@ def metric_lookup(  # Noqa: D
 
 def test_get_names(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     semantic_model_lookup: SemanticModelLookup,
 ) -> None:
     assert_object_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         obj_id="result0",
         obj={
             "dimension_references": sorted([d.element_name for d in semantic_model_lookup.get_dimension_references()]),
@@ -73,11 +73,11 @@ def test_get_semantic_models_for_measure(semantic_model_lookup: SemanticModelLoo
 
 
 def test_elements_for_metric(  # noqa: D
-    request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, metric_lookup: MetricLookup
+    request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, metric_lookup: MetricLookup
 ) -> None:
     assert_object_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         obj_id="result0",
         obj=tuple(
             spec.qualified_name
@@ -95,11 +95,11 @@ def test_elements_for_metric(  # noqa: D
 
 
 def test_local_linked_elements_for_metric(  # noqa: D
-    request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, metric_lookup: MetricLookup
+    request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, metric_lookup: MetricLookup
 ) -> None:
     assert_object_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         obj_id="result0",
         obj=tuple(
             spec.qualified_name
@@ -119,11 +119,11 @@ def test_get_semantic_models_for_entity(semantic_model_lookup: SemanticModelLook
 
 
 def test_linkable_set(  # noqa: D
-    request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, metric_lookup: MetricLookup
+    request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, metric_lookup: MetricLookup
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=metric_lookup.linkable_set_for_metrics(
             (MetricReference(element_name="views"),),
@@ -138,7 +138,7 @@ def test_linkable_set(  # noqa: D
 
 
 def test_linkable_set_for_common_dimensions_in_different_models(
-    request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, metric_lookup: MetricLookup
+    request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, metric_lookup: MetricLookup
 ) -> None:
     """Tests case where a metric has dimensions with the same path.
 
@@ -146,7 +146,7 @@ def test_linkable_set_for_common_dimensions_in_different_models(
     """
     assert_linkable_element_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="result0",
         linkable_element_set=metric_lookup.linkable_set_for_metrics(
             (MetricReference(element_name="bookings_per_view"),),

--- a/metricflow/test/plan_conversion/dataflow_to_sql/test_conversion_metrics_to_sql.py
+++ b/metricflow/test/plan_conversion/dataflow_to_sql/test_conversion_metrics_to_sql.py
@@ -14,14 +14,14 @@ from metricflow.specs.specs import (
     MetricSpec,
     TimeDimensionSpec,
 )
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.plan_conversion.test_dataflow_to_sql_plan import convert_and_check
 
 
 @pytest.mark.sql_engine_snapshot
 def test_conversion_rate(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -42,7 +42,7 @@ def test_conversion_rate(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -52,7 +52,7 @@ def test_conversion_rate(
 @pytest.mark.sql_engine_snapshot
 def test_conversion_rate_with_window(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -77,7 +77,7 @@ def test_conversion_rate_with_window(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -87,7 +87,7 @@ def test_conversion_rate_with_window(
 @pytest.mark.sql_engine_snapshot
 def test_conversion_rate_with_no_group_by(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -103,7 +103,7 @@ def test_conversion_rate_with_no_group_by(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -113,7 +113,7 @@ def test_conversion_rate_with_no_group_by(
 @pytest.mark.sql_engine_snapshot
 def test_conversion_count_with_no_group_by(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -129,7 +129,7 @@ def test_conversion_count_with_no_group_by(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -139,7 +139,7 @@ def test_conversion_count_with_no_group_by(
 @pytest.mark.sql_engine_snapshot
 def test_conversion_rate_with_constant_properties(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -163,7 +163,7 @@ def test_conversion_rate_with_constant_properties(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -173,7 +173,7 @@ def test_conversion_rate_with_constant_properties(
 @pytest.mark.sql_engine_snapshot
 def test_conversion_metric_join_to_timespine_and_fill_nulls_with_0(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -192,7 +192,7 @@ def test_conversion_metric_join_to_timespine_and_fill_nulls_with_0(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,

--- a/metricflow/test/plan_conversion/dataflow_to_sql/test_distinct_values_to_sql.py
+++ b/metricflow/test/plan_conversion/dataflow_to_sql/test_distinct_values_to_sql.py
@@ -11,14 +11,14 @@ from metricflow.protocols.sql_client import SqlClient
 from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.specs.column_assoc import ColumnAssociationResolver
 from metricflow.specs.specs import DimensionSpec, MetricFlowQuerySpec
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.plan_conversion.test_dataflow_to_sql_plan import convert_and_check
 
 
 @pytest.mark.sql_engine_snapshot
 def test_dimensions_requiring_join(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -34,7 +34,7 @@ def test_dimensions_requiring_join(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -44,7 +44,7 @@ def test_dimensions_requiring_join(
 @pytest.mark.sql_engine_snapshot
 def test_dimension_values_with_a_join_and_a_filter(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -62,7 +62,7 @@ def test_dimension_values_with_a_join_and_a_filter(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,

--- a/metricflow/test/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
+++ b/metricflow/test/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
@@ -12,7 +12,7 @@ from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanCon
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.specs.specs import MetricFlowQuerySpec, MetricSpec
 from metricflow.test.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.plan_conversion.test_dataflow_to_sql_plan import convert_and_check
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
 
@@ -20,7 +20,7 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
 @pytest.mark.sql_engine_snapshot
 def test_metric_time_dimension_transform_node_using_primary_time(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -34,7 +34,7 @@ def test_metric_time_dimension_transform_node_using_primary_time(  # noqa: D
     )
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=metric_time_dimension_transform_node,
@@ -44,7 +44,7 @@ def test_metric_time_dimension_transform_node_using_primary_time(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_metric_time_dimension_transform_node_using_non_primary_time(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -59,7 +59,7 @@ def test_metric_time_dimension_transform_node_using_non_primary_time(  # noqa: D
     )
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=metric_time_dimension_transform_node,
@@ -69,7 +69,7 @@ def test_metric_time_dimension_transform_node_using_non_primary_time(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_simple_query_with_metric_time_dimension(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -89,7 +89,7 @@ def test_simple_query_with_metric_time_dimension(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_node.parent_node,

--- a/metricflow/test/plan_conversion/test_dataflow_to_execution.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_execution.py
@@ -17,7 +17,7 @@ from metricflow.specs.specs import (
     TimeDimensionSpec,
 )
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_execution_plan_text_equal
 
 
@@ -38,7 +38,7 @@ def make_execution_plan_converter(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_joined_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     simple_semantic_manifest_lookup: SemanticManifestLookup,
     sql_client: SqlClient,
@@ -68,7 +68,7 @@ def test_joined_plan(  # noqa: D
 
     assert_execution_plan_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_client=sql_client,
         execution_plan=execution_plan,
     )
@@ -77,7 +77,7 @@ def test_joined_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_small_combined_metrics_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     dataflow_plan_builder: DataflowPlanBuilder,
     simple_semantic_manifest_lookup: SemanticManifestLookup,
@@ -105,7 +105,7 @@ def test_small_combined_metrics_plan(  # noqa: D
 
     assert_execution_plan_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_client=sql_client,
         execution_plan=execution_plan,
     )
@@ -114,7 +114,7 @@ def test_small_combined_metrics_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_combined_metrics_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     dataflow_plan_builder: DataflowPlanBuilder,
     simple_semantic_manifest_lookup: SemanticManifestLookup,
@@ -144,7 +144,7 @@ def test_combined_metrics_plan(  # noqa: D
 
     assert_execution_plan_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_client=sql_client,
         execution_plan=execution_plan,
     )
@@ -153,7 +153,7 @@ def test_combined_metrics_plan(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_multihop_joined_plan(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     multihop_dataflow_plan_builder: DataflowPlanBuilder,
     partitioned_multi_hop_join_semantic_manifest_lookup: SemanticManifestLookup,
     sql_client: SqlClient,
@@ -189,7 +189,7 @@ def test_multihop_joined_plan(  # noqa: D
 
     assert_execution_plan_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_client=sql_client,
         execution_plan=execution_plan,
     )

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -52,7 +52,7 @@ from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql.sql_plan import SqlJoinType
 from metricflow.test.dataflow_plan_to_svg import display_graph_if_requested
 from metricflow.test.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_plan_snapshot_text_equal
 from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_from_plan_equal, assert_sql_plan_text_equal
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
@@ -60,7 +60,7 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
 
 def convert_and_check(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
     node: BaseOutput,
@@ -76,19 +76,19 @@ def convert_and_check(
     sql_query_plan = conversion_result.sql_plan
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=sql_query_plan,
     )
 
     assert_sql_plan_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_query_plan=sql_query_plan,
     )
 
     assert_rendered_sql_from_plan_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_query_plan=sql_query_plan,
         sql_client=sql_client,
     )
@@ -103,13 +103,13 @@ def convert_and_check(
     sql_query_plan = conversion_result.sql_plan
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=sql_query_plan,
     )
 
     assert_rendered_sql_from_plan_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_query_plan=sql_query_plan,
         sql_client=sql_client,
     )
@@ -118,7 +118,7 @@ def convert_and_check(
 @pytest.mark.sql_engine_snapshot
 def test_source_node(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -130,7 +130,7 @@ def test_source_node(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=source_node,
@@ -140,7 +140,7 @@ def test_source_node(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_filter_node(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -158,7 +158,7 @@ def test_filter_node(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=filter_node,
@@ -168,7 +168,7 @@ def test_filter_node(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_filter_with_where_constraint_node(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
@@ -206,7 +206,7 @@ def test_filter_with_where_constraint_node(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=where_constraint_node,
@@ -216,7 +216,7 @@ def test_filter_with_where_constraint_node(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_measure_aggregation_node(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -254,7 +254,7 @@ def test_measure_aggregation_node(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=aggregated_measure_node,
@@ -264,7 +264,7 @@ def test_measure_aggregation_node(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_single_join_node(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -315,7 +315,7 @@ def test_single_join_node(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=join_node,
@@ -325,7 +325,7 @@ def test_single_join_node(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_multi_join_node(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -380,7 +380,7 @@ def test_multi_join_node(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=join_node,
@@ -390,7 +390,7 @@ def test_multi_join_node(
 @pytest.mark.sql_engine_snapshot
 def test_compute_metrics_node(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -449,7 +449,7 @@ def test_compute_metrics_node(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=compute_metrics_node,
@@ -459,7 +459,7 @@ def test_compute_metrics_node(
 @pytest.mark.sql_engine_snapshot
 def test_compute_metrics_node_simple_expr(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -517,20 +517,20 @@ def test_compute_metrics_node_simple_expr(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=compute_metrics_node,
@@ -540,7 +540,7 @@ def test_compute_metrics_node_simple_expr(
 @pytest.mark.sql_engine_snapshot
 def test_join_to_time_spine_node_without_offset(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -585,20 +585,20 @@ def test_join_to_time_spine_node_without_offset(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=join_to_time_spine_node,
@@ -608,7 +608,7 @@ def test_join_to_time_spine_node_without_offset(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_join_to_time_spine_node_with_offset_window(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -654,20 +654,20 @@ def test_join_to_time_spine_node_with_offset_window(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=join_to_time_spine_node,
@@ -677,7 +677,7 @@ def test_join_to_time_spine_node_with_offset_window(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_join_to_time_spine_node_with_offset_to_grain(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -724,20 +724,20 @@ def test_join_to_time_spine_node_with_offset_to_grain(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=dataflow_plan,
         plan_snapshot_text=dataflow_plan.structure_text(),
     )
 
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=join_to_time_spine_node,
@@ -747,7 +747,7 @@ def test_join_to_time_spine_node_with_offset_to_grain(
 @pytest.mark.sql_engine_snapshot
 def test_compute_metrics_node_ratio_from_single_semantic_model(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -808,7 +808,7 @@ def test_compute_metrics_node_ratio_from_single_semantic_model(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=compute_metrics_node,
@@ -818,7 +818,7 @@ def test_compute_metrics_node_ratio_from_single_semantic_model(
 @pytest.mark.sql_engine_snapshot
 def test_order_by_node(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -874,7 +874,7 @@ def test_order_by_node(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=order_by_node,
@@ -884,7 +884,7 @@ def test_order_by_node(
 @pytest.mark.sql_engine_snapshot
 def test_semi_additive_join_node(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -905,7 +905,7 @@ def test_semi_additive_join_node(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=semi_additive_join_node,
@@ -915,7 +915,7 @@ def test_semi_additive_join_node(
 @pytest.mark.sql_engine_snapshot
 def test_semi_additive_join_node_with_queried_group_by(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -939,7 +939,7 @@ def test_semi_additive_join_node_with_queried_group_by(
     )
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=semi_additive_join_node,
@@ -949,7 +949,7 @@ def test_semi_additive_join_node_with_queried_group_by(
 @pytest.mark.sql_engine_snapshot
 def test_semi_additive_join_node_with_grouping(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -974,7 +974,7 @@ def test_semi_additive_join_node_with_grouping(
     )
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=semi_additive_join_node,
@@ -984,7 +984,7 @@ def test_semi_additive_join_node_with_grouping(
 @pytest.mark.sql_engine_snapshot
 def test_constrain_time_range_node(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -1021,7 +1021,7 @@ def test_constrain_time_range_node(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=constrain_time_node,
@@ -1031,7 +1031,7 @@ def test_constrain_time_range_node(
 @pytest.mark.sql_engine_snapshot
 def test_compute_metrics_node_ratio_from_multiple_semantic_models(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -1057,7 +1057,7 @@ def test_compute_metrics_node_ratio_from_multiple_semantic_models(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -1067,7 +1067,7 @@ def test_compute_metrics_node_ratio_from_multiple_semantic_models(
 @pytest.mark.sql_engine_snapshot
 def test_combine_output_node(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     sql_client: SqlClient,
@@ -1117,7 +1117,7 @@ def test_combine_output_node(  # noqa: D
     combine_output_node = CombineAggregatedOutputsNode([aggregated_measure_node, aggregated_measure_node_2])
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=combine_output_node,
@@ -1127,7 +1127,7 @@ def test_combine_output_node(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_dimensions_requiring_join(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -1143,7 +1143,7 @@ def test_dimensions_requiring_join(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -1153,7 +1153,7 @@ def test_dimensions_requiring_join(
 @pytest.mark.sql_engine_snapshot
 def test_dimension_with_joined_where_constraint(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -1169,7 +1169,7 @@ def test_dimension_with_joined_where_constraint(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,

--- a/metricflow/test/query/group_by_item/conftest.py
+++ b/metricflow/test/query/group_by_item/conftest.py
@@ -16,7 +16,7 @@ from metricflow.naming.naming_scheme import QueryItemNamingScheme
 from metricflow.naming.object_builder_scheme import ObjectBuilderNamingScheme
 from metricflow.query.group_by_item.resolution_dag.dag import GroupByItemResolutionDag
 from metricflow.query.group_by_item.resolution_dag.dag_builder import GroupByItemResolutionDagBuilder
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query.group_by_item.ambiguous_resolution_query_id import AmbiguousResolutionQueryId
 
 
@@ -37,7 +37,7 @@ def _build_resolution_dag(
 
 @pytest.fixture(scope="session")
 def resolution_dags(
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
 ) -> Dict[AmbiguousResolutionQueryId, GroupByItemResolutionDag]:
     """Return a dict that maps the ID to the resolution DAG for use in test cases."""

--- a/metricflow/test/query/group_by_item/filter_spec_resolution/test_spec_lookup.py
+++ b/metricflow/test/query/group_by_item/filter_spec_resolution/test_spec_lookup.py
@@ -30,7 +30,7 @@ from metricflow.query.group_by_item.filter_spec_resolution.filter_spec_lookup im
 )
 from metricflow.query.group_by_item.filter_spec_resolution.filter_spec_resolver import WhereFilterSpecResolver
 from metricflow.query.group_by_item.resolution_dag.dag import GroupByItemResolutionDag
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.model.modify.modify_input_metric_filter import ModifyInputMetricFilterTransform
 from metricflow.test.model.modify.modify_manifest import modify_manifest
 from metricflow.test.model.modify.modify_metric_filter import ModifyMetricFilterTransform
@@ -42,12 +42,12 @@ logger = logging.getLogger(__name__)
 
 def assert_spec_lookup_snapshot_equal(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     spec_lookup: FilterSpecResolutionLookUp,
 ) -> None:
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="result",
         snapshot_str=mf_pformat(spec_lookup, include_none_object_fields=False),
     )
@@ -56,7 +56,7 @@ def assert_spec_lookup_snapshot_equal(  # noqa: D
 @pytest.mark.parametrize("dag_case_id", [case_id.value for case_id in AmbiguousResolutionQueryId])
 def test_filter_spec_resolution(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     naming_scheme: QueryItemNamingScheme,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
     resolution_dags: Dict[AmbiguousResolutionQueryId, GroupByItemResolutionDag],
@@ -74,13 +74,13 @@ def test_filter_spec_resolution(  # noqa: D
     resolution_result = spec_pattern_resolver.resolve_lookup()
 
     assert_spec_lookup_snapshot_equal(
-        request=request, mf_test_session_state=mf_test_session_state, spec_lookup=resolution_result
+        request=request, mf_test_configuration=mf_test_configuration, spec_lookup=resolution_result
     )
 
 
 def check_resolution_with_filter(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     semantic_manifest: PydanticSemanticManifest,
     transform_rules: Sequence[SemanticManifestTransformRule[PydanticSemanticManifest]],
     queried_metrics: Sequence[MetricReference],
@@ -115,19 +115,19 @@ def check_resolution_with_filter(  # noqa: D
 
     assert_spec_lookup_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         spec_lookup=resolution_result,
     )
 
 
 def test_filter_resolution_for_valid_metric_filter(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest: PydanticSemanticManifest,
 ) -> None:
     check_resolution_with_filter(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         semantic_manifest=ambiguous_resolution_manifest,
         transform_rules=(
             ModifyMetricFilterTransform(
@@ -149,12 +149,12 @@ def test_filter_resolution_for_valid_metric_filter(  # noqa: D
 
 def test_filter_resolution_for_invalid_metric_filter(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest: PydanticSemanticManifest,
 ) -> None:
     check_resolution_with_filter(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         semantic_manifest=ambiguous_resolution_manifest,
         transform_rules=(
             ModifyMetricFilterTransform(
@@ -176,12 +176,12 @@ def test_filter_resolution_for_invalid_metric_filter(  # noqa: D
 
 def test_filter_resolution_for_valid_metric_input_filter(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest: PydanticSemanticManifest,
 ) -> None:
     check_resolution_with_filter(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         semantic_manifest=ambiguous_resolution_manifest,
         transform_rules=(
             ModifyInputMetricFilterTransform(
@@ -203,12 +203,12 @@ def test_filter_resolution_for_valid_metric_input_filter(  # noqa: D
 
 def test_filter_resolution_for_invalid_metric_input_filter(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest: PydanticSemanticManifest,
 ) -> None:
     check_resolution_with_filter(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         semantic_manifest=ambiguous_resolution_manifest,
         transform_rules=(
             ModifyInputMetricFilterTransform(
@@ -230,7 +230,7 @@ def test_filter_resolution_for_invalid_metric_input_filter(  # noqa: D
 
 def test_filter_resolution_for_derived_metrics_with_common_filtered_metric(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest: PydanticSemanticManifest,
 ) -> None:
     """Checks that there are 2 filter spec resolutions even if the metric + filter combination is repeated.
@@ -239,7 +239,7 @@ def test_filter_resolution_for_derived_metrics_with_common_filtered_metric(
     """
     check_resolution_with_filter(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         semantic_manifest=ambiguous_resolution_manifest,
         transform_rules=(),
         queried_metrics=(

--- a/metricflow/test/query/group_by_item/resolution_dag/test_resolution_dags.py
+++ b/metricflow/test/query/group_by_item/resolution_dag/test_resolution_dags.py
@@ -8,7 +8,7 @@ from _pytest.fixtures import FixtureRequest
 
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.query.group_by_item.resolution_dag.dag import GroupByItemResolutionDag
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query.group_by_item.ambiguous_resolution_query_id import AmbiguousResolutionQueryId
 from metricflow.test.snapshot_utils import assert_plan_snapshot_text_equal
 
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("dag_case_id", [case_id.value for case_id in AmbiguousResolutionQueryId])
 def test_snapshot(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
     resolution_dags: Dict[AmbiguousResolutionQueryId, GroupByItemResolutionDag],
     dag_case_id: str,
@@ -27,7 +27,7 @@ def test_snapshot(
     resolution_dag = resolution_dags[AmbiguousResolutionQueryId(dag_case_id)]
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=resolution_dag,
         plan_snapshot_text=resolution_dag.structure_text(),
     )

--- a/metricflow/test/query/group_by_item/test_available_group_by_items.py
+++ b/metricflow/test/query/group_by_item/test_available_group_by_items.py
@@ -10,7 +10,7 @@ from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.query.group_by_item.group_by_item_resolver import GroupByItemResolver
 from metricflow.query.group_by_item.resolution_dag.dag import GroupByItemResolutionDag
 from metricflow.specs.specs import LinkableSpecSet
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query.group_by_item.conftest import AmbiguousResolutionQueryId
 from metricflow.test.snapshot_utils import assert_linkable_spec_set_snapshot_equal
 
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("dag_case_id", [case_id.value for case_id in AmbiguousResolutionQueryId])
 def test_available_group_by_items(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
     resolution_dags: Dict[AmbiguousResolutionQueryId, GroupByItemResolutionDag],
     dag_case_id: str,
@@ -34,7 +34,7 @@ def test_available_group_by_items(  # noqa: D
     result = group_by_item_resolver.resolve_available_items()
     assert_linkable_spec_set_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         set_id="set0",
         spec_set=LinkableSpecSet.from_specs(result.specs),
     )

--- a/metricflow/test/query/group_by_item/test_matching_item_for_filters.py
+++ b/metricflow/test/query/group_by_item/test_matching_item_for_filters.py
@@ -12,7 +12,7 @@ from metricflow.naming.naming_scheme import QueryItemNamingScheme
 from metricflow.naming.object_builder_scheme import ObjectBuilderNamingScheme
 from metricflow.query.group_by_item.group_by_item_resolver import GroupByItemResolver
 from metricflow.query.group_by_item.resolution_dag.dag import GroupByItemResolutionDag
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query.group_by_item.conftest import AmbiguousResolutionQueryId
 from metricflow.test.snapshot_utils import assert_object_snapshot_equal
 
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("dag_case_id", [case_id.value for case_id in AmbiguousResolutionQueryId])
 def test_ambiguous_metric_time_in_query_filter(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     naming_scheme: QueryItemNamingScheme,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
     resolution_dags: Dict[AmbiguousResolutionQueryId, GroupByItemResolutionDag],
@@ -46,7 +46,7 @@ def test_ambiguous_metric_time_in_query_filter(  # noqa: D
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         obj_id="result",
         obj=result,
     )

--- a/metricflow/test/query/group_by_item/test_matching_item_for_querying.py
+++ b/metricflow/test/query/group_by_item/test_matching_item_for_querying.py
@@ -17,7 +17,7 @@ from metricflow.query.group_by_item.resolution_dag.dag import GroupByItemResolut
 from metricflow.query.group_by_item.resolution_dag.resolution_nodes.metric_resolution_node import (
     MetricGroupByItemResolutionNode,
 )
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query.group_by_item.conftest import AmbiguousResolutionQueryId
 from metricflow.test.snapshot_utils import assert_object_snapshot_equal
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_MONTH, MTD_SPEC_YEAR
@@ -65,7 +65,7 @@ def test_ambiguous_metric_time_in_query(  # noqa: D
 
 def test_unavailable_group_by_item_in_derived_metric_parent(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     naming_scheme: QueryItemNamingScheme,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
     resolution_dags: Dict[AmbiguousResolutionQueryId, GroupByItemResolutionDag],
@@ -85,7 +85,7 @@ def test_unavailable_group_by_item_in_derived_metric_parent(  # noqa: D
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         obj_id="result",
         obj=result,
     )
@@ -93,7 +93,7 @@ def test_unavailable_group_by_item_in_derived_metric_parent(  # noqa: D
 
 def test_invalid_group_by_item(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     naming_scheme: QueryItemNamingScheme,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
     resolution_dags: Dict[AmbiguousResolutionQueryId, GroupByItemResolutionDag],
@@ -112,7 +112,7 @@ def test_invalid_group_by_item(  # noqa: D
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         obj_id="result",
         obj=result,
     )
@@ -120,7 +120,7 @@ def test_invalid_group_by_item(  # noqa: D
 
 def test_missing_parent_for_metric(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     naming_scheme: QueryItemNamingScheme,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
 ) -> None:
@@ -142,5 +142,5 @@ def test_missing_parent_for_metric(
     result = group_by_item_resolver.resolve_available_items(metric_node)
 
     assert_object_snapshot_equal(
-        request=request, mf_test_session_state=mf_test_session_state, obj_id="result", obj=result
+        request=request, mf_test_configuration=mf_test_configuration, obj_id="result", obj=result
     )

--- a/metricflow/test/query/test_ambiguous_entity_path.py
+++ b/metricflow/test/query/test_ambiguous_entity_path.py
@@ -11,7 +11,7 @@ from metricflow.query.group_by_item.filter_spec_resolution.filter_pattern_factor
 )
 from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.query.query_parser import MetricFlowQueryParser
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_object_snapshot_equal, assert_str_snapshot_equal
 
 logger = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ def multi_hop_query_parser(  # noqa: D
 
 def test_resolvable_ambiguous_entity_path(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     multi_hop_query_parser: MetricFlowQueryParser,
 ) -> None:
     query_spec = multi_hop_query_parser.parse_and_validate_query(
@@ -39,7 +39,7 @@ def test_resolvable_ambiguous_entity_path(  # noqa: D
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -47,7 +47,7 @@ def test_resolvable_ambiguous_entity_path(  # noqa: D
 
 def test_ambiguous_entity_path_resolves_to_shortest_entity_path_item(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     multi_hop_query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests that 'entity_1__country' resolves to 'entity_1__country' not 'entity_1__entity_0__country'."""
@@ -58,7 +58,7 @@ def test_ambiguous_entity_path_resolves_to_shortest_entity_path_item(
 
     assert_object_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         obj_id="result_0",
         obj=query_spec,
     )
@@ -66,7 +66,7 @@ def test_ambiguous_entity_path_resolves_to_shortest_entity_path_item(
 
 def test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     multi_hop_query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests an input with an ambiguous entity-path that can't be resolved due to multiple matches.
@@ -81,7 +81,7 @@ def test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )
@@ -89,7 +89,7 @@ def test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches(
 
 def test_non_resolvable_ambiguous_entity_path_due_to_mismatch(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     multi_hop_query_parser: MetricFlowQueryParser,
 ) -> None:
     """Tests an input with an ambiguous entity-path that can't be resolved due to a mismatch between metrics.
@@ -104,7 +104,7 @@ def test_non_resolvable_ambiguous_entity_path_due_to_mismatch(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )

--- a/metricflow/test/query/test_suggestions.py
+++ b/metricflow/test/query/test_suggestions.py
@@ -16,7 +16,7 @@ from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.plan_conversion.column_resolver import DunderColumnAssociationResolver
 from metricflow.query.query_exceptions import InvalidQueryException
 from metricflow.query.query_parser import MetricFlowQueryParser
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.model.modify.modify_manifest import modify_manifest
 from metricflow.test.model.modify.modify_metric_filter import ModifyMetricFilterTransform
 from metricflow.test.snapshot_utils import assert_str_snapshot_equal
@@ -25,42 +25,42 @@ logger = logging.getLogger(__name__)
 
 
 def test_suggestions_for_group_by_item(  # noqa: D
-    request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, query_parser: MetricFlowQueryParser
+    request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, query_parser: MetricFlowQueryParser
 ) -> None:
     with pytest.raises(InvalidQueryException) as e:
         query_parser.parse_and_validate_query(metric_names=("bookings",), group_by_names=("booking__instant",))
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )
 
 
 def test_suggestions_for_metric(  # noqa: D
-    request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, query_parser: MetricFlowQueryParser
+    request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, query_parser: MetricFlowQueryParser
 ) -> None:
     with pytest.raises(InvalidQueryException) as e:
         query_parser.parse_and_validate_query(metric_names=("booking",), group_by_names=(METRIC_TIME_ELEMENT_NAME,))
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )
 
 
 def test_suggestions_for_multiple_metrics(  # noqa: D
-    request: FixtureRequest, mf_test_session_state: MetricFlowTestSessionState, query_parser: MetricFlowQueryParser
+    request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, query_parser: MetricFlowQueryParser
 ) -> None:
     with pytest.raises(InvalidQueryException) as e:
         query_parser.parse_and_validate_query(metric_names=("bookings", "listings"), group_by_names=("booking__ds",))
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )
@@ -68,7 +68,7 @@ def test_suggestions_for_multiple_metrics(  # noqa: D
 
 def test_suggestions_for_defined_where_filter(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     simple_semantic_manifest: PydanticSemanticManifest,
 ) -> None:
     modified_manifest = modify_manifest(
@@ -93,7 +93,7 @@ def test_suggestions_for_defined_where_filter(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )
@@ -101,7 +101,7 @@ def test_suggestions_for_defined_where_filter(  # noqa: D
 
 def test_suggestions_for_defined_filters_in_multi_metric_query(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     simple_semantic_manifest: PydanticSemanticManifest,
 ) -> None:
     """Tests that the suggestions for invalid items in filters are specific to the metric."""
@@ -146,7 +146,7 @@ def test_suggestions_for_defined_filters_in_multi_metric_query(
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="result_0",
         snapshot_str=str(e.value),
     )

--- a/metricflow/test/query_rendering/compare_rendered_query.py
+++ b/metricflow/test/query_rendering/compare_rendered_query.py
@@ -9,13 +9,13 @@ from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanCon
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from metricflow.test.dataflow_plan_to_svg import display_graph_if_requested
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_from_plan_equal
 
 
 def convert_and_check(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
     node: BaseOutput,
@@ -34,13 +34,13 @@ def convert_and_check(
     sql_query_plan = conversion_result.sql_plan
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=sql_query_plan,
     )
 
     assert_rendered_sql_from_plan_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_query_plan=sql_query_plan,
         sql_client=sql_client,
     )
@@ -55,13 +55,13 @@ def convert_and_check(
     sql_query_plan = conversion_result.sql_plan
     display_graph_if_requested(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dag_graph=sql_query_plan,
     )
 
     assert_rendered_sql_from_plan_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_query_plan=sql_query_plan,
         sql_client=sql_client,
     )

--- a/metricflow/test/query_rendering/test_cumulative_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_cumulative_metric_rendering.py
@@ -19,7 +19,7 @@ from metricflow.query.query_parser import MetricFlowQueryParser
 from metricflow.specs.column_assoc import ColumnAssociationResolver
 from metricflow.specs.specs import EntityReference, MetricFlowQuerySpec, MetricSpec, TimeDimensionSpec
 from metricflow.test.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query_rendering.compare_rendered_query import convert_and_check
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_MONTH
 
@@ -27,7 +27,7 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_MONTH
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
@@ -50,7 +50,7 @@ def test_cumulative_metric(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -60,7 +60,7 @@ def test_cumulative_metric(
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_with_time_constraint(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
@@ -91,7 +91,7 @@ def test_cumulative_metric_with_time_constraint(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -101,7 +101,7 @@ def test_cumulative_metric_with_time_constraint(
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_with_non_adjustable_time_filter(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -129,7 +129,7 @@ def test_cumulative_metric_with_non_adjustable_time_filter(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -139,7 +139,7 @@ def test_cumulative_metric_with_non_adjustable_time_filter(
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_no_ds(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
@@ -156,7 +156,7 @@ def test_cumulative_metric_no_ds(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -166,7 +166,7 @@ def test_cumulative_metric_no_ds(
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_no_window(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
@@ -189,7 +189,7 @@ def test_cumulative_metric_no_window(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -199,7 +199,7 @@ def test_cumulative_metric_no_window(
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_no_window_with_time_constraint(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
@@ -219,7 +219,7 @@ def test_cumulative_metric_no_window_with_time_constraint(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -229,7 +229,7 @@ def test_cumulative_metric_no_window_with_time_constraint(
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_grain_to_date(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
@@ -252,7 +252,7 @@ def test_cumulative_metric_grain_to_date(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -262,7 +262,7 @@ def test_cumulative_metric_grain_to_date(
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_month(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     extended_date_dataflow_plan_builder: DataflowPlanBuilder,
     extended_date_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
@@ -282,7 +282,7 @@ def test_cumulative_metric_month(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=extended_date_dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -292,7 +292,7 @@ def test_cumulative_metric_month(
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_metric_with_agg_time_dimension(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
@@ -311,7 +311,7 @@ def test_cumulative_metric_with_agg_time_dimension(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,

--- a/metricflow/test/query_rendering/test_derived_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_derived_metric_rendering.py
@@ -20,7 +20,7 @@ from metricflow.specs.specs import (
     MetricFlowQuerySpec,
     MetricSpec,
 )
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query_rendering.compare_rendered_query import convert_and_check
 from metricflow.test.time.metric_time_dimension import (
     MTD_SPEC_DAY,
@@ -34,7 +34,7 @@ from metricflow.test.time.metric_time_dimension import (
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -48,7 +48,7 @@ def test_derived_metric(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -58,7 +58,7 @@ def test_derived_metric(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_nested_derived_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -72,7 +72,7 @@ def test_nested_derived_metric(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -82,7 +82,7 @@ def test_nested_derived_metric(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_window(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -96,7 +96,7 @@ def test_derived_metric_with_offset_window(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -106,7 +106,7 @@ def test_derived_metric_with_offset_window(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -127,7 +127,7 @@ def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -137,7 +137,7 @@ def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_to_grain(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -151,7 +151,7 @@ def test_derived_metric_with_offset_to_grain(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -161,7 +161,7 @@ def test_derived_metric_with_offset_to_grain(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -175,7 +175,7 @@ def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -185,7 +185,7 @@ def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_offset_metric_with_one_input_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -199,7 +199,7 @@ def test_derived_offset_metric_with_one_input_metric(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -209,7 +209,7 @@ def test_derived_offset_metric_with_one_input_metric(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_window_and_granularity(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -223,7 +223,7 @@ def test_derived_metric_with_offset_window_and_granularity(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -233,7 +233,7 @@ def test_derived_metric_with_offset_window_and_granularity(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_month_dimension_and_offset_window(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     extended_date_dataflow_plan_builder: DataflowPlanBuilder,
     extended_date_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -247,7 +247,7 @@ def test_derived_metric_with_month_dimension_and_offset_window(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=extended_date_dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -257,7 +257,7 @@ def test_derived_metric_with_month_dimension_and_offset_window(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_to_grain_and_granularity(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -271,7 +271,7 @@ def test_derived_metric_with_offset_to_grain_and_granularity(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -281,7 +281,7 @@ def test_derived_metric_with_offset_to_grain_and_granularity(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -295,7 +295,7 @@ def test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity( 
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -305,7 +305,7 @@ def test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity( 
 @pytest.mark.sql_engine_snapshot
 def test_derived_offset_cumulative_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -319,7 +319,7 @@ def test_derived_offset_cumulative_metric(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -329,7 +329,7 @@ def test_derived_offset_cumulative_metric(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_nested_offsets(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -344,7 +344,7 @@ def test_nested_offsets(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -354,7 +354,7 @@ def test_nested_offsets(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_nested_derived_metric_with_offset_multiple_input_metrics(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -369,7 +369,7 @@ def test_nested_derived_metric_with_offset_multiple_input_metrics(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -379,7 +379,7 @@ def test_nested_derived_metric_with_offset_multiple_input_metrics(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_nested_offsets_with_where_constraint(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -401,7 +401,7 @@ def test_nested_offsets_with_where_constraint(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -411,7 +411,7 @@ def test_nested_offsets_with_where_constraint(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_nested_offsets_with_time_constraint(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -429,7 +429,7 @@ def test_nested_offsets_with_time_constraint(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -439,7 +439,7 @@ def test_nested_offsets_with_time_constraint(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_time_offset_metric_with_time_constraint(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -456,7 +456,7 @@ def test_time_offset_metric_with_time_constraint(  # noqa: D
     )
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -466,7 +466,7 @@ def test_time_offset_metric_with_time_constraint(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_nested_filters(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -479,7 +479,7 @@ def test_nested_filters(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -489,7 +489,7 @@ def test_nested_filters(
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_time_offset_metric_with_time_constraint(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -507,7 +507,7 @@ def test_cumulative_time_offset_metric_with_time_constraint(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -517,7 +517,7 @@ def test_cumulative_time_offset_metric_with_time_constraint(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -537,7 +537,7 @@ def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -547,7 +547,7 @@ def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(
 @pytest.mark.sql_engine_snapshot
 def test_offset_window_with_agg_time_dim(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -563,7 +563,7 @@ def test_offset_window_with_agg_time_dim(  # noqa: D
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -573,7 +573,7 @@ def test_offset_window_with_agg_time_dim(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_offset_to_grain_with_agg_time_dim(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -589,7 +589,7 @@ def test_offset_to_grain_with_agg_time_dim(  # noqa: D
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -599,7 +599,7 @@ def test_offset_to_grain_with_agg_time_dim(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_offset_metric_with_agg_time_dim(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -615,7 +615,7 @@ def test_derived_offset_metric_with_agg_time_dim(  # noqa: D
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -625,7 +625,7 @@ def test_derived_offset_metric_with_agg_time_dim(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_multi_metric_fill_null(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -643,7 +643,7 @@ def test_multi_metric_fill_null(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -653,7 +653,7 @@ def test_multi_metric_fill_null(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_nested_fill_nulls_without_time_spine(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -668,7 +668,7 @@ def test_nested_fill_nulls_without_time_spine(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -678,7 +678,7 @@ def test_nested_fill_nulls_without_time_spine(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_nested_fill_nulls_without_time_spine_multi_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -696,7 +696,7 @@ def test_nested_fill_nulls_without_time_spine_multi_metric(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -706,7 +706,7 @@ def test_nested_fill_nulls_without_time_spine_multi_metric(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_offset_window_metric_multiple_granularities(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -722,7 +722,7 @@ def test_offset_window_metric_multiple_granularities(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -732,7 +732,7 @@ def test_offset_window_metric_multiple_granularities(
 @pytest.mark.sql_engine_snapshot
 def test_offset_to_grain_metric_multiple_granularities(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -748,7 +748,7 @@ def test_offset_to_grain_metric_multiple_granularities(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -758,7 +758,7 @@ def test_offset_to_grain_metric_multiple_granularities(
 @pytest.mark.sql_engine_snapshot
 def test_offset_window_metric_filter_and_query_have_different_granularities(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -777,7 +777,7 @@ def test_offset_window_metric_filter_and_query_have_different_granularities(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -787,7 +787,7 @@ def test_offset_window_metric_filter_and_query_have_different_granularities(
 @pytest.mark.sql_engine_snapshot
 def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -806,7 +806,7 @@ def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,

--- a/metricflow/test/query_rendering/test_fill_nulls_with_rendering.py
+++ b/metricflow/test/query_rendering/test_fill_nulls_with_rendering.py
@@ -23,14 +23,14 @@ from metricflow.specs.specs import (
     MetricSpec,
     TimeDimensionSpec,
 )
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query_rendering.compare_rendered_query import convert_and_check
 
 
 @pytest.mark.sql_engine_snapshot
 def test_simple_fill_nulls_with_0_metric_time(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -44,7 +44,7 @@ def test_simple_fill_nulls_with_0_metric_time(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -54,7 +54,7 @@ def test_simple_fill_nulls_with_0_metric_time(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_simple_fill_nulls_with_0_month(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -68,7 +68,7 @@ def test_simple_fill_nulls_with_0_month(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -78,7 +78,7 @@ def test_simple_fill_nulls_with_0_month(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_simple_fill_nulls_with_0_with_non_metric_time(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -94,7 +94,7 @@ def test_simple_fill_nulls_with_0_with_non_metric_time(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -104,7 +104,7 @@ def test_simple_fill_nulls_with_0_with_non_metric_time(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_simple_fill_nulls_with_0_with_categorical_dimension(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -118,7 +118,7 @@ def test_simple_fill_nulls_with_0_with_categorical_dimension(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -128,7 +128,7 @@ def test_simple_fill_nulls_with_0_with_categorical_dimension(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_simple_fill_nulls_without_time_spine(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -142,7 +142,7 @@ def test_simple_fill_nulls_without_time_spine(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -152,7 +152,7 @@ def test_simple_fill_nulls_without_time_spine(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_cumulative_fill_nulls(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -166,7 +166,7 @@ def test_cumulative_fill_nulls(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -176,7 +176,7 @@ def test_cumulative_fill_nulls(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_derived_fill_nulls_for_one_input_metric(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -190,7 +190,7 @@ def test_derived_fill_nulls_for_one_input_metric(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -200,7 +200,7 @@ def test_derived_fill_nulls_for_one_input_metric(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_join_to_time_spine_with_filters(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -219,7 +219,7 @@ def test_join_to_time_spine_with_filters(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,

--- a/metricflow/test/query_rendering/test_granularity_date_part_rendering.py
+++ b/metricflow/test/query_rendering/test_granularity_date_part_rendering.py
@@ -19,14 +19,14 @@ from metricflow.specs.specs import (
     MetricFlowQuerySpec,
     MetricSpec,
 )
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query_rendering.compare_rendered_query import convert_and_check
 
 
 @pytest.mark.sql_engine_snapshot
 def test_simple_query_with_date_part(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -42,7 +42,7 @@ def test_simple_query_with_date_part(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -52,7 +52,7 @@ def test_simple_query_with_date_part(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_simple_query_with_multiple_date_parts(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -73,7 +73,7 @@ def test_simple_query_with_multiple_date_parts(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -83,7 +83,7 @@ def test_simple_query_with_multiple_date_parts(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_offset_window_with_date_part(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -99,7 +99,7 @@ def test_offset_window_with_date_part(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,

--- a/metricflow/test/query_rendering/test_metric_time_without_metrics.py
+++ b/metricflow/test/query_rendering/test_metric_time_without_metrics.py
@@ -12,7 +12,7 @@ from metricflow.filters.time_constraint import TimeRangeConstraint
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.specs.specs import DimensionSpec, MetricFlowQuerySpec, TimeDimensionSpec
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.plan_conversion.test_dataflow_to_sql_plan import convert_and_check
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
 
@@ -20,7 +20,7 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
 @pytest.mark.sql_engine_snapshot
 def test_metric_time_only(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -34,7 +34,7 @@ def test_metric_time_only(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -44,7 +44,7 @@ def test_metric_time_only(
 @pytest.mark.sql_engine_snapshot
 def test_metric_time_quarter_alone(  # noqa:D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -61,7 +61,7 @@ def test_metric_time_quarter_alone(  # noqa:D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -71,7 +71,7 @@ def test_metric_time_quarter_alone(  # noqa:D
 @pytest.mark.sql_engine_snapshot
 def test_metric_time_with_other_dimensions(  # noqa:D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -88,7 +88,7 @@ def test_metric_time_with_other_dimensions(  # noqa:D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -98,7 +98,7 @@ def test_metric_time_with_other_dimensions(  # noqa:D
 @pytest.mark.sql_engine_snapshot
 def test_dimensions_with_time_constraint(  # noqa:D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -118,7 +118,7 @@ def test_dimensions_with_time_constraint(  # noqa:D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,

--- a/metricflow/test/query_rendering/test_query_rendering.py
+++ b/metricflow/test/query_rendering/test_query_rendering.py
@@ -29,7 +29,7 @@ from metricflow.specs.specs import (
     MetricSpec,
     TimeDimensionSpec,
 )
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query_rendering.compare_rendered_query import convert_and_check
 from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_WEEK
 
@@ -37,7 +37,7 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_WE
 @pytest.mark.sql_engine_snapshot
 def test_multihop_node(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     multihop_dataflow_plan_builder: DataflowPlanBuilder,
     multihop_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -60,7 +60,7 @@ def test_multihop_node(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=multihop_dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -70,7 +70,7 @@ def test_multihop_node(
 @pytest.mark.sql_engine_snapshot
 def test_filter_with_where_constraint_on_join_dim(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     query_parser: MetricFlowQueryParser,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -88,7 +88,7 @@ def test_filter_with_where_constraint_on_join_dim(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -98,7 +98,7 @@ def test_filter_with_where_constraint_on_join_dim(
 @pytest.mark.sql_engine_snapshot
 def test_partitioned_join(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -118,7 +118,7 @@ def test_partitioned_join(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -128,7 +128,7 @@ def test_partitioned_join(
 @pytest.mark.sql_engine_snapshot
 def test_limit_rows(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -149,7 +149,7 @@ def test_limit_rows(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -159,7 +159,7 @@ def test_limit_rows(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_distinct_values(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -179,7 +179,7 @@ def test_distinct_values(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -189,7 +189,7 @@ def test_distinct_values(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_local_dimension_using_local_entity(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -208,7 +208,7 @@ def test_local_dimension_using_local_entity(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -218,7 +218,7 @@ def test_local_dimension_using_local_entity(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_measure_constraint(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -232,7 +232,7 @@ def test_measure_constraint(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -242,7 +242,7 @@ def test_measure_constraint(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_measure_constraint_with_reused_measure(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -256,7 +256,7 @@ def test_measure_constraint_with_reused_measure(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -266,7 +266,7 @@ def test_measure_constraint_with_reused_measure(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_measure_constraint_with_single_expr_and_alias(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -281,7 +281,7 @@ def test_measure_constraint_with_single_expr_and_alias(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -291,7 +291,7 @@ def test_measure_constraint_with_single_expr_and_alias(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_join_to_scd_dimension(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     scd_column_association_resolver: ColumnAssociationResolver,
     scd_query_parser: MetricFlowQueryParser,
     scd_dataflow_plan_builder: DataflowPlanBuilder,
@@ -310,7 +310,7 @@ def test_join_to_scd_dimension(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=scd_dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -320,7 +320,7 @@ def test_join_to_scd_dimension(
 @pytest.mark.sql_engine_snapshot
 def test_multi_hop_through_scd_dimension(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     scd_dataflow_plan_builder: DataflowPlanBuilder,
     scd_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -336,7 +336,7 @@ def test_multi_hop_through_scd_dimension(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=scd_dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -346,7 +346,7 @@ def test_multi_hop_through_scd_dimension(
 @pytest.mark.sql_engine_snapshot
 def test_multi_hop_to_scd_dimension(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     scd_dataflow_plan_builder: DataflowPlanBuilder,
     scd_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -362,7 +362,7 @@ def test_multi_hop_to_scd_dimension(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=scd_dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -372,7 +372,7 @@ def test_multi_hop_to_scd_dimension(
 @pytest.mark.sql_engine_snapshot
 def test_multiple_metrics_no_dimensions(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -388,7 +388,7 @@ def test_multiple_metrics_no_dimensions(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -398,7 +398,7 @@ def test_multiple_metrics_no_dimensions(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_metric_with_measures_from_multiple_sources_no_dimensions(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -411,7 +411,7 @@ def test_metric_with_measures_from_multiple_sources_no_dimensions(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -421,7 +421,7 @@ def test_metric_with_measures_from_multiple_sources_no_dimensions(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_common_semantic_model(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -435,7 +435,7 @@ def test_common_semantic_model(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -445,7 +445,7 @@ def test_common_semantic_model(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_min_max_only_categorical(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -465,7 +465,7 @@ def test_min_max_only_categorical(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -475,7 +475,7 @@ def test_min_max_only_categorical(
 @pytest.mark.sql_engine_snapshot
 def test_min_max_only_time(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -496,7 +496,7 @@ def test_min_max_only_time(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -506,7 +506,7 @@ def test_min_max_only_time(
 @pytest.mark.sql_engine_snapshot
 def test_min_max_only_time_quarter(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -527,7 +527,7 @@ def test_min_max_only_time_quarter(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -537,7 +537,7 @@ def test_min_max_only_time_quarter(
 @pytest.mark.sql_engine_snapshot
 def test_min_max_metric_time(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -552,7 +552,7 @@ def test_min_max_metric_time(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,
@@ -562,7 +562,7 @@ def test_min_max_metric_time(
 @pytest.mark.sql_engine_snapshot
 def test_min_max_metric_time_week(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     sql_client: SqlClient,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -577,7 +577,7 @@ def test_min_max_metric_time_week(
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,

--- a/metricflow/test/query_rendering/test_time_spine_join_rendering.py
+++ b/metricflow/test/query_rendering/test_time_spine_join_rendering.py
@@ -20,14 +20,14 @@ from metricflow.specs.specs import (
     MetricFlowQuerySpec,
     MetricSpec,
 )
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.query_rendering.compare_rendered_query import convert_and_check
 
 
 @pytest.mark.sql_engine_snapshot
 def test_simple_join_to_time_spine(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
@@ -41,7 +41,7 @@ def test_simple_join_to_time_spine(  # noqa: D
 
     convert_and_check(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
         node=dataflow_plan.sink_output_nodes[0].parent_node,

--- a/metricflow/test/snapshot_utils.py
+++ b/metricflow/test/snapshot_utils.py
@@ -199,7 +199,7 @@ def assert_snapshot_text_equal(
             "to see what's new."
         )
 
-    if mf_test_session_state.display_plans:
+    if mf_test_session_state.display_snapshots:
         if not mf_test_session_state.overwrite_snapshots:
             logger.warning(f"Not overwriting snapshots, so displaying existing snapshot at {file_path}")
 

--- a/metricflow/test/snapshot_utils.py
+++ b/metricflow/test/snapshot_utils.py
@@ -203,14 +203,9 @@ def assert_snapshot_text_equal(
         if not mf_test_session_state.overwrite_snapshots:
             logger.warning(f"Not overwriting snapshots, so displaying existing snapshot at {file_path}")
 
-        if mf_test_session_state.plans_displayed >= mf_test_session_state.max_plans_displayed:
-            raise RuntimeError(
-                f"Can't display snapshot - hit limit of "
-                f"{mf_test_session_state.max_plans_displayed} "
-                f"plans displayed."
-            )
+        if len(request.session.items) > 1:
+            raise ValueError("Displaying snapshots is only supported when there's a single item in a testing session.")
         webbrowser.open("file://" + file_path)
-        mf_test_session_state.plans_displayed += 1
 
     # Read the existing plan from the file and compare with the actual plan
     with open(file_path, "r") as snapshot_text_file:

--- a/metricflow/test/source_schema_tools.py
+++ b/metricflow/test/source_schema_tools.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 from metricflow.protocols.sql_client import SqlEngine
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.fixtures.sql_clients.ddl_sql_client import SqlClientWithDDLMethods
 from metricflow.test.table_snapshot.table_snapshots import (
     SqlTableSnapshotLoader,
@@ -41,7 +41,7 @@ def get_populate_source_schema_shell_command(engine: SqlEngine) -> str:
 
 
 def populate_source_schema(
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ddl_sql_client: SqlClientWithDDLMethods,
     source_table_snapshot_repository: SqlTableSnapshotRepository,
 ) -> None:
@@ -51,10 +51,10 @@ def populate_source_schema(
     pyproject.toml. However, because the filename does not begin with "test_", it's not normally collected and run. As
     such, all parameters to this function are defined in fixtures.
     """
-    if not mf_test_session_state.use_persistent_source_schema:
+    if not mf_test_configuration.use_persistent_source_schema:
         raise ValueError("This should be run with the flag to enable use of the persistent source schema")
 
-    schema_name = mf_test_session_state.mf_source_schema
+    schema_name = mf_test_configuration.mf_source_schema
 
     logger.info(f"Dropping schema {schema_name}")
     ddl_sql_client.drop_schema(schema_name=schema_name, cascade=True)

--- a/metricflow/test/sql/compare_sql_plan.py
+++ b/metricflow/test/sql/compare_sql_plan.py
@@ -6,7 +6,7 @@ from metricflow.dag.mf_dag import DagId
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
 from metricflow.sql.sql_plan import SqlQueryPlan, SqlQueryPlanNode
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState, check_sql_engine_snapshot_marker
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration, check_sql_engine_snapshot_marker
 from metricflow.test.snapshot_utils import (
     assert_plan_snapshot_text_equal,
     make_schema_replacement_function,
@@ -15,7 +15,7 @@ from metricflow.test.snapshot_utils import (
 
 def assert_default_rendered_sql_equal(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     plan_id: str,
     sql_plan_node: SqlQueryPlanNode,
 ) -> None:
@@ -26,7 +26,7 @@ def assert_default_rendered_sql_equal(  # noqa: D
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=sql_query_plan,
         plan_snapshot_text=rendered_sql,
         plan_snapshot_file_extension=".sql",
@@ -35,7 +35,7 @@ def assert_default_rendered_sql_equal(  # noqa: D
 
 def assert_rendered_sql_equal(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     plan_id: str,
     sql_plan_node: SqlQueryPlanNode,
     sql_client: SqlClient,
@@ -45,7 +45,7 @@ def assert_rendered_sql_equal(  # noqa: D
 
     assert_rendered_sql_from_plan_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_query_plan=sql_query_plan,
         sql_client=sql_client,
     )
@@ -53,7 +53,7 @@ def assert_rendered_sql_equal(  # noqa: D
 
 def assert_rendered_sql_from_plan_equal(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_query_plan: SqlQueryPlan,
     sql_client: SqlClient,
 ) -> None:
@@ -64,12 +64,12 @@ def assert_rendered_sql_from_plan_equal(
 
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=sql_query_plan,
         plan_snapshot_text=rendered_sql,
         plan_snapshot_file_extension=".sql",
         incomparable_strings_replacement_function=make_schema_replacement_function(
-            system_schema=mf_test_session_state.mf_system_schema, source_schema=mf_test_session_state.mf_source_schema
+            system_schema=mf_test_configuration.mf_system_schema, source_schema=mf_test_configuration.mf_source_schema
         ),
         additional_sub_directories_for_snapshots=(sql_client.sql_engine_type.value,) if sql_client else (),
     )
@@ -77,15 +77,15 @@ def assert_rendered_sql_from_plan_equal(
 
 def assert_sql_plan_text_equal(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_query_plan: SqlQueryPlan,
 ) -> None:
     assert_plan_snapshot_text_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         plan=sql_query_plan,
         plan_snapshot_text=sql_query_plan.structure_text(),
         incomparable_strings_replacement_function=make_schema_replacement_function(
-            system_schema=mf_test_session_state.mf_system_schema, source_schema=mf_test_session_state.mf_source_schema
+            system_schema=mf_test_configuration.mf_system_schema, source_schema=mf_test_configuration.mf_source_schema
         ),
     )

--- a/metricflow/test/sql/optimizer/test_column_pruner.py
+++ b/metricflow/test/sql/optimizer/test_column_pruner.py
@@ -22,7 +22,7 @@ from metricflow.sql.sql_plan import (
     SqlTableFromClauseNode,
 )
 from metricflow.sql.sql_table import SqlTable
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.sql.compare_sql_plan import assert_default_rendered_sql_equal
 
 
@@ -210,21 +210,21 @@ def base_select_statement() -> SqlSelectStatementNode:
 
 def test_no_pruning(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where no pruning should occur."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=base_select_statement,
         plan_id="before_pruning",
     )
     column_pruned_select_node = column_pruner.optimize(base_select_statement)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=column_pruned_select_node,
         plan_id="after_pruning",
     )
@@ -232,7 +232,7 @@ def test_no_pruning(
 
 def test_prune_from_source(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
@@ -275,7 +275,7 @@ def test_prune_from_source(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=select_statement_with_some_from_source_column_removed,
         plan_id="before_pruning",
     )
@@ -283,7 +283,7 @@ def test_prune_from_source(
     column_pruned_select_node = column_pruner.optimize(select_statement_with_some_from_source_column_removed)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=column_pruned_select_node,
         plan_id="after_pruning",
     )
@@ -291,7 +291,7 @@ def test_prune_from_source(
 
 def test_prune_joined_source(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
@@ -334,7 +334,7 @@ def test_prune_joined_source(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=select_statement_with_some_joined_source_column_removed,
         plan_id="before_pruning",
     )
@@ -342,7 +342,7 @@ def test_prune_joined_source(
     column_pruned_select_node = column_pruner.optimize(select_statement_with_some_joined_source_column_removed)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=column_pruned_select_node,
         plan_id="after_pruning",
     )
@@ -350,7 +350,7 @@ def test_prune_joined_source(
 
 def test_dont_prune_if_in_where(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
@@ -377,7 +377,7 @@ def test_dont_prune_if_in_where(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=select_statement_with_other_exprs,
         plan_id="before_pruning",
     )
@@ -385,7 +385,7 @@ def test_dont_prune_if_in_where(
     column_pruned_select_node = column_pruner.optimize(select_statement_with_other_exprs)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=column_pruned_select_node,
         plan_id="after_pruning",
     )
@@ -393,7 +393,7 @@ def test_dont_prune_if_in_where(
 
 def test_dont_prune_with_str_expr(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
@@ -416,7 +416,7 @@ def test_dont_prune_with_str_expr(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=select_statement_with_other_exprs,
         plan_id="before_pruning",
     )
@@ -424,7 +424,7 @@ def test_dont_prune_with_str_expr(
     column_pruned_select_node = column_pruner.optimize(select_statement_with_other_exprs)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=column_pruned_select_node,
         plan_id="after_pruning",
     )
@@ -432,7 +432,7 @@ def test_dont_prune_with_str_expr(
 
 def test_prune_with_str_expr(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
@@ -455,7 +455,7 @@ def test_prune_with_str_expr(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=select_statement_with_other_exprs,
         plan_id="before_pruning",
     )
@@ -463,7 +463,7 @@ def test_prune_with_str_expr(
     column_pruned_select_node = column_pruner.optimize(select_statement_with_other_exprs)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=column_pruned_select_node,
         plan_id="after_pruning",
     )
@@ -603,14 +603,14 @@ def string_select_statement() -> SqlSelectStatementNode:
 
 def test_prune_str_expr(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
     string_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where a string expr in a node results in the parent being pruned properly."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=string_select_statement,
         plan_id="before_pruning",
     )
@@ -618,7 +618,7 @@ def test_prune_str_expr(
     column_pruned_select_node = column_pruner.optimize(string_select_statement)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=column_pruned_select_node,
         plan_id="after_pruning",
     )
@@ -731,14 +731,14 @@ def grandparent_pruning_select_statement() -> SqlSelectStatementNode:
 
 def test_prune_grandparents(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
     grandparent_pruning_select_statement: SqlQueryPlanNode,
 ) -> None:
     """Tests a case where a string expr in a node prevents the parent from being pruned, but prunes grandparents."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=grandparent_pruning_select_statement,
         plan_id="before_pruning",
     )
@@ -746,7 +746,7 @@ def test_prune_grandparents(
     column_pruned_select_node = column_pruner.optimize(grandparent_pruning_select_statement)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=column_pruned_select_node,
         plan_id="after_pruning",
     )
@@ -876,14 +876,14 @@ def join_grandparent_pruning_select_statement() -> SqlSelectStatementNode:
 
 def test_prune_grandparents_in_join_query(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
     join_grandparent_pruning_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests pruning grandparents of a join query."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=join_grandparent_pruning_select_statement,
         plan_id="before_pruning",
     )
@@ -891,7 +891,7 @@ def test_prune_grandparents_in_join_query(
     column_pruned_select_node = column_pruner.optimize(join_grandparent_pruning_select_statement)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=column_pruned_select_node,
         plan_id="after_pruning",
     )
@@ -899,7 +899,7 @@ def test_prune_grandparents_in_join_query(
 
 def test_prune_distinct_select(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     column_pruner: SqlColumnPrunerOptimizer,
 ) -> None:
     """Test that distinct select node shouldn't be pruned."""
@@ -945,7 +945,7 @@ def test_prune_distinct_select(
     )
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=select_node,
         plan_id="before_pruning",
     )
@@ -953,7 +953,7 @@ def test_prune_distinct_select(
     column_pruner.optimize(select_node)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=select_node,
         plan_id="after_pruning",
     )

--- a/metricflow/test/sql/optimizer/test_rewriting_sub_query_reducer.py
+++ b/metricflow/test/sql/optimizer/test_rewriting_sub_query_reducer.py
@@ -23,7 +23,7 @@ from metricflow.sql.sql_plan import (
     SqlTableFromClauseNode,
 )
 from metricflow.sql.sql_table import SqlTable
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.sql.compare_sql_plan import assert_default_rendered_sql_equal
 
 
@@ -172,13 +172,13 @@ def base_select_statement() -> SqlSelectStatementNode:
 
 def test_reduce_sub_query(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where an outer query should be reduced into its inner query with merged LIMIT expressions."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=base_select_statement,
         plan_id="before_reducing",
     )
@@ -187,7 +187,7 @@ def test_reduce_sub_query(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=sub_query_reducer.optimize(base_select_statement),
         plan_id="after_reducing",
     )
@@ -343,13 +343,13 @@ def join_select_statement() -> SqlSelectStatementNode:
 
 def test_reduce_join(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     join_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where reducing occurs on a JOIN."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=join_select_statement,
         plan_id="before_reducing",
     )
@@ -358,7 +358,7 @@ def test_reduce_join(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=sub_query_reducer.optimize(join_select_statement),
         plan_id="after_reducing",
     )
@@ -516,13 +516,13 @@ def colliding_select_statement() -> SqlSelectStatementNode:
 
 def test_colliding_alias(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     colliding_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where reducing occurs on a JOIN."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=colliding_select_statement,
         plan_id="before_reducing",
     )
@@ -531,7 +531,7 @@ def test_colliding_alias(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=sub_query_reducer.optimize(colliding_select_statement),
         plan_id="after_reducing",
     )
@@ -751,13 +751,13 @@ def reduce_all_join_select_statement() -> SqlSelectStatementNode:
 
 def test_reduce_all_join_sources(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     reduce_all_join_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where reducing occurs all all sources on a JOIN."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=reduce_all_join_select_statement,
         plan_id="before_reducing",
     )
@@ -766,7 +766,7 @@ def test_reduce_all_join_sources(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=sub_query_reducer.optimize(reduce_all_join_select_statement),
         plan_id="after_reducing",
     )
@@ -894,13 +894,13 @@ def reducing_join_statement() -> SqlSelectStatementNode:
 
 def test_reducing_join_statement(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     reducing_join_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where a join query should not reduced an aggregate."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=reducing_join_statement,
         plan_id="before_reducing",
     )
@@ -909,7 +909,7 @@ def test_reducing_join_statement(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=sub_query_reducer.optimize(reducing_join_statement),
         plan_id="after_reducing",
     )
@@ -1037,13 +1037,13 @@ def reducing_join_left_node_statement() -> SqlSelectStatementNode:
 
 def test_reducing_join_left_node_statement(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     reducing_join_left_node_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where a join query should not reduced an aggregate."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=reducing_join_left_node_statement,
         plan_id="before_reducing",
     )
@@ -1052,7 +1052,7 @@ def test_reducing_join_left_node_statement(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=sub_query_reducer.optimize(reducing_join_left_node_statement),
         plan_id="after_reducing",
     )
@@ -1060,7 +1060,7 @@ def test_reducing_join_left_node_statement(
 
 def test_rewriting_distinct_select_node_is_not_reduced(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:
     """Tests to ensure distinct select node doesn't get overwritten."""
     select_node = SqlSelectStatementNode(
@@ -1105,7 +1105,7 @@ def test_rewriting_distinct_select_node_is_not_reduced(
     )
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=select_node,
         plan_id="before_reducing",
     )
@@ -1114,7 +1114,7 @@ def test_rewriting_distinct_select_node_is_not_reduced(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=sub_query_reducer.optimize(select_node),
         plan_id="after_reducing",
     )

--- a/metricflow/test/sql/optimizer/test_sub_query_reducer.py
+++ b/metricflow/test/sql/optimizer/test_sub_query_reducer.py
@@ -19,7 +19,7 @@ from metricflow.sql.sql_plan import (
     SqlTableFromClauseNode,
 )
 from metricflow.sql.sql_table import SqlTable
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.sql.compare_sql_plan import assert_default_rendered_sql_equal
 
 
@@ -133,13 +133,13 @@ def base_select_statement() -> SqlSelectStatementNode:
 
 def test_reduce_sub_query(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where an outer query should be reduced into its inner query with merged LIMIT expressions."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=base_select_statement,
         plan_id="before_reducing",
     )
@@ -148,7 +148,7 @@ def test_reduce_sub_query(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=sub_query_reducer.optimize(base_select_statement),
         plan_id="after_reducing",
     )
@@ -247,13 +247,13 @@ def rewrite_order_by_statement() -> SqlSelectStatementNode:
 
 def test_rewrite_order_by_with_a_join_in_parent(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     rewrite_order_by_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests rewriting an order by when the parent has a join."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=rewrite_order_by_statement,
         plan_id="before_reducing",
     )
@@ -262,7 +262,7 @@ def test_rewrite_order_by_with_a_join_in_parent(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=sub_query_reducer.optimize(rewrite_order_by_statement),
         plan_id="after_reducing",
     )
@@ -270,7 +270,7 @@ def test_rewrite_order_by_with_a_join_in_parent(
 
 def test_distinct_select_node_is_not_reduced(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:
     """Tests to ensure distinct select node doesn't get overwritten."""
     select_node = SqlSelectStatementNode(
@@ -315,7 +315,7 @@ def test_distinct_select_node_is_not_reduced(
     )
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=select_node,
         plan_id="before_reducing",
     )
@@ -324,7 +324,7 @@ def test_distinct_select_node_is_not_reduced(
 
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=sub_query_reducer.optimize(select_node),
         plan_id="after_reducing",
     )

--- a/metricflow/test/sql/optimizer/test_table_alias_simplifier.py
+++ b/metricflow/test/sql/optimizer/test_table_alias_simplifier.py
@@ -19,7 +19,7 @@ from metricflow.sql.sql_plan import (
     SqlTableFromClauseNode,
 )
 from metricflow.sql.sql_table import SqlTable
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.sql.compare_sql_plan import assert_default_rendered_sql_equal
 
 
@@ -151,20 +151,20 @@ def base_select_statement() -> SqlSelectStatementNode:
 
 def test_table_alias_simplification(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where no pruning should occur."""
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=base_select_statement,
         plan_id="before_alias_simplification",
     )
     simplified_select_node = SqlTableAliasSimplifier().optimize(base_select_statement)
     assert_default_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=simplified_select_node,
         plan_id="after_alias_simplification",
     )

--- a/metricflow/test/sql/test_engine_specific_rendering.py
+++ b/metricflow/test/sql/test_engine_specific_rendering.py
@@ -24,14 +24,14 @@ from metricflow.sql.sql_plan import (
     SqlTableFromClauseNode,
 )
 from metricflow.sql.sql_table import SqlTable
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_equal
 
 
 @pytest.mark.sql_engine_snapshot
 def test_cast_to_timestamp(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the cast to timestamp expression in a query."""
@@ -55,7 +55,7 @@ def test_cast_to_timestamp(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="Test Cast to Timestamp Expression",
             select_columns=tuple(select_columns),
@@ -74,7 +74,7 @@ def test_cast_to_timestamp(
 @pytest.mark.sql_engine_snapshot
 def test_generate_uuid(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the generate uuid expression in a query."""
@@ -89,7 +89,7 @@ def test_generate_uuid(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="Test Generate UUID Expression",
             select_columns=tuple(select_columns),
@@ -108,7 +108,7 @@ def test_generate_uuid(
 @pytest.mark.sql_engine_snapshot
 def test_continuous_percentile_expr(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the continuous percentile expression in a query."""
@@ -138,7 +138,7 @@ def test_continuous_percentile_expr(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="Test Continuous Percentile Expression",
             select_columns=tuple(select_columns),
@@ -157,7 +157,7 @@ def test_continuous_percentile_expr(
 @pytest.mark.sql_engine_snapshot
 def test_discrete_percentile_expr(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the discrete percentile expression in a query."""
@@ -187,7 +187,7 @@ def test_discrete_percentile_expr(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="Test Discrete Percentile Expression",
             select_columns=tuple(select_columns),
@@ -206,7 +206,7 @@ def test_discrete_percentile_expr(
 @pytest.mark.sql_engine_snapshot
 def test_approximate_continuous_percentile_expr(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the approximate continuous percentile expression in a query."""
@@ -236,7 +236,7 @@ def test_approximate_continuous_percentile_expr(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="Test Approximate Continuous Percentile Expression",
             select_columns=tuple(select_columns),
@@ -255,7 +255,7 @@ def test_approximate_continuous_percentile_expr(
 @pytest.mark.sql_engine_snapshot
 def test_approximate_discrete_percentile_expr(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     """Tests rendering of the approximate discrete percentile expression in a query."""
@@ -285,7 +285,7 @@ def test_approximate_discrete_percentile_expr(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="Test Approximate Discrete Percentile Expression",
             select_columns=tuple(select_columns),

--- a/metricflow/test/sql/test_sql_expr_render.py
+++ b/metricflow/test/sql/test_sql_expr_render.py
@@ -33,7 +33,7 @@ from metricflow.sql.sql_exprs import (
     SqlWindowFunctionExpression,
     SqlWindowOrderByArgument,
 )
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 
 logger = logging.getLogger(__name__)
@@ -258,7 +258,7 @@ def test_between_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> No
 
 def test_window_function_expr(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     default_expr_renderer: DefaultSqlExpressionRenderer,
 ) -> None:
     partition_by_args = (
@@ -322,7 +322,7 @@ def test_window_function_expr(  # noqa: D
 
     assert_str_snapshot_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         snapshot_id="rendered_sql",
         snapshot_str="\n".join(rendered_sql_lines),
     )

--- a/metricflow/test/sql/test_sql_plan_render.py
+++ b/metricflow/test/sql/test_sql_plan_render.py
@@ -26,7 +26,7 @@ from metricflow.sql.sql_plan import (
     SqlTableFromClauseNode,
 )
 from metricflow.sql.sql_table import SqlTable, SqlTableType
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.sql.compare_sql_plan import assert_rendered_sql_equal
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.sql_engine_snapshot
 def test_component_rendering(
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     """Checks that all components of SELECT query are rendered for the 0, 1, >1 component count cases."""
@@ -60,7 +60,7 @@ def test_component_rendering(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="test0",
             select_columns=tuple(select_columns),
@@ -91,7 +91,7 @@ def test_component_rendering(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="test1",
             select_columns=tuple(select_columns),
@@ -122,7 +122,7 @@ def test_component_rendering(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="test2",
             select_columns=tuple(select_columns),
@@ -153,7 +153,7 @@ def test_component_rendering(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="test3",
             select_columns=tuple(select_columns),
@@ -178,7 +178,7 @@ def test_component_rendering(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="test4",
             select_columns=tuple(select_columns),
@@ -203,7 +203,7 @@ def test_component_rendering(
 
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="test5",
             select_columns=tuple(select_columns),
@@ -222,12 +222,12 @@ def test_component_rendering(
 @pytest.mark.sql_engine_snapshot
 def test_render_where(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="test0",
             select_columns=(
@@ -263,12 +263,12 @@ def test_render_where(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_render_order_by(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="test0",
             select_columns=(
@@ -313,12 +313,12 @@ def test_render_order_by(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_render_limit(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlSelectStatementNode(
             description="test0",
             select_columns=(
@@ -345,7 +345,7 @@ def test_render_limit(  # noqa: D
 @pytest.mark.sql_engine_snapshot
 def test_render_create_table_as(  # noqa: D
     request: FixtureRequest,
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
     select_node = SqlSelectStatementNode(
@@ -366,7 +366,7 @@ def test_render_create_table_as(  # noqa: D
     )
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlCreateTableAsNode(
             sql_table=SqlTable(
                 schema_name="schema_name",
@@ -380,7 +380,7 @@ def test_render_create_table_as(  # noqa: D
     )
     assert_rendered_sql_equal(
         request=request,
-        mf_test_session_state=mf_test_session_state,
+        mf_test_configuration=mf_test_configuration,
         sql_plan_node=SqlCreateTableAsNode(
             sql_table=SqlTable(
                 schema_name="schema_name",

--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -11,7 +11,7 @@ from metricflow.random_id import random_id
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql.sql_table import SqlTable
 from metricflow.test.compare_df import assert_dataframes_equal
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.fixtures.sql_clients.ddl_sql_client import SqlClientWithDDLMethods
 
 logger = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ def test_select_one_query(sql_client: SqlClient) -> None:  # noqa: D
 
 
 def test_create_table_from_dataframe(  # noqa: D
-    mf_test_session_state: MetricFlowTestSessionState, ddl_sql_client: SqlClientWithDDLMethods
+    mf_test_configuration: MetricFlowTestConfiguration, ddl_sql_client: SqlClientWithDDLMethods
 ) -> None:
     expected_df = pd.DataFrame(
         columns=["int_col", "str_col", "float_col", "bool_col", "time_col"],
@@ -62,7 +62,7 @@ def test_create_table_from_dataframe(  # noqa: D
             (3, None, 1.2, None, "2020-01-04"),  # Test None types for NA conversions
         ],
     )
-    sql_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=_random_table())
+    sql_table = SqlTable(schema_name=mf_test_configuration.mf_system_schema, table_name=_random_table())
     ddl_sql_client.create_table_from_dataframe(sql_table=sql_table, df=expected_df)
 
     actual_df = ddl_sql_client.query(f"SELECT * FROM {sql_table.sql}")
@@ -93,8 +93,8 @@ def example_df() -> pd.DataFrame:
     )
 
 
-def test_dry_run(mf_test_session_state: MetricFlowTestSessionState, sql_client: SqlClient) -> None:  # noqa: D
-    test_table = SqlTable(schema_name=mf_test_session_state.mf_system_schema, table_name=_random_table())
+def test_dry_run(mf_test_configuration: MetricFlowTestConfiguration, sql_client: SqlClient) -> None:  # noqa: D
+    test_table = SqlTable(schema_name=mf_test_configuration.mf_system_schema, table_name=_random_table())
 
     stmt = f"CREATE TABLE {test_table.sql} AS SELECT 1 AS foo"
     sql_client.dry_run(stmt)

--- a/metricflow/test/table_snapshot/test_source_schema.py
+++ b/metricflow/test/table_snapshot/test_source_schema.py
@@ -8,7 +8,7 @@ import pytest
 from metricflow.protocols.sql_client import SqlClient, SqlEngine
 from metricflow.sql.sql_table import SqlTable
 from metricflow.test.compare_df import assert_dataframes_equal
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.fixtures.table_fixtures import CONFIGURED_SOURCE_TABLE_SNAPSHOT_REPOSITORY
 from metricflow.test.source_schema_tools import get_populate_source_schema_shell_command
 from metricflow.test.table_snapshot.table_snapshots import (
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
     ids=lambda table_name: f"table_name={table_name}",
 )
 def test_validate_data_in_source_schema(
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
     source_table_snapshot_repository: SqlTableSnapshotRepository,
     table_name: str,
@@ -38,10 +38,10 @@ def test_validate_data_in_source_schema(
     This is useful to run when a persisted source schema is used to validate that the tables were properly created by a
     call to populate_source_schema().
     """
-    if not mf_test_session_state.use_persistent_source_schema:
+    if not mf_test_configuration.use_persistent_source_schema:
         pytest.skip("Skipping as this session is running without the persistent source schema flag.")
 
-    schema_name = mf_test_session_state.mf_source_schema
+    schema_name = mf_test_configuration.mf_source_schema
 
     matching_table_snapshots = tuple(
         table_snapshot

--- a/metricflow/test/table_snapshot/test_table_snapshots.py
+++ b/metricflow/test/table_snapshot/test_table_snapshots.py
@@ -10,7 +10,7 @@ from dbt_semantic_interfaces.test_utils import as_datetime
 from metricflow.protocols.sql_client import SqlEngine
 from metricflow.random_id import random_id
 from metricflow.test.compare_df import assert_dataframes_equal
-from metricflow.test.fixtures.setup_fixtures import MetricFlowTestSessionState
+from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.fixtures.sql_clients.ddl_sql_client import SqlClientWithDDLMethods
 from metricflow.test.table_snapshot.table_snapshots import (
     SqlTableColumnDefinition,
@@ -57,7 +57,7 @@ def test_as_df(table_snapshot: SqlTableSnapshot) -> None:
 
 
 def test_load(
-    mf_test_session_state: MetricFlowTestSessionState,
+    mf_test_configuration: MetricFlowTestConfiguration,
     ddl_sql_client: SqlClientWithDDLMethods,
     table_snapshot: SqlTableSnapshot,
 ) -> None:


### PR DESCRIPTION
### Description

`MetricFlowTestSessionState` was an odd object that contained both configuration and state for the test session. The reason for the state was that it needed to keep track of the number of displayed graphs so that in case the user tried to display graphs for all tests, the user wouldn't be flooded. To address this, this PR makes the following changes:

* Update the flag behavior so that you can only display graphs when running a single test. In retrospect, displaying graphs for multiple tests seems like an uncommon use case.
* Rename `MetricFlowTestSessionState` to `MetricFlowTestConfiguration`
* Use separate flags for displaying snapshots vs graphs.
* Other minor changes.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
