### PR TITLE
Add `raw_strings` Argument to `preserve_raw_strings `

### DIFF
--- a/metricflow/mf_logging/pretty_print.py
+++ b/metricflow/mf_logging/pretty_print.py
@@ -424,21 +424,32 @@ def mf_pformat_many(  # type: ignore
     include_object_field_names: bool = True,
     include_none_object_fields: bool = False,
     include_empty_object_fields: bool = False,
+    preserve_raw_strings: bool = False,
 ) -> str:
-    """Prints many objects in an indented form."""
+    """Prints many objects in an indented form.
+
+    If preserve_raw_strings is set, and a value of the obj_dict is of type str, then use the value itself, not the
+    representation of the string. e.g. if value="foo", then "foo" instead of "'foo'". Useful for values that contain
+    newlines.
+    """
     lines: List[str] = [description]
     for key, value in obj_dict.items():
+        if preserve_raw_strings and isinstance(value, str):
+            value_str = value
+        else:
+            value_str = mf_pformat(
+                obj=value,
+                max_line_length=max(0, max_line_length - len(indent_prefix)),
+                indent_prefix=indent_prefix,
+                include_object_field_names=include_object_field_names,
+                include_none_object_fields=include_none_object_fields,
+                include_empty_object_fields=include_empty_object_fields,
+            )
+
         item_block_lines = (
             f"{key}:",
             indent(
-                mf_pformat(
-                    obj=value,
-                    max_line_length=max(0, max_line_length - len(indent_prefix)),
-                    indent_prefix=indent_prefix,
-                    include_object_field_names=include_object_field_names,
-                    include_none_object_fields=include_none_object_fields,
-                    include_empty_object_fields=include_empty_object_fields,
-                ),
+                value_str,
                 indent_prefix=indent_prefix,
             ),
         )

--- a/metricflow/test/collection_helpers/test_pretty_print.py
+++ b/metricflow/test/collection_helpers/test_pretty_print.py
@@ -148,3 +148,35 @@ def test_pformat_many() -> None:  # noqa: D
         ).rstrip()
         == result
     )
+
+
+def test_pformat_many_with_raw_strings() -> None:  # noqa: D
+    result = mf_pformat_many("Example description:", obj_dict={"object_0": "foo\nbar"}, preserve_raw_strings=True)
+
+    assert (
+        textwrap.dedent(
+            """\
+            Example description:
+
+            object_0:
+              foo
+              bar
+            """
+        ).rstrip()
+        == result
+    )
+
+
+def test_pformat_many_with_strings() -> None:  # noqa: D
+    result = mf_pformat_many("Example description:", obj_dict={"object_0": "foo\nbar"})
+    assert (
+        textwrap.dedent(
+            """\
+            Example description:
+
+            object_0:
+              'foo\\nbar'
+            """
+        ).rstrip()
+        == result
+    )


### PR DESCRIPTION
### Description

This PR adds an argument to `mf_pformat_many` so that for multi-line strings (e.g. rendered SQL), the log output looks cleaner.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
