### PR TITLE
Update Ruff to 0.3.3

### DIFF
--- a/.changes/unreleased/Dependencies-20240320-171717.yaml
+++ b/.changes/unreleased/Dependencies-20240320-171717.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Update Ruff to 0.3.3
+time: 2024-03-20T17:17:17.779847-07:00
+custom:
+  Author: tlento
+  Issue: "769"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   # Faster version of flake8 / isort / etc.
   # Uses ruff.toml for configuration.
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.260'
+    rev: 'v0.3.3'
     hooks:
     - id: ruff
       verbose: true

--- a/metricflow/aggregation_properties.py
+++ b/metricflow/aggregation_properties.py
@@ -65,5 +65,5 @@ class AggregationState(Enum):
     PARTIAL = "PARTIAL"
     COMPLETE = "COMPLETE"
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}.{self.name}"

--- a/metricflow/cli/cli_context.py
+++ b/metricflow/cli/cli_context.py
@@ -121,7 +121,7 @@ class CLIContext:
         return results
 
     @property
-    def mf(self) -> MetricFlowEngine:  # noqa: D
+    def mf(self) -> MetricFlowEngine:  # noqa: D102
         if self._mf is None:
             self._mf = MetricFlowEngine(
                 semantic_manifest_lookup=self.semantic_manifest_lookup,
@@ -135,7 +135,7 @@ class CLIContext:
         self._semantic_manifest_lookup = SemanticManifestLookup(self.semantic_manifest)
 
     @property
-    def semantic_manifest_lookup(self) -> SemanticManifestLookup:  # noqa: D
+    def semantic_manifest_lookup(self) -> SemanticManifestLookup:  # noqa: D102
         if self._semantic_manifest_lookup is None:
             self._build_semantic_manifest_lookup()
         assert self._semantic_manifest_lookup is not None

--- a/metricflow/cli/custom_click_types.py
+++ b/metricflow/cli/custom_click_types.py
@@ -1,4 +1,5 @@
 """This module contains custom helper click types."""
+
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, Generic, List, Optional, Sequence, Tuple, TypeVar
@@ -50,9 +51,9 @@ class SequenceParamType(click.ParamType, Generic[T]):
 
         super().__init__(*args, **kwargs)
 
-    def convert(  # noqa: D
+    def convert(  # noqa: D102
         self, value: str, param: Optional[click.Parameter], ctx: Optional[click.Context]
-    ) -> Sequence[T]:
+    ) -> Sequence[T]:  # noqa: D102
         if len(value) == 0:
             if self.min_length > 0:
                 self.fail(
@@ -124,7 +125,7 @@ class MutuallyExclusiveOption(click.Option):
 
         super(MutuallyExclusiveOption, self).__init__(*args, **kwargs)
 
-    def handle_parse_result(  # type: ignore # noqa: D
+    def handle_parse_result(  # type: ignore  # noqa: D102
         self, ctx: click.Context, opts: Dict[str, Any], args: List[str]
     ) -> Tuple[Any, List[str]]:
         mutually_exclusive_opts_present = len(self.mutually_exclusive.intersection(opts)) > 0

--- a/metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -242,7 +242,7 @@ class AdapterBackedSqlClient:
         logger.info(f"Finished running the dry_run in {stop - start:.2f}s")
         return
 
-    def close(self) -> None:  # noqa: D
+    def close(self) -> None:  # noqa: D102
         self._adapter.cancel_open_connections()
 
     def render_bind_parameter_key(self, bind_parameter_key: str) -> str:

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -56,7 +56,7 @@ _telemetry_reporter.add_python_log_handler()
 @error_if_not_in_dbt_project
 @pass_config
 @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
-def cli(cfg: CLIContext, verbose: bool) -> None:  # noqa: D
+def cli(cfg: CLIContext, verbose: bool) -> None:  # noqa: D103
     # Some HTTP logging callback somewhere is failing to close its SSL connections correctly.
     # For now, filter those warnings so they don't pop up in CLI stderr
     # note - this should be addressed as adapter connection issues might produce these as well
@@ -358,7 +358,7 @@ def query(
 @cli.group()
 @pass_config
 @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
-def list(cfg: CLIContext) -> None:  # noqa: D
+def list(cfg: CLIContext) -> None:
     """Retrieve metadata values about metrics/dimensions/entities/dimension values."""
 
 
@@ -535,7 +535,7 @@ def dimension_values(
 
 def _print_issues(
     issues: SemanticManifestValidationResults, show_non_blocking: bool = False, verbose: bool = False
-) -> None:  # noqa: D
+) -> None:
     for issue in issues.errors:
         print(f"• {issue.as_cli_formatted_str(verbose=verbose)}")
     if show_non_blocking:

--- a/metricflow/cli/utils.py
+++ b/metricflow/cli/utils.py
@@ -85,7 +85,7 @@ def convert_to_datetime(datetime_str: Optional[str]) -> Optional[dt.datetime]:
         raise click.BadParameter("must be valid iso8601 timestamp")
 
 
-def parse_comma_separated_inputs(value: Optional[str]) -> Optional[List[str]]:  # noqa: D
+def parse_comma_separated_inputs(value: Optional[str]) -> Optional[List[str]]:  # noqa: D103
     # If comma exist, explode this into a list and return
     if value is None:
         return None

--- a/metricflow/dag/dag_to_text.py
+++ b/metricflow/dag/dag_to_text.py
@@ -1,4 +1,5 @@
 """Functions to help generate a text representation of a DAG."""
+
 from __future__ import annotations
 
 import logging
@@ -26,7 +27,7 @@ class MaxWidthTracker:
     76.
     """
 
-    def __init__(self, max_width: int) -> None:  # noqa: D
+    def __init__(self, max_width: int) -> None:  # noqa: D107
         self._current_max_width = max_width
 
     @contextmanager
@@ -38,7 +39,7 @@ class MaxWidthTracker:
         self._current_max_width = previous_max_width
 
     @property
-    def current_max_width(self) -> int:  # noqa: D
+    def current_max_width(self) -> int:  # noqa: D102
         return self._current_max_width
 
 
@@ -70,7 +71,7 @@ class MetricFlowDagTextFormatter:
         self._thread_local_data = threading.local()
 
     @property
-    def _max_width_tracker(self) -> MaxWidthTracker:  # noqa: D
+    def _max_width_tracker(self) -> MaxWidthTracker:
         if not hasattr(self._thread_local_data, "max_width_tracker"):
             self._thread_local_data.max_width_tracker = MaxWidthTracker(self._max_width)
         return self._thread_local_data.max_width_tracker

--- a/metricflow/dag/mf_dag.py
+++ b/metricflow/dag/mf_dag.py
@@ -36,11 +36,11 @@ class NodeId:
 
     id_str: str
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return self.id_str
 
     @staticmethod
-    def create_unique(id_prefix: IdPrefix) -> NodeId:  # noqa: D
+    def create_unique(id_prefix: IdPrefix) -> NodeId:  # noqa: D102
         return NodeId(str(SequentialIdGenerator.create_next_id(id_prefix)))
 
 
@@ -48,14 +48,14 @@ class DagNodeVisitor(Generic[VisitorOutputT], ABC):
     """An object that can be used to visit the nodes of a DAG graph."""
 
     @abstractmethod
-    def visit_node(self, node: DagNode) -> VisitorOutputT:  # noqa: D
+    def visit_node(self, node: DagNode) -> VisitorOutputT:  # noqa: D102
         pass
 
 
 class DagNode(ABC):
     """A node in a DAG. These should be immutable."""
 
-    def __init__(self, node_id: NodeId) -> None:  # noqa: D
+    def __init__(self, node_id: NodeId) -> None:  # noqa: D107
         self._node_id = node_id
 
     @property
@@ -87,10 +87,10 @@ class DagNode(ABC):
 
     @property
     @abstractmethod
-    def parent_nodes(self) -> Sequence[DagNode]:  # noqa: D
+    def parent_nodes(self) -> Sequence[DagNode]:  # noqa: D102
         pass
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(node_id={self.node_id})"
 
     @classmethod
@@ -162,7 +162,7 @@ class DagId:
 
     id_str: str
 
-    def __str__(self) -> str:  # noqa: D
+    def __str__(self) -> str:  # noqa: D105
         return self.id_str
 
     @staticmethod
@@ -171,26 +171,26 @@ class DagId:
         return DagId(id_str)
 
     @staticmethod
-    def from_id_prefix(id_prefix: IdPrefix) -> DagId:  # noqa: D
+    def from_id_prefix(id_prefix: IdPrefix) -> DagId:  # noqa: D102
         return DagId(id_str=SequentialIdGenerator.create_next_id(id_prefix).str_value)
 
 
 DagNodeT = TypeVar("DagNodeT", bound=DagNode)
 
 
-class MetricFlowDag(Generic[DagNodeT]):  # noqa: D
+class MetricFlowDag(Generic[DagNodeT]):
     """Represents a directed acyclic graph. The sink nodes will have the connected components."""
 
-    def __init__(self, dag_id: DagId, sink_nodes: Sequence[DagNodeT]):  # noqa: D
+    def __init__(self, dag_id: DagId, sink_nodes: Sequence[DagNodeT]):  # noqa: D107
         self._dag_id = dag_id
         self._sink_nodes = tuple(sink_nodes)
 
     @property
-    def dag_id(self) -> DagId:  # noqa: D
+    def dag_id(self) -> DagId:  # noqa: D102
         return self._dag_id
 
     @property
-    def sink_nodes(self) -> Sequence[DagNodeT]:  # noqa: D
+    def sink_nodes(self) -> Sequence[DagNodeT]:  # noqa: D102
         return self._sink_nodes
 
     def structure_text(self, formatter: MetricFlowDagTextFormatter = MetricFlowDagTextFormatter()) -> str:

--- a/metricflow/dag/sequential_id.py
+++ b/metricflow/dag/sequential_id.py
@@ -17,7 +17,7 @@ class SequentialId:
     index: int
 
     @property
-    def str_value(self) -> str:  # noqa: D
+    def str_value(self) -> str:  # noqa: D102
         return f"{self.id_prefix.str_value}_{self.index}"
 
     @override
@@ -33,7 +33,7 @@ class SequentialIdGenerator:
     _prefix_to_next_value: Dict[IdPrefix, int] = {}
 
     @classmethod
-    def create_next_id(cls, id_prefix: IdPrefix) -> SequentialId:  # noqa: D
+    def create_next_id(cls, id_prefix: IdPrefix) -> SequentialId:  # noqa: D102
         with cls._state_lock:
             if id_prefix not in cls._prefix_to_next_value:
                 cls._prefix_to_next_value[id_prefix] = cls._default_start_value

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -117,7 +117,7 @@ class MeasureSpecProperties:
 class DataflowPlanBuilder:
     """Builds a dataflow plan to satisfy a given query."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         source_node_set: SourceNodeSet,
         semantic_manifest_lookup: SemanticManifestLookup,

--- a/metricflow/dataflow/builder/node_data_set.py
+++ b/metricflow/dataflow/builder/node_data_set.py
@@ -55,7 +55,7 @@ class DataflowPlanNodeOutputDataSetResolver(DataflowToSqlQueryPlanConverter):
     another class to have better separation of concerns.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         column_association_resolver: ColumnAssociationResolver,
         semantic_manifest_lookup: SemanticManifestLookup,
@@ -67,7 +67,7 @@ class DataflowPlanNodeOutputDataSetResolver(DataflowToSqlQueryPlanConverter):
             semantic_manifest_lookup=semantic_manifest_lookup,
         )
 
-    def get_output_data_set(self, node: DataflowPlanNode) -> SqlDataSet:  # noqa: D
+    def get_output_data_set(self, node: DataflowPlanNode) -> SqlDataSet:
         """Cached since this will be called repeatedly during the computation of multiple metrics.
 
         # TODO: The cache needs to be pruned, but has not yet been an issue.

--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -71,7 +71,7 @@ class JoinLinkableInstancesRecipe:
 
     validity_window: Optional[ValidityWindowJoinDescription] = None
 
-    def __post_init__(self) -> None:  # noqa: D
+    def __post_init__(self) -> None:  # noqa: D105
         if self.join_on_entity is None and self.join_type != SqlJoinType.CROSS_JOIN:
             raise RuntimeError("`join_on_entity` is required unless using CROSS JOIN.")
 

--- a/metricflow/dataflow/builder/partitions.py
+++ b/metricflow/dataflow/builder/partitions.py
@@ -33,7 +33,7 @@ class PartitionTimeDimensionJoinDescription:
 class PartitionJoinResolver:
     """When joining data sets, this class helps to figure out the necessary partition specs to join on."""
 
-    def __init__(self, semantic_model_lookup: SemanticModelAccessor) -> None:  # noqa: D
+    def __init__(self, semantic_model_lookup: SemanticModelAccessor) -> None:  # noqa: D107
         self._semantic_model_lookup = semantic_model_lookup
 
     def _get_partitions(self, spec_set: InstanceSpecSet) -> PartitionSpecSet:

--- a/metricflow/dataflow/builder/source_node.py
+++ b/metricflow/dataflow/builder/source_node.py
@@ -38,7 +38,7 @@ class SourceNodeSet:
     time_spine_node: MetricTimeDimensionTransformNode
 
     @property
-    def all_nodes(self) -> Sequence[BaseOutput]:  # noqa: D
+    def all_nodes(self) -> Sequence[BaseOutput]:  # noqa: D102
         return (
             self.source_nodes_for_metric_queries + self.source_nodes_for_group_by_item_queries + (self.time_spine_node,)
         )
@@ -47,7 +47,7 @@ class SourceNodeSet:
 class SourceNodeBuilder:
     """Helps build a `SourceNodeSet` - refer to that class for more details."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         column_association_resolver: ColumnAssociationResolver,
         semantic_manifest_lookup: SemanticManifestLookup,

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -81,7 +81,7 @@ class DataflowPlanNode(DagNode, Visitable, ABC):
         raise NotImplementedError
 
     @property
-    def node_type(self) -> Type:  # noqa: D
+    def node_type(self) -> Type:  # noqa: D102
         # TODO: Remove.
         return self.__class__
 
@@ -95,77 +95,77 @@ class DataflowPlanNodeVisitor(Generic[VisitorOutputT], ABC):
     """
 
     @abstractmethod
-    def visit_source_node(self, node: ReadSqlSourceNode) -> VisitorOutputT:  # noqa: D
+    def visit_source_node(self, node: ReadSqlSourceNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_join_to_base_output_node(self, node: JoinToBaseOutputNode) -> VisitorOutputT:  # noqa: D
+    def visit_join_to_base_output_node(self, node: JoinToBaseOutputNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_aggregate_measures_node(self, node: AggregateMeasuresNode) -> VisitorOutputT:  # noqa: D
+    def visit_aggregate_measures_node(self, node: AggregateMeasuresNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_compute_metrics_node(self, node: ComputeMetricsNode) -> VisitorOutputT:  # noqa: D
+    def visit_compute_metrics_node(self, node: ComputeMetricsNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> VisitorOutputT:  # noqa: D
+    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_where_constraint_node(self, node: WhereConstraintNode) -> VisitorOutputT:  # noqa: D
+    def visit_where_constraint_node(self, node: WhereConstraintNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> VisitorOutputT:  # noqa: D
+    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> VisitorOutputT:  # noqa: D
+    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_pass_elements_filter_node(self, node: FilterElementsNode) -> VisitorOutputT:  # noqa: D
+    def visit_pass_elements_filter_node(self, node: FilterElementsNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_combine_aggregated_outputs_node(self, node: CombineAggregatedOutputsNode) -> VisitorOutputT:  # noqa: D
+    def visit_combine_aggregated_outputs_node(self, node: CombineAggregatedOutputsNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_constrain_time_range_node(self, node: ConstrainTimeRangeNode) -> VisitorOutputT:  # noqa: D
+    def visit_constrain_time_range_node(self, node: ConstrainTimeRangeNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_join_over_time_range_node(self, node: JoinOverTimeRangeNode) -> VisitorOutputT:  # noqa: D
+    def visit_join_over_time_range_node(self, node: JoinOverTimeRangeNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_semi_additive_join_node(self, node: SemiAdditiveJoinNode) -> VisitorOutputT:  # noqa: D
+    def visit_semi_additive_join_node(self, node: SemiAdditiveJoinNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_metric_time_dimension_transform_node(  # noqa: D
+    def visit_metric_time_dimension_transform_node(  # noqa: D102
         self, node: MetricTimeDimensionTransformNode
-    ) -> VisitorOutputT:
+    ) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> VisitorOutputT:  # noqa: D
+    def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_min_max_node(self, node: MinMaxNode) -> VisitorOutputT:  # noqa: D
+    def visit_min_max_node(self, node: MinMaxNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_add_generated_uuid_column_node(self, node: AddGeneratedUuidColumnNode) -> VisitorOutputT:  # noqa: D
+    def visit_add_generated_uuid_column_node(self, node: AddGeneratedUuidColumnNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_join_conversion_events_node(self, node: JoinConversionEventsNode) -> VisitorOutputT:  # noqa: D
+    def visit_join_conversion_events_node(self, node: JoinConversionEventsNode) -> VisitorOutputT:  # noqa: D102
         pass
 
 
@@ -197,11 +197,11 @@ class SinkNodeVisitor(Generic[VisitorOutputT], ABC):
     """Similar to DataflowPlanNodeVisitor, but only for sink nodes."""
 
     @abstractmethod
-    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> VisitorOutputT:  # noqa: D
+    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> VisitorOutputT:  # noqa: D
+    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> VisitorOutputT:  # noqa: D102
         pass
 
 
@@ -209,19 +209,19 @@ class SinkOutput(DataflowPlanNode, ABC):
     """A node where incoming data goes out of the graph."""
 
     @abstractmethod
-    def accept_sink_node_visitor(self, visitor: SinkNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept_sink_node_visitor(self, visitor: SinkNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         pass
 
     @property
     @abstractmethod
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         pass
 
 
 class DataflowPlan(MetricFlowDag[SinkOutput]):
     """Describes the flow of metric data as it goes from source nodes to sink nodes in the graph."""
 
-    def __init__(self, sink_output_nodes: Sequence[SinkOutput], plan_id: Optional[DagId] = None) -> None:  # noqa: D
+    def __init__(self, sink_output_nodes: Sequence[SinkOutput], plan_id: Optional[DagId] = None) -> None:  # noqa: D107
         if len(sink_output_nodes) == 0:
             raise RuntimeError("Can't create a dataflow plan without sink node(s).")
         self._sink_output_nodes = tuple(sink_output_nodes)
@@ -231,10 +231,10 @@ class DataflowPlan(MetricFlowDag[SinkOutput]):
         )
 
     @property
-    def sink_output_nodes(self) -> Sequence[SinkOutput]:  # noqa: D
+    def sink_output_nodes(self) -> Sequence[SinkOutput]:  # noqa: D102
         return self._sink_output_nodes
 
     @property
-    def sink_output_node(self) -> SinkOutput:  # noqa: D
+    def sink_output_node(self) -> SinkOutput:  # noqa: D102
         assert len(self._sink_output_nodes) == 1, f"Only 1 sink node supported. Got: {self._sink_output_nodes}"
         return self._sink_output_nodes[0]

--- a/metricflow/dataflow/nodes/add_generated_uuid.py
+++ b/metricflow/dataflow/nodes/add_generated_uuid.py
@@ -11,32 +11,32 @@ from metricflow.visitor import VisitorOutputT
 class AddGeneratedUuidColumnNode(BaseOutput):
     """Adds a UUID column."""
 
-    def __init__(self, parent_node: BaseOutput) -> None:  # noqa: D
+    def __init__(self, parent_node: BaseOutput) -> None:  # noqa: D107
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[parent_node])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_ADD_UUID_COLUMN_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_add_generated_uuid_column_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Adds an internally generated UUID column"
 
     @property
-    def parent_node(self) -> DataflowPlanNode:  # noqa: D
+    def parent_node(self) -> DataflowPlanNode:  # noqa: D102
         assert len(self.parent_nodes) == 1
         return self.parent_nodes[0]
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return super().displayed_properties
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return isinstance(other_node, self.__class__)
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> AddGeneratedUuidColumnNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> AddGeneratedUuidColumnNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return AddGeneratedUuidColumnNode(parent_node=new_parent_nodes[0])

--- a/metricflow/dataflow/nodes/aggregate_measures.py
+++ b/metricflow/dataflow/nodes/aggregate_measures.py
@@ -44,18 +44,18 @@ class AggregateMeasuresNode(AggregatedMeasuresOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[self._parent_node])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_AGGREGATE_MEASURES_ID_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_aggregate_measures_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return """Aggregate Measures"""
 
     @property
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         return self._parent_node
 
     @property
@@ -66,13 +66,13 @@ class AggregateMeasuresNode(AggregatedMeasuresOutput):
         """
         return self._metric_input_measure_specs
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
             isinstance(other_node, self.__class__)
             and other_node.metric_input_measure_specs == self.metric_input_measure_specs
         )
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> AggregateMeasuresNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> AggregateMeasuresNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return AggregateMeasuresNode(
             parent_node=new_parent_nodes[0],

--- a/metricflow/dataflow/nodes/combine_aggregated_outputs.py
+++ b/metricflow/dataflow/nodes/combine_aggregated_outputs.py
@@ -15,26 +15,26 @@ from metricflow.visitor import VisitorOutputT
 class CombineAggregatedOutputsNode(ComputedMetricsOutput):
     """Combines metrics from different nodes into a single output."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         parent_nodes: Sequence[Union[BaseOutput, ComputedMetricsOutput]],
     ) -> None:
         super().__init__(node_id=self.create_unique_id(), parent_nodes=parent_nodes)
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_COMBINE_AGGREGATED_OUTPUTS_ID_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_combine_aggregated_outputs_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Combine Aggregated Outputs"
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return isinstance(other_node, self.__class__)
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> CombineAggregatedOutputsNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> CombineAggregatedOutputsNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return CombineAggregatedOutputsNode(parent_nodes=new_parent_nodes)

--- a/metricflow/dataflow/nodes/compute_metrics.py
+++ b/metricflow/dataflow/nodes/compute_metrics.py
@@ -17,7 +17,7 @@ from metricflow.visitor import VisitorOutputT
 class ComputeMetricsNode(ComputedMetricsOutput):
     """A node that computes metrics from input measures. Dimensions / entities are passed through."""
 
-    def __init__(self, parent_node: BaseOutput, metric_specs: Sequence[MetricSpec]) -> None:  # noqa: D
+    def __init__(self, parent_node: BaseOutput, metric_specs: Sequence[MetricSpec]) -> None:
         """Constructor.
 
         Args:
@@ -29,32 +29,32 @@ class ComputeMetricsNode(ComputedMetricsOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(self._parent_node,))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_COMPUTE_METRICS_ID_PREFIX
 
     @property
-    def metric_specs(self) -> Sequence[MetricSpec]:  # noqa: D
+    def metric_specs(self) -> Sequence[MetricSpec]:
         """The metric instances that this node is supposed to compute and should have in the output."""
         return self._metric_specs
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_compute_metrics_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return """Compute Metrics via Expressions"""
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + tuple(
             DisplayedProperty("metric_spec", metric_spec) for metric_spec in self._metric_specs
         )
 
     @property
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         return self._parent_node
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         if not isinstance(other_node, self.__class__):
             return False
 
@@ -63,7 +63,7 @@ class ComputeMetricsNode(ComputedMetricsOutput):
 
         return isinstance(other_node, self.__class__) and other_node.metric_specs == self.metric_specs
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> ComputeMetricsNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> ComputeMetricsNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return ComputeMetricsNode(
             parent_node=new_parent_nodes[0],

--- a/metricflow/dataflow/nodes/constrain_time.py
+++ b/metricflow/dataflow/nodes/constrain_time.py
@@ -17,7 +17,7 @@ class ConstrainTimeRangeNode(AggregatedMeasuresOutput, BaseOutput):
     includes sales for a specific range of dates.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         parent_node: BaseOutput,
         time_range_constraint: TimeRangeConstraint,
@@ -26,39 +26,39 @@ class ConstrainTimeRangeNode(AggregatedMeasuresOutput, BaseOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(parent_node,))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_CONSTRAIN_TIME_RANGE_ID_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_constrain_time_range_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return (
             f"Constrain Time Range to [{self.time_range_constraint.start_time.isoformat()}, "
             f"{self.time_range_constraint.end_time.isoformat()}]"
         )
 
     @property
-    def time_range_constraint(self) -> TimeRangeConstraint:  # noqa: D
+    def time_range_constraint(self) -> TimeRangeConstraint:  # noqa: D102
         return self._time_range_constraint
 
     @property
-    def parent_node(self) -> DataflowPlanNode:  # noqa: D
+    def parent_node(self) -> DataflowPlanNode:  # noqa: D102
         assert len(self.parent_nodes) == 1
         return self.parent_nodes[0]
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (
             DisplayedProperty("time_range_start", self.time_range_constraint.start_time.isoformat()),
             DisplayedProperty("time_range_end", self.time_range_constraint.end_time.isoformat()),
         )
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return isinstance(other_node, self.__class__) and self.time_range_constraint == other_node.time_range_constraint
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> ConstrainTimeRangeNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> ConstrainTimeRangeNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return ConstrainTimeRangeNode(
             parent_node=new_parent_nodes[0],

--- a/metricflow/dataflow/nodes/filter_elements.py
+++ b/metricflow/dataflow/nodes/filter_elements.py
@@ -13,7 +13,7 @@ from metricflow.visitor import VisitorOutputT
 class FilterElementsNode(BaseOutput):
     """Only passes the listed elements."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         parent_node: BaseOutput,
         include_specs: InstanceSpecSet,
@@ -27,7 +27,7 @@ class FilterElementsNode(BaseOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(parent_node,))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_PASS_FILTER_ELEMENTS_ID_PREFIX
 
     @property
@@ -40,18 +40,18 @@ class FilterElementsNode(BaseOutput):
         """True if you only want the distinct values for the selected specs."""
         return self._distinct
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_pass_elements_filter_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         if self._replace_description:
             return self._replace_description
 
         return f"Pass Only Elements: {mf_pformat([x.qualified_name for x in self._include_specs.all_specs])}"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         additional_properties: Tuple[DisplayedProperty, ...] = ()
         if not self._replace_description:
             additional_properties = tuple(
@@ -62,17 +62,17 @@ class FilterElementsNode(BaseOutput):
         return tuple(super().displayed_properties) + additional_properties
 
     @property
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         return self._parent_node
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
             isinstance(other_node, self.__class__)
             and other_node.include_specs == self.include_specs
             and other_node.distinct == self.distinct
         )
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> FilterElementsNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> FilterElementsNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return FilterElementsNode(
             parent_node=new_parent_nodes[0],

--- a/metricflow/dataflow/nodes/join_conversion_events.py
+++ b/metricflow/dataflow/nodes/join_conversion_events.py
@@ -52,54 +52,54 @@ class JoinConversionEventsNode(BaseOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(base_node, conversion_node))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_JOIN_CONVERSION_EVENTS_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_join_conversion_events_node(self)
 
     @property
-    def base_node(self) -> DataflowPlanNode:  # noqa: D
+    def base_node(self) -> DataflowPlanNode:  # noqa: D102
         return self._base_node
 
     @property
-    def conversion_node(self) -> DataflowPlanNode:  # noqa: D
+    def conversion_node(self) -> DataflowPlanNode:  # noqa: D102
         return self._conversion_node
 
     @property
-    def conversion_measure_spec(self) -> MeasureSpec:  # noqa: D
+    def conversion_measure_spec(self) -> MeasureSpec:  # noqa: D102
         return self._conversion_measure_spec
 
     @property
-    def base_time_dimension_spec(self) -> TimeDimensionSpec:  # noqa: D
+    def base_time_dimension_spec(self) -> TimeDimensionSpec:  # noqa: D102
         return self._base_time_dimension_spec
 
     @property
-    def conversion_time_dimension_spec(self) -> TimeDimensionSpec:  # noqa: D
+    def conversion_time_dimension_spec(self) -> TimeDimensionSpec:  # noqa: D102
         return self._conversion_time_dimension_spec
 
     @property
-    def unique_identifier_keys(self) -> Sequence[InstanceSpec]:  # noqa: D
+    def unique_identifier_keys(self) -> Sequence[InstanceSpec]:  # noqa: D102
         return self._unique_identifier_keys
 
     @property
-    def entity_spec(self) -> EntitySpec:  # noqa: D
+    def entity_spec(self) -> EntitySpec:  # noqa: D102
         return self._entity_spec
 
     @property
-    def window(self) -> Optional[MetricTimeWindow]:  # noqa: D
+    def window(self) -> Optional[MetricTimeWindow]:  # noqa: D102
         return self._window
 
     @property
-    def constant_properties(self) -> Optional[Sequence[ConstantPropertySpec]]:  # noqa: D
+    def constant_properties(self) -> Optional[Sequence[ConstantPropertySpec]]:  # noqa: D102
         return self._constant_properties
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"Find conversions for {self.entity_spec.qualified_name} within the range of {f'{self.window.count} {self.window.granularity.value}' if self.window else 'INF'}"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return (
             tuple(super().displayed_properties)
             + (
@@ -115,7 +115,7 @@ class JoinConversionEventsNode(BaseOutput):
             )
         )
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
             isinstance(other_node, self.__class__)
             and other_node.base_time_dimension_spec == self.base_time_dimension_spec
@@ -127,7 +127,7 @@ class JoinConversionEventsNode(BaseOutput):
             and other_node.constant_properties == self.constant_properties
         )
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> JoinConversionEventsNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> JoinConversionEventsNode:  # noqa: D102
         assert len(new_parent_nodes) == 2
         return JoinConversionEventsNode(
             base_node=new_parent_nodes[0],

--- a/metricflow/dataflow/nodes/join_over_time.py
+++ b/metricflow/dataflow/nodes/join_over_time.py
@@ -52,33 +52,33 @@ class JoinOverTimeRangeNode(BaseOutput):
         super().__init__(node_id=node_id or self.create_unique_id(), parent_nodes=parent_nodes)
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_JOIN_SELF_OVER_TIME_RANGE_ID_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_join_over_time_range_node(self)
 
     @property
-    def grain_to_date(self) -> Optional[TimeGranularity]:  # noqa: D
+    def grain_to_date(self) -> Optional[TimeGranularity]:  # noqa: D102
         return self._grain_to_date
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return """Join Self Over Time Range"""
 
     @property
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         return self._parent_node
 
     @property
-    def window(self) -> Optional[MetricTimeWindow]:  # noqa: D
+    def window(self) -> Optional[MetricTimeWindow]:  # noqa: D102
         return self._window
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return super().displayed_properties
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
             isinstance(other_node, self.__class__)
             and other_node.grain_to_date == self.grain_to_date
@@ -86,7 +86,7 @@ class JoinOverTimeRangeNode(BaseOutput):
             and other_node.time_range_constraint == self.time_range_constraint
         )
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> JoinOverTimeRangeNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> JoinOverTimeRangeNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return JoinOverTimeRangeNode(
             parent_node=new_parent_nodes[0],

--- a/metricflow/dataflow/nodes/join_to_base.py
+++ b/metricflow/dataflow/nodes/join_to_base.py
@@ -36,7 +36,7 @@ class JoinDescription:
 
     validity_window: Optional[ValidityWindowJoinDescription] = None
 
-    def __post_init__(self) -> None:  # noqa: D
+    def __post_init__(self) -> None:  # noqa: D105
         if self.join_on_entity is None and self.join_type != SqlJoinType.CROSS_JOIN:
             raise RuntimeError("`join_on_entity` is required unless using CROSS JOIN.")
 
@@ -67,32 +67,32 @@ class JoinToBaseOutputNode(BaseOutput):
         super().__init__(node_id=node_id or self.create_unique_id(), parent_nodes=parent_nodes)
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_JOIN_TO_STANDARD_OUTPUT_ID_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_join_to_base_output_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return """Join Standard Outputs"""
 
     @property
-    def left_node(self) -> BaseOutput:  # noqa: D
+    def left_node(self) -> BaseOutput:  # noqa: D102
         return self._left_node
 
     @property
-    def join_targets(self) -> Sequence[JoinDescription]:  # noqa: D
+    def join_targets(self) -> Sequence[JoinDescription]:  # noqa: D102
         return self._join_targets
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + tuple(
             DisplayedProperty(f"join{i}_for_node_id_{join_description.join_node.node_id}", join_description)
             for i, join_description in enumerate(self._join_targets)
         )
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         if not isinstance(other_node, self.__class__) or len(self.join_targets) != len(other_node.join_targets):
             return False
 
@@ -108,7 +108,7 @@ class JoinToBaseOutputNode(BaseOutput):
                 return False
         return True
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> JoinToBaseOutputNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> JoinToBaseOutputNode:  # noqa: D102
         assert len(new_parent_nodes) > 1
         new_left_node = new_parent_nodes[0]
         new_join_nodes = new_parent_nodes[1:]

--- a/metricflow/dataflow/nodes/join_to_time_spine.py
+++ b/metricflow/dataflow/nodes/join_to_time_spine.py
@@ -58,7 +58,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(self._parent_node,))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_JOIN_TO_TIME_SPINE_ID_PREFIX
 
     @property
@@ -91,15 +91,15 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         """Join type to use when joining to time spine."""
         return self._join_type
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_join_to_time_spine_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return """Join to Time Spine Dataset"""
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (
             DisplayedProperty("requested_agg_time_dimension_specs", self._requested_agg_time_dimension_specs),
             DisplayedProperty("use_custom_agg_time_dimension", self._use_custom_agg_time_dimension),
@@ -110,10 +110,10 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
         )
 
     @property
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         return self._parent_node
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
             isinstance(other_node, self.__class__)
             and other_node.time_range_constraint == self.time_range_constraint
@@ -124,7 +124,7 @@ class JoinToTimeSpineNode(BaseOutput, ABC):
             and other_node.join_type == self.join_type
         )
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> JoinToTimeSpineNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> JoinToTimeSpineNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return JoinToTimeSpineNode(
             parent_node=new_parent_nodes[0],

--- a/metricflow/dataflow/nodes/metric_time_transform.py
+++ b/metricflow/dataflow/nodes/metric_time_transform.py
@@ -21,7 +21,7 @@ class MetricTimeDimensionTransformNode(BaseOutput):
     metric time dimension and only contains measures that are defined to use it.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         parent_node: BaseOutput,
         aggregation_time_dimension_reference: TimeDimensionReference,
@@ -31,7 +31,7 @@ class MetricTimeDimensionTransformNode(BaseOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[parent_node])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_SET_MEASURE_AGGREGATION_TIME
 
     @property
@@ -39,30 +39,32 @@ class MetricTimeDimensionTransformNode(BaseOutput):
         """The time dimension that measures in the input should be aggregated to."""
         return self._aggregation_time_dimension_reference
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_metric_time_dimension_transform_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"Metric Time Dimension '{self.aggregation_time_dimension_reference.element_name}'" ""
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (
             DisplayedProperty("aggregation_time_dimension", self.aggregation_time_dimension_reference.element_name),
         )
 
     @property
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         return self._parent_node
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
             isinstance(other_node, self.__class__)
             and other_node.aggregation_time_dimension_reference == self.aggregation_time_dimension_reference
         )
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> MetricTimeDimensionTransformNode:  # noqa: D
+    def with_new_parents(  # noqa: D102
+        self, new_parent_nodes: Sequence[BaseOutput]
+    ) -> MetricTimeDimensionTransformNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return MetricTimeDimensionTransformNode(
             parent_node=new_parent_nodes[0],

--- a/metricflow/dataflow/nodes/min_max.py
+++ b/metricflow/dataflow/nodes/min_max.py
@@ -10,28 +10,28 @@ from metricflow.visitor import VisitorOutputT
 class MinMaxNode(BaseOutput):
     """Calculate the min and max of a single instance data set."""
 
-    def __init__(self, parent_node: BaseOutput) -> None:  # noqa: D
+    def __init__(self, parent_node: BaseOutput) -> None:  # noqa: D107
         self._parent_node = parent_node
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(parent_node,))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_MIN_MAX_ID_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_min_max_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Calculate min and max"
 
     @property
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         return self._parent_node
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return isinstance(other_node, self.__class__)
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> MinMaxNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> MinMaxNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return MinMaxNode(parent_node=new_parent_nodes[0])

--- a/metricflow/dataflow/nodes/order_by_limit.py
+++ b/metricflow/dataflow/nodes/order_by_limit.py
@@ -36,7 +36,7 @@ class OrderByLimitNode(ComputedMetricsOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(self._parent_node,))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_ORDER_BY_LIMIT_ID_PREFIX
 
     @property
@@ -49,17 +49,17 @@ class OrderByLimitNode(ComputedMetricsOutput):
         """The number of rows to limit by."""
         return self._limit
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_order_by_limit_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"Order By {[order_by_spec.instance_spec.qualified_name for order_by_spec in self._order_by_specs]}" + (
             f" Limit {self._limit}" if self.limit else ""
         )
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return (
             tuple(super().displayed_properties)
             + tuple(DisplayedProperty("order_by_spec", order_by_spec) for order_by_spec in self._order_by_specs)
@@ -67,17 +67,17 @@ class OrderByLimitNode(ComputedMetricsOutput):
         )
 
     @property
-    def parent_node(self) -> Union[BaseOutput, ComputedMetricsOutput]:  # noqa: D
+    def parent_node(self) -> Union[BaseOutput, ComputedMetricsOutput]:  # noqa: D102
         return self._parent_node
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
             isinstance(other_node, self.__class__)
             and other_node.order_by_specs == self.order_by_specs
             and other_node.limit == self.limit
         )
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> OrderByLimitNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> OrderByLimitNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
 
         return OrderByLimitNode(

--- a/metricflow/dataflow/nodes/read_sql_source.py
+++ b/metricflow/dataflow/nodes/read_sql_source.py
@@ -25,10 +25,10 @@ class ReadSqlSourceNode(BaseOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=())
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_READ_SQL_SOURCE_ID_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_source_node(self)
 
     @property
@@ -36,7 +36,7 @@ class ReadSqlSourceNode(BaseOutput):
         """Return the data set that this source represents and is passed to the child nodes."""
         return self._dataset
 
-    def __str__(self) -> str:  # noqa: D
+    def __str__(self) -> str:  # noqa: D105
         return jinja2.Template(
             textwrap.dedent(
                 """\
@@ -46,16 +46,16 @@ class ReadSqlSourceNode(BaseOutput):
         ).render(class_name=self.__class__.__name__, data_set=str(self.data_set))
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"""Read From {self.data_set}"""
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (DisplayedProperty("data_set", self.data_set),)
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return isinstance(other_node, self.__class__) and other_node.data_set == self.data_set
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> ReadSqlSourceNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> ReadSqlSourceNode:  # noqa: D102
         assert len(new_parent_nodes) == 0
         return ReadSqlSourceNode(data_set=self.data_set)

--- a/metricflow/dataflow/nodes/semi_additive_join.py
+++ b/metricflow/dataflow/nodes/semi_additive_join.py
@@ -88,41 +88,41 @@ class SemiAdditiveJoinNode(BaseOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=parent_nodes)
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_SEMI_ADDITIVE_JOIN_ID_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_semi_additive_join_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"""Join on {self.agg_by_function.name}({self.time_dimension_spec.element_name}) and {[i.element_name for i in self.entity_specs]} grouping by {self.queried_time_dimension_spec.element_name if self.queried_time_dimension_spec else None}"""
 
     @property
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         return self._parent_node
 
     @property
-    def entity_specs(self) -> Sequence[LinklessEntitySpec]:  # noqa: D
+    def entity_specs(self) -> Sequence[LinklessEntitySpec]:  # noqa: D102
         return self._entity_specs
 
     @property
-    def time_dimension_spec(self) -> TimeDimensionSpec:  # noqa: D
+    def time_dimension_spec(self) -> TimeDimensionSpec:  # noqa: D102
         return self._time_dimension_spec
 
     @property
-    def agg_by_function(self) -> AggregationType:  # noqa: D
+    def agg_by_function(self) -> AggregationType:  # noqa: D102
         return self._agg_by_function
 
     @property
-    def queried_time_dimension_spec(self) -> Optional[TimeDimensionSpec]:  # noqa: D
+    def queried_time_dimension_spec(self) -> Optional[TimeDimensionSpec]:  # noqa: D102
         return self._queried_time_dimension_spec
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return super().displayed_properties
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         if not isinstance(other_node, self.__class__):
             return False
 
@@ -134,7 +134,7 @@ class SemiAdditiveJoinNode(BaseOutput):
             and other_node.queried_time_dimension_spec == self.queried_time_dimension_spec
         )
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> SemiAdditiveJoinNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> SemiAdditiveJoinNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
 
         return SemiAdditiveJoinNode(

--- a/metricflow/dataflow/nodes/where_filter.py
+++ b/metricflow/dataflow/nodes/where_filter.py
@@ -13,7 +13,7 @@ from metricflow.visitor import VisitorOutputT
 class WhereConstraintNode(AggregatedMeasuresOutput):
     """Remove rows using a WHERE clause."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         parent_node: BaseOutput,
         where_constraint: WhereFilterSpec,
@@ -23,7 +23,7 @@ class WhereConstraintNode(AggregatedMeasuresOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(parent_node,))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_WHERE_CONSTRAINT_ID_PREFIX
 
     @property
@@ -31,23 +31,23 @@ class WhereConstraintNode(AggregatedMeasuresOutput):
         """Returns the specs for the elements that it should pass."""
         return self._where
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_where_constraint_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         # Can't put the where condition here as it can cause rendering issues when there are SQL execution parameters.
         # e.g. "Constrain Output with WHERE listing__country = :1"
         return "Constrain Output with WHERE"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (DisplayedProperty("where_condition", self.where),)
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return isinstance(other_node, self.__class__) and other_node.where == self.where
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> WhereConstraintNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> WhereConstraintNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return WhereConstraintNode(
             parent_node=new_parent_nodes[0],

--- a/metricflow/dataflow/nodes/write_to_dataframe.py
+++ b/metricflow/dataflow/nodes/write_to_dataframe.py
@@ -16,32 +16,32 @@ from metricflow.visitor import VisitorOutputT
 class WriteToResultDataframeNode(SinkOutput):
     """A node where incoming data gets written to a dataframe."""
 
-    def __init__(self, parent_node: BaseOutput) -> None:  # noqa: D
+    def __init__(self, parent_node: BaseOutput) -> None:  # noqa: D107
         self._parent_node = parent_node
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(parent_node,))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_WRITE_TO_RESULT_DATAFRAME_ID_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_write_to_result_dataframe_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return """Write to Dataframe"""
 
     @property
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         assert len(self.parent_nodes) == 1
         return self._parent_node
 
-    def accept_sink_node_visitor(self, visitor: SinkNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept_sink_node_visitor(self, visitor: SinkNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_write_to_result_dataframe_node(self)
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return isinstance(other_node, self.__class__)
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> WriteToResultDataframeNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> WriteToResultDataframeNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return WriteToResultDataframeNode(parent_node=new_parent_nodes[0])

--- a/metricflow/dataflow/nodes/write_to_table.py
+++ b/metricflow/dataflow/nodes/write_to_table.py
@@ -17,7 +17,7 @@ from metricflow.visitor import VisitorOutputT
 class WriteToResultTableNode(SinkOutput):
     """A node where incoming data gets written to a table."""
 
-    def __init__(  # noqa: D
+    def __init__(
         self,
         parent_node: BaseOutput,
         output_sql_table: SqlTable,
@@ -33,32 +33,32 @@ class WriteToResultTableNode(SinkOutput):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(parent_node,))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_WRITE_TO_RESULT_DATAFRAME_ID_PREFIX
 
-    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_write_to_result_table_node(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return """Write to Table"""
 
     @property
-    def parent_node(self) -> BaseOutput:  # noqa: D
+    def parent_node(self) -> BaseOutput:  # noqa: D102
         assert len(self.parent_nodes) == 1
         return self._parent_node
 
-    def accept_sink_node_visitor(self, visitor: SinkNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept_sink_node_visitor(self, visitor: SinkNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_write_to_result_table_node(self)
 
     @property
-    def output_sql_table(self) -> SqlTable:  # noqa: D
+    def output_sql_table(self) -> SqlTable:  # noqa: D102
         return self._output_sql_table
 
-    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D
+    def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return isinstance(other_node, self.__class__) and other_node.output_sql_table == self.output_sql_table
 
-    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> WriteToResultTableNode:  # noqa: D
+    def with_new_parents(self, new_parent_nodes: Sequence[BaseOutput]) -> WriteToResultTableNode:  # noqa: D102
         return WriteToResultTableNode(
             parent_node=new_parent_nodes[0],
             output_sql_table=self.output_sql_table,

--- a/metricflow/dataflow/optimizer/dataflow_plan_optimizer.py
+++ b/metricflow/dataflow/optimizer/dataflow_plan_optimizer.py
@@ -9,5 +9,5 @@ class DataflowPlanOptimizer(ABC):
     """Converts one dataflow plan into another dataflow plan that is more optimal in some way (e.g. performance)."""
 
     @abstractmethod
-    def optimize(self, dataflow_plan: DataflowPlan) -> DataflowPlan:  # noqa: D
+    def optimize(self, dataflow_plan: DataflowPlan) -> DataflowPlan:  # noqa: D102
         raise NotImplementedError

--- a/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
+++ b/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class ComputeMetricsBranchCombinerResult:  # noqa: D
+class ComputeMetricsBranchCombinerResult:  # noqa: D101
     # Perhaps adding more metadata about how nodes got combined would be useful.
     # If combined_branch is None, it means combination could not occur.
     combined_branch: Optional[BaseOutput] = None
@@ -45,7 +45,7 @@ class ComputeMetricsBranchCombinerResult:  # noqa: D
         return self.combined_branch is not None
 
     @property
-    def checked_combined_branch(self) -> BaseOutput:  # noqa: D
+    def checked_combined_branch(self) -> BaseOutput:  # noqa: D102
         assert self.combined_branch is not None
         return self.combined_branch
 
@@ -125,7 +125,7 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
     is propagated up to the result at the root node.
     """
 
-    def __init__(self, left_branch_node: BaseOutput) -> None:  # noqa: D
+    def __init__(self, left_branch_node: BaseOutput) -> None:  # noqa: D107
         self._current_left_node: DataflowPlanNode = left_branch_node
         self._log_level = logging.DEBUG
 
@@ -185,7 +185,7 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
 
         return combined_parents
 
-    def _default_handler(self, current_right_node: BaseOutput) -> ComputeMetricsBranchCombinerResult:  # noqa: D
+    def _default_handler(self, current_right_node: BaseOutput) -> ComputeMetricsBranchCombinerResult:
         combined_parent_nodes = self._combine_parent_branches(current_right_node)
         if combined_parent_nodes is None:
             return ComputeMetricsBranchCombinerResult()
@@ -208,19 +208,19 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         )
         return ComputeMetricsBranchCombinerResult()
 
-    def visit_source_node(self, node: ReadSqlSourceNode) -> ComputeMetricsBranchCombinerResult:  # noqa: D
+    def visit_source_node(self, node: ReadSqlSourceNode) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_handler(node)
 
-    def visit_join_to_base_output_node(  # noqa: D
+    def visit_join_to_base_output_node(  # noqa: D102
         self, node: JoinToBaseOutputNode
-    ) -> ComputeMetricsBranchCombinerResult:
+    ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_handler(node)
 
-    def visit_aggregate_measures_node(  # noqa: D
+    def visit_aggregate_measures_node(  # noqa: D102
         self, node: AggregateMeasuresNode
-    ) -> ComputeMetricsBranchCombinerResult:
+    ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         current_right_node = node
 
@@ -269,7 +269,7 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         )
         return ComputeMetricsBranchCombinerResult(combined_node)
 
-    def visit_compute_metrics_node(self, node: ComputeMetricsNode) -> ComputeMetricsBranchCombinerResult:  # noqa: D
+    def visit_compute_metrics_node(self, node: ComputeMetricsNode) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         current_right_node = node
         self._log_visit_node_type(current_right_node)
         combined_parent_nodes = self._combine_parent_branches(current_right_node)
@@ -316,29 +316,31 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         )
         return ComputeMetricsBranchCombinerResult()
 
-    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> ComputeMetricsBranchCombinerResult:  # noqa: D
+    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._handle_unsupported_node(node)
 
-    def visit_where_constraint_node(self, node: WhereConstraintNode) -> ComputeMetricsBranchCombinerResult:  # noqa: D
+    def visit_where_constraint_node(  # noqa: D102
+        self, node: WhereConstraintNode
+    ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_handler(node)
 
-    def visit_write_to_result_dataframe_node(  # noqa: D
+    def visit_write_to_result_dataframe_node(  # noqa: D102
         self, node: WriteToResultDataframeNode
     ) -> ComputeMetricsBranchCombinerResult:
         self._log_visit_node_type(node)
         return self._handle_unsupported_node(node)
 
-    def visit_write_to_result_table_node(  # noqa: D
+    def visit_write_to_result_table_node(  # noqa: D102
         self, node: WriteToResultTableNode
-    ) -> ComputeMetricsBranchCombinerResult:
+    ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._handle_unsupported_node(node)
 
-    def visit_pass_elements_filter_node(  # noqa: D
+    def visit_pass_elements_filter_node(  # noqa: D102
         self, node: FilterElementsNode
-    ) -> ComputeMetricsBranchCombinerResult:
+    ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
 
         current_right_node = node
@@ -382,52 +384,54 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         )
         return ComputeMetricsBranchCombinerResult(combined_node)
 
-    def visit_combine_aggregated_outputs_node(  # noqa: D
+    def visit_combine_aggregated_outputs_node(  # noqa: D102
         self, node: CombineAggregatedOutputsNode
     ) -> ComputeMetricsBranchCombinerResult:
         self._log_visit_node_type(node)
         return self._handle_unsupported_node(node)
 
-    def visit_constrain_time_range_node(  # noqa: D
+    def visit_constrain_time_range_node(  # noqa: D102
         self, node: ConstrainTimeRangeNode
-    ) -> ComputeMetricsBranchCombinerResult:
+    ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_handler(node)
 
-    def visit_join_over_time_range_node(  # noqa: D
+    def visit_join_over_time_range_node(  # noqa: D102
         self, node: JoinOverTimeRangeNode
-    ) -> ComputeMetricsBranchCombinerResult:
+    ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_handler(node)
 
-    def visit_semi_additive_join_node(  # noqa: D
+    def visit_semi_additive_join_node(  # noqa: D102
         self, node: SemiAdditiveJoinNode
-    ) -> ComputeMetricsBranchCombinerResult:
+    ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_handler(node)
 
-    def visit_metric_time_dimension_transform_node(  # noqa: D
+    def visit_metric_time_dimension_transform_node(  # noqa: D102
         self, node: MetricTimeDimensionTransformNode
     ) -> ComputeMetricsBranchCombinerResult:
         self._log_visit_node_type(node)
         return self._default_handler(node)
 
-    def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> ComputeMetricsBranchCombinerResult:  # noqa: D
+    def visit_join_to_time_spine_node(  # noqa: D102
+        self, node: JoinToTimeSpineNode
+    ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_handler(node)
 
-    def visit_add_generated_uuid_column_node(  # noqa: D
+    def visit_add_generated_uuid_column_node(  # noqa: D102
         self, node: AddGeneratedUuidColumnNode
     ) -> ComputeMetricsBranchCombinerResult:
         self._log_visit_node_type(node)
         return self._default_handler(node)
 
-    def visit_join_conversion_events_node(  # noqa: D
+    def visit_join_conversion_events_node(  # noqa: D102
         self, node: JoinConversionEventsNode
-    ) -> ComputeMetricsBranchCombinerResult:
+    ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_handler(node)
 
-    def visit_min_max_node(self, node: MinMaxNode) -> ComputeMetricsBranchCombinerResult:  # noqa: D
+    def visit_min_max_node(self, node: MinMaxNode) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_handler(node)

--- a/metricflow/dataflow/optimizer/source_scan/matching_linkable_specs.py
+++ b/metricflow/dataflow/optimizer/source_scan/matching_linkable_specs.py
@@ -6,10 +6,10 @@ from metricflow.specs.specs import InstanceSpecSet, InstanceSpecSetTransform
 class MatchingLinkableSpecsTransform(InstanceSpecSetTransform[bool]):
     """Returns true if two spec sets have the same set of linkable specs."""
 
-    def __init__(self, left_spec_set: InstanceSpecSet) -> None:  # noqa: D
+    def __init__(self, left_spec_set: InstanceSpecSet) -> None:  # noqa: D107
         self._left_spec_set = left_spec_set
 
-    def transform(self, spec_set: InstanceSpecSet) -> bool:  # noqa: D
+    def transform(self, spec_set: InstanceSpecSet) -> bool:  # noqa: D102
         return (
             set(self._left_spec_set.dimension_specs) == set(spec_set.dimension_specs)
             and set(self._left_spec_set.time_dimension_specs) == set(spec_set.time_dimension_specs)

--- a/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
+++ b/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
@@ -41,17 +41,17 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class OptimizeBranchResult:  # noqa: D
+class OptimizeBranchResult:  # noqa: D101
     base_output_node: Optional[BaseOutput] = None
     sink_node: Optional[SinkOutput] = None
 
     @property
-    def checked_base_output(self) -> BaseOutput:  # noqa: D
+    def checked_base_output(self) -> BaseOutput:  # noqa: D102
         assert self.base_output_node, f"Expected the result of traversal to produce a {BaseOutput}"
         return self.base_output_node
 
     @property
-    def checked_sink_node(self) -> SinkOutput:  # noqa: D
+    def checked_sink_node(self) -> SinkOutput:  # noqa: D102
         assert self.sink_node, f"Expected the result of traversal to produce a {SinkOutput}"
         return self.sink_node
 
@@ -119,7 +119,7 @@ class SourceScanOptimizer(
     parents.
     """
 
-    def __init__(self) -> None:  # noqa: D
+    def __init__(self) -> None:  # noqa: D107
         self._log_level = logging.DEBUG
 
     def _log_visit_node_type(self, node: DataflowPlanNode) -> None:
@@ -149,19 +149,19 @@ class SourceScanOptimizer(
             sink_node=node.with_new_parents(tuple(x.checked_base_output for x in optimized_parents))
         )
 
-    def visit_source_node(self, node: ReadSqlSourceNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_source_node(self, node: ReadSqlSourceNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_join_to_base_output_node(self, node: JoinToBaseOutputNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_join_to_base_output_node(self, node: JoinToBaseOutputNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_aggregate_measures_node(self, node: AggregateMeasuresNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_aggregate_measures_node(self, node: AggregateMeasuresNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_compute_metrics_node(self, node: ComputeMetricsNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_compute_metrics_node(self, node: ComputeMetricsNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         # Run the optimizer on the parent branch to handle derived metrics, which are defined recursively in the DAG.
         optimized_parent_result: OptimizeBranchResult = node.parent_node.accept(self)
@@ -175,23 +175,25 @@ class SourceScanOptimizer(
 
         return OptimizeBranchResult(base_output_node=node)
 
-    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_where_constraint_node(self, node: WhereConstraintNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_where_constraint_node(self, node: WhereConstraintNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_write_to_result_dataframe_node(  # noqa: D102
+        self, node: WriteToResultDataframeNode
+    ) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_sink_node_handler(node)
 
-    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_sink_node_handler(node)
 
-    def visit_pass_elements_filter_node(self, node: FilterElementsNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_pass_elements_filter_node(self, node: FilterElementsNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
@@ -232,9 +234,9 @@ class SourceScanOptimizer(
             )
         return results
 
-    def visit_combine_aggregated_outputs_node(  # noqa: D
+    def visit_combine_aggregated_outputs_node(  # noqa: D102
         self, node: CombineAggregatedOutputsNode
-    ) -> OptimizeBranchResult:
+    ) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         # The parent node of the CombineAggregatedOutputsNode can be either ComputeMetricsNodes or CombineAggregatedOutputsNodes
 
@@ -271,9 +273,11 @@ class SourceScanOptimizer(
             # Otherwise, replaced the branch with the one that was combined in combined_parent_branches
             else:
                 combined_parent_branches = [
-                    branch_combination_result.left_branch
-                    if branch_combination_result.combined_branch is None
-                    else branch_combination_result.combined_branch
+                    (
+                        branch_combination_result.left_branch
+                        if branch_combination_result.combined_branch is None
+                        else branch_combination_result.combined_branch
+                    )
                     for branch_combination_result in combination_results
                 ]
 
@@ -289,25 +293,25 @@ class SourceScanOptimizer(
             base_output_node=CombineAggregatedOutputsNode(parent_nodes=combined_parent_branches)
         )
 
-    def visit_constrain_time_range_node(self, node: ConstrainTimeRangeNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_constrain_time_range_node(self, node: ConstrainTimeRangeNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_join_over_time_range_node(self, node: JoinOverTimeRangeNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_join_over_time_range_node(self, node: JoinOverTimeRangeNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_semi_additive_join_node(self, node: SemiAdditiveJoinNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_semi_additive_join_node(self, node: SemiAdditiveJoinNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_metric_time_dimension_transform_node(  # noqa: D
+    def visit_metric_time_dimension_transform_node(  # noqa: D102
         self, node: MetricTimeDimensionTransformNode
     ) -> OptimizeBranchResult:
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def optimize(self, dataflow_plan: DataflowPlan) -> DataflowPlan:  # noqa: D
+    def optimize(self, dataflow_plan: DataflowPlan) -> DataflowPlan:  # noqa: D102
         optimized_result: OptimizeBranchResult = dataflow_plan.sink_output_node.accept(self)
 
         logger.log(
@@ -328,18 +332,20 @@ class SourceScanOptimizer(
             sink_output_nodes=[dataflow_plan.sink_output_node],
         )
 
-    def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_add_generated_uuid_column_node(self, node: AddGeneratedUuidColumnNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_add_generated_uuid_column_node(  # noqa: D102
+        self, node: AddGeneratedUuidColumnNode
+    ) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_join_conversion_events_node(self, node: JoinConversionEventsNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_join_conversion_events_node(self, node: JoinConversionEventsNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 
-    def visit_min_max_node(self, node: MinMaxNode) -> OptimizeBranchResult:  # noqa: D
+    def visit_min_max_node(self, node: MinMaxNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)

--- a/metricflow/dataset/convert_semantic_model.py
+++ b/metricflow/dataset/convert_semantic_model.py
@@ -78,7 +78,7 @@ class SemanticModelToDataSetConverter:
     # Regex for inferring whether an expression for an element is a column reference.
     _SQL_IDENTIFIER_REGEX = re.compile("^[a-zA-Z_][a-zA-Z_0-9]*$")
 
-    def __init__(self, column_association_resolver: ColumnAssociationResolver) -> None:  # noqa: D
+    def __init__(self, column_association_resolver: ColumnAssociationResolver) -> None:  # noqa: D107
         self._column_association_resolver = column_association_resolver
 
     def _create_dimension_instance(
@@ -123,13 +123,15 @@ class SemanticModelToDataSetConverter:
             associated_columns=(self._column_association_resolver.resolve_spec(time_dimension_spec),),
             spec=time_dimension_spec,
             defined_from=(
-                SemanticModelElementReference(
-                    semantic_model_name=semantic_model_name,
-                    element_name=element_name,
-                ),
-            )
-            if semantic_model_name
-            else (),
+                (
+                    SemanticModelElementReference(
+                        semantic_model_name=semantic_model_name,
+                        element_name=element_name,
+                    ),
+                )
+                if semantic_model_name
+                else ()
+            ),
         )
 
     def _create_entity_instance(

--- a/metricflow/dataset/dataset.py
+++ b/metricflow/dataset/dataset.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class DataSet(ABC):
     """Describes a set of data that a source node in the dataflow plan contains."""
 
-    def __init__(self, instance_set: InstanceSet) -> None:  # noqa:
+    def __init__(self, instance_set: InstanceSet) -> None:  # noqa: D107
         self._instance_set = instance_set
 
     @property
@@ -67,5 +67,5 @@ class DataSet(ABC):
         """If this data set was created from a semantic model, return the reference."""
         raise NotImplementedError
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}()"

--- a/metricflow/dataset/semantic_model_adapter.py
+++ b/metricflow/dataset/semantic_model_adapter.py
@@ -11,7 +11,7 @@ from metricflow.sql.sql_plan import SqlSelectStatementNode
 class SemanticModelDataSet(SqlDataSet):
     """Similar to SqlDataSet, but contains metadata on the semantic model that was used to create this."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         semantic_model_reference: SemanticModelReference,
         instance_set: InstanceSet,
@@ -20,10 +20,10 @@ class SemanticModelDataSet(SqlDataSet):
         self._semantic_model_reference = semantic_model_reference
         super().__init__(instance_set=instance_set, sql_select_node=sql_select_node)
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}({repr(self._semantic_model_reference.semantic_model_name)})"
 
     @property
     @override
-    def semantic_model_reference(self) -> SemanticModelReference:  # noqa: D
+    def semantic_model_reference(self) -> SemanticModelReference:
         return self._semantic_model_reference

--- a/metricflow/dataset/sql_dataset.py
+++ b/metricflow/dataset/sql_dataset.py
@@ -39,7 +39,7 @@ class SqlDataSet(DataSet):
         super().__init__(instance_set=instance_set)
 
     @property
-    def sql_node(self) -> SqlQueryPlanNode:  # noqa: D
+    def sql_node(self) -> SqlQueryPlanNode:  # noqa: D102
         node_to_return = self._sql_select_node or self._sql_node
         if node_to_return is None:
             raise RuntimeError("This node was not created with a SQL node.")

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -117,7 +117,7 @@ class MetricFlowQueryRequest:
     query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC
 
     @staticmethod
-    def create_with_random_request_id(  # noqa: D
+    def create_with_random_request_id(  # noqa: D102
         saved_query_name: Optional[str] = None,
         metric_names: Optional[Sequence[str]] = None,
         metrics: Optional[Sequence[MetricQueryParameter]] = None,
@@ -155,7 +155,7 @@ class MetricFlowQueryRequest:
 
 
 @dataclass(frozen=True)
-class MetricFlowQueryResult:  # noqa: D
+class MetricFlowQueryResult:
     """The result of a query and context on how it was generated."""
 
     query_spec: MetricFlowQuerySpec
@@ -206,7 +206,7 @@ class MetricFlowExplainResult:
         )
 
     @property
-    def execution_plan(self) -> ExecutionPlan:  # noqa: D
+    def execution_plan(self) -> ExecutionPlan:  # noqa: D102
         return self.convert_to_execution_plan_result.execution_plan
 
 
@@ -290,7 +290,7 @@ class AbstractMetricFlowEngine(ABC):
         pass
 
     @abstractmethod
-    def explain_get_dimension_values(  # noqa: D
+    def explain_get_dimension_values(
         self,
         metric_names: Optional[List[str]] = None,
         metrics: Optional[Sequence[MetricQueryParameter]] = None,
@@ -407,7 +407,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         )
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
-    def query(self, mf_request: MetricFlowQueryRequest) -> MetricFlowQueryResult:  # noqa: D
+    def query(self, mf_request: MetricFlowQueryRequest) -> MetricFlowQueryResult:  # noqa: D102
         logger.info(f"Starting query request:\n{indent(mf_pformat(mf_request))}")
         explain_result = self._create_execution_plan(mf_request)
         execution_plan = explain_result.convert_to_execution_plan_result.execution_plan
@@ -549,10 +549,10 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         )
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
-    def explain(self, mf_request: MetricFlowQueryRequest) -> MetricFlowExplainResult:  # noqa: D
+    def explain(self, mf_request: MetricFlowQueryRequest) -> MetricFlowExplainResult:  # noqa: D102
         return self._create_execution_plan(mf_request)
 
-    def get_measures_for_metrics(self, metric_names: List[str]) -> List[Measure]:  # noqa: D
+    def get_measures_for_metrics(self, metric_names: List[str]) -> List[Measure]:  # noqa: D102
         metrics = self._semantic_manifest_lookup.metric_lookup.get_metrics(
             metric_references=[MetricReference(element_name=metric_name) for metric_name in metric_names]
         )
@@ -578,7 +578,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 )
         return list(measures)
 
-    def simple_dimensions_for_metrics(  # noqa: D
+    def simple_dimensions_for_metrics(  # noqa: D102
         self,
         metric_names: List[str],
         without_any_property: Sequence[LinkableElementProperties] = (
@@ -652,7 +652,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                     )
         return sorted(dimensions, key=lambda dimension: dimension.qualified_name)
 
-    def entities_for_metrics(self, metric_names: List[str]) -> List[Entity]:  # noqa: D
+    def entities_for_metrics(self, metric_names: List[str]) -> List[Entity]:  # noqa: D102
         path_key_to_linkable_entities = (
             self._semantic_manifest_lookup.metric_lookup.linkable_set_for_metrics(
                 metric_references=[MetricReference(element_name=mname) for mname in metric_names],
@@ -685,7 +685,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         return entities
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
-    def list_metrics(self) -> List[Metric]:  # noqa: D
+    def list_metrics(self) -> List[Metric]:  # noqa: D102
         metric_references = self._semantic_manifest_lookup.metric_lookup.metric_references
         metrics = self._semantic_manifest_lookup.metric_lookup.get_metrics(metric_references)
         return [
@@ -697,14 +697,14 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         ]
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
-    def list_saved_queries(self) -> List[SavedQuery]:  # noqa: D
+    def list_saved_queries(self) -> List[SavedQuery]:  # noqa: D102
         return [
             SavedQuery.from_pydantic(saved_query)
             for saved_query in self._semantic_manifest_lookup.semantic_manifest.saved_queries
         ]
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
-    def get_dimension_values(  # noqa: D
+    def get_dimension_values(  # noqa: D102
         self,
         metric_names: List[str],
         get_group_by_values: str,
@@ -739,7 +739,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         return sorted([str(val) for val in dim_vals])
 
     @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
-    def explain_get_dimension_values(  # noqa: D
+    def explain_get_dimension_values(  # noqa: D102
         self,
         metric_names: Optional[List[str]] = None,
         metrics: Optional[Sequence[MetricQueryParameter]] = None,

--- a/metricflow/engine/time_source.py
+++ b/metricflow/engine/time_source.py
@@ -8,5 +8,5 @@ from metricflow.time.time_source import TimeSource
 class ServerTimeSource(TimeSource):
     """A time source that represents the current datetime in UTC."""
 
-    def get_time(self) -> dt.datetime:  # noqa: D
+    def get_time(self) -> dt.datetime:  # noqa: D102
         return dt.datetime.utcnow()

--- a/metricflow/errors/errors.py
+++ b/metricflow/errors/errors.py
@@ -10,13 +10,13 @@ class CustomerFacingSemanticException(Exception):
     pass
 
 
-class UnableToSatisfyQueryError(CustomerFacingSemanticException):  # noqa:D
-    def __init__(self, error_name: str, context: Optional[Dict[str, str]] = None) -> None:  # noqa:D
+class UnableToSatisfyQueryError(CustomerFacingSemanticException):  # noqa: D101
+    def __init__(self, error_name: str, context: Optional[Dict[str, str]] = None) -> None:
         """Context will be printed as list of items when this is converted to a string."""
         self.error_name = error_name
         self._context = context
 
-    def __str__(self) -> str:  # noqa:D
+    def __str__(self) -> str:  # noqa: D105
         error_lines = ["Unable To Satisfy Query Error: " + self.error_name]
         if self._context:
             for key, value in self._context.items():
@@ -25,23 +25,23 @@ class UnableToSatisfyQueryError(CustomerFacingSemanticException):  # noqa:D
         return "\n".join(error_lines)
 
 
-class SemanticException(Exception):  # noqa:D
+class SemanticException(Exception):  # noqa: D101
     pass
 
 
-class DuplicateMetricError(SemanticException):  # noqa:D
+class DuplicateMetricError(SemanticException):  # noqa: D101
     pass
 
 
-class MetricNotFoundError(SemanticException, KeyError):  # noqa:D
+class MetricNotFoundError(SemanticException, KeyError):  # noqa: D101
     pass
 
 
-class NonExistentMeasureError(SemanticException):  # noqa:D
+class NonExistentMeasureError(SemanticException):  # noqa: D101
     pass
 
 
-class InvalidSemanticModelError(SemanticException):  # noqa:D
+class InvalidSemanticModelError(SemanticException):  # noqa: D101
     pass
 
 
@@ -54,7 +54,7 @@ class ExecutionException(Exception):
 class ModelCreationException(Exception):
     """Exception to represent errors related to the building a model."""
 
-    def __init__(self, msg: str = "") -> None:  # noqa: D
+    def __init__(self, msg: str = "") -> None:  # noqa: D107
         error_msg = "An error occurred when attempting to build the semantic model"
         if msg:
             error_msg += f"\n{msg}"
@@ -80,5 +80,5 @@ class UnknownMetricLinkingError(ValueError):
 class InvalidQuerySyntax(Exception):
     """Raised when query syntax is invalid. Primarily used in the where clause."""
 
-    def __init__(self, msg: str) -> None:  # noqa: D
+    def __init__(self, msg: str) -> None:  # noqa: D107
         super().__init__(msg)

--- a/metricflow/execution/execution_plan.py
+++ b/metricflow/execution/execution_plan.py
@@ -89,7 +89,7 @@ class TaskExecutionResult:
 class SelectSqlQueryToDataFrameTask(ExecutionPlanTask):
     """A task that runs a SELECT and puts that result into a dataframe."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         sql_client: SqlClient,
         sql_query: str,
@@ -102,22 +102,22 @@ class SelectSqlQueryToDataFrameTask(ExecutionPlanTask):
         super().__init__(task_id=self.create_unique_id(), parent_nodes=parent_nodes or [])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.EXEC_NODE_READ_SQL_QUERY
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Run a query and write the results to a data frame"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (DisplayedProperty(key="sql_query", value=self._sql_query),)
 
     @property
-    def bind_parameters(self) -> SqlBindParameters:  # noqa: D
+    def bind_parameters(self) -> SqlBindParameters:  # noqa: D102
         return self._bind_parameters
 
-    def execute(self) -> TaskExecutionResult:  # noqa: D
+    def execute(self) -> TaskExecutionResult:  # noqa: D102
         start_time = time.time()
 
         df = self._sql_client.query(
@@ -131,13 +131,13 @@ class SelectSqlQueryToDataFrameTask(ExecutionPlanTask):
         )
 
     @property
-    def sql_query(self) -> Optional[SqlQuery]:  # noqa: D
+    def sql_query(self) -> Optional[SqlQuery]:  # noqa: D102
         return SqlQuery(
             sql_query=self._sql_query,
             bind_parameters=self._bind_parameters,
         )
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(sql_query='{self._sql_query}')"
 
 
@@ -147,7 +147,7 @@ class SelectSqlQueryToTableTask(ExecutionPlanTask):
     The provided SQL query is the query that will be run, so it should be a CREATE... or similar.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         sql_client: SqlClient,
         sql_query: str,
@@ -162,22 +162,22 @@ class SelectSqlQueryToTableTask(ExecutionPlanTask):
         super().__init__(task_id=self.create_unique_id(), parent_nodes=parent_nodes or [])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.EXEC_NODE_WRITE_TO_TABLE
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Run a query and write the results to a table"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (
             DisplayedProperty(key="sql_query", value=self._sql_query),
             DisplayedProperty(key="output_table", value=self._output_table),
             DisplayedProperty(key="bind_parameters", value=self._bind_parameters),
         )
 
-    def execute(self) -> TaskExecutionResult:  # noqa: D
+    def execute(self) -> TaskExecutionResult:  # noqa: D102
         start_time = time.time()
         logger.info(f"Dropping table {self._output_table} in case it already exists")
         self._sql_client.execute(f"DROP TABLE IF EXISTS {self._output_table.sql}")
@@ -191,10 +191,10 @@ class SelectSqlQueryToTableTask(ExecutionPlanTask):
         return TaskExecutionResult(start_time=start_time, end_time=end_time, sql=self._sql_query)
 
     @property
-    def sql_query(self) -> Optional[SqlQuery]:  # noqa: D
+    def sql_query(self) -> Optional[SqlQuery]:  # noqa: D102
         return SqlQuery(sql_query=self._sql_query, bind_parameters=self._bind_parameters)
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(sql_query='{self._sql_query}', output_table={self._output_table})"
 
 

--- a/metricflow/execution/executor.py
+++ b/metricflow/execution/executor.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class ExecutionResults:
     """Stores the results from executing the tasks in an execution plan."""
 
-    def __init__(self) -> None:  # noqa: D
+    def __init__(self) -> None:  # noqa: D107
         # Dict from the task to the result.
         self._results: OrderedDict[NodeId, TaskExecutionResult] = OrderedDict()
 
@@ -28,11 +28,11 @@ class ExecutionResults:
         """Returns true if any of the tasks had an error."""
         return any([len(result.errors) > 0 for node_id, result in self._results.items()])
 
-    def get_result(self, task_id: NodeId) -> TaskExecutionResult:  # noqa: D
+    def get_result(self, task_id: NodeId) -> TaskExecutionResult:  # noqa: D102
         assert task_id in self._results
         return self._results[task_id]
 
-    def all_results(self) -> Dict[NodeId, TaskExecutionResult]:  # noqa: D
+    def all_results(self) -> Dict[NodeId, TaskExecutionResult]:  # noqa: D102
         return self._results
 
 
@@ -40,7 +40,7 @@ class ExecutionPlanExecutor(ABC):
     """Runs the tasks in an execution plan."""
 
     @abstractmethod
-    def execute_plan(self, plan: ExecutionPlan) -> ExecutionResults:  # noqa: D
+    def execute_plan(self, plan: ExecutionPlan) -> ExecutionResults:  # noqa: D102
         pass
 
 
@@ -72,7 +72,7 @@ class SequentialPlanExecutor(ExecutionPlanExecutor):
             else:
                 logger.info(f"Task ID: {current_task.node_id} exited unexpectedly")
 
-    def execute_plan(self, plan: ExecutionPlan) -> ExecutionResults:  # noqa: D
+    def execute_plan(self, plan: ExecutionPlan) -> ExecutionResults:  # noqa: D102
         results = ExecutionResults()
 
         for leaf_node in plan.sink_nodes:

--- a/metricflow/filters/time_constraint.py
+++ b/metricflow/filters/time_constraint.py
@@ -21,7 +21,7 @@ class TimeRangeConstraint(SerializableDataclass):
     start_time: datetime.datetime
     end_time: datetime.datetime
 
-    def __post_init__(self) -> None:  # noqa: D
+    def __post_init__(self) -> None:  # noqa: D105
         if self.start_time > self.end_time:
             logger.warning(f"start_time must not be > end_time. start_time={self.start_time} end_time={self.end_time}")
 
@@ -32,11 +32,11 @@ class TimeRangeConstraint(SerializableDataclass):
             raise RuntimeError(f"end_time={self.end_time} exceeds the limits of {TimeRangeConstraint.ALL_TIME_END()}")
 
     @staticmethod
-    def ALL_TIME_BEGIN() -> datetime.datetime:  # noqa: D
+    def ALL_TIME_BEGIN() -> datetime.datetime:  # noqa: D102
         return datetime.datetime(2000, 1, 1)
 
     @staticmethod
-    def ALL_TIME_END() -> datetime.datetime:  # noqa: D
+    def ALL_TIME_END() -> datetime.datetime:  # noqa: D102
         return datetime.datetime(2040, 12, 31)
 
     @staticmethod
@@ -88,19 +88,19 @@ class TimeRangeConstraint(SerializableDataclass):
             end_time=self.end_time,
         )
 
-    def is_subset_of(self, other: TimeRangeConstraint) -> bool:  # noqa: D
+    def is_subset_of(self, other: TimeRangeConstraint) -> bool:  # noqa: D102
         return self.start_time >= other.start_time and self.end_time <= other.end_time
 
-    def __str__(self) -> str:  # noqa: D
+    def __str__(self) -> str:  # noqa: D105
         return f"[{self.start_time.isoformat()}, {self.end_time.isoformat()}]"
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return (
             f"{self.__class__.__name__}(start_time='{self.start_time.isoformat()}', "
             f"end_time='{self.end_time.isoformat()}')"
         )
 
-    def intersection(self, other: TimeRangeConstraint) -> TimeRangeConstraint:  # noqa: D
+    def intersection(self, other: TimeRangeConstraint) -> TimeRangeConstraint:  # noqa: D102
         # self is completely before the other
         if self.end_time < other.start_time:
             return TimeRangeConstraint.empty_time()

--- a/metricflow/inference/context/data_warehouse.py
+++ b/metricflow/inference/context/data_warehouse.py
@@ -60,7 +60,7 @@ class TableProperties:
     table: SqlTable
     columns: Dict[SqlColumn, ColumnProperties] = field(default_factory=lambda: {}, init=False)
 
-    def __post_init__(self, column_props: List[ColumnProperties]) -> None:  # noqa: D
+    def __post_init__(self, column_props: List[ColumnProperties]) -> None:  # noqa: D105
         for col in column_props:
             self.columns[col.column] = col
 
@@ -74,7 +74,7 @@ class DataWarehouseInferenceContext(InferenceContext):
     tables: Dict[SqlTable, TableProperties] = field(default_factory=lambda: {}, init=False)
     columns: Dict[SqlColumn, ColumnProperties] = field(default_factory=lambda: {}, init=False)
 
-    def __post_init__(self, table_props: List[TableProperties]) -> None:  # noqa: D
+    def __post_init__(self, table_props: List[TableProperties]) -> None:  # noqa: D105
         for stats in table_props:
             self.tables[stats.table] = stats
             for column in stats.columns.values():

--- a/metricflow/inference/models.py
+++ b/metricflow/inference/models.py
@@ -33,7 +33,7 @@ class InferenceSignalNode(ABC):
     on the property that sibling nodes are mutually exclusive in the hierarchy.
     """
 
-    def __init__(self, parent: Optional[InferenceSignalNode], name: str) -> None:  # noqa: D
+    def __init__(self, parent: Optional[InferenceSignalNode], name: str) -> None:  # noqa: D107
         self.name = name
 
         self.parent = parent
@@ -42,7 +42,7 @@ class InferenceSignalNode(ABC):
         if parent is not None:
             parent.children.append(self)
 
-    def __str__(self) -> str:  # noqa: D
+    def __str__(self) -> str:  # noqa: D105
         return f"InferenceSignalNode: {self.name}"
 
     @property
@@ -65,7 +65,7 @@ class InferenceSignalNode(ABC):
 # This is kinda horrible but there's no way of instancing the tree with type safety without
 # hardcoding it. Having some magic that dynamically assigns attributes could work, but then
 # we lose IDE autocompletion and static checking
-class _TreeNodes:  # noqa: D
+class _TreeNodes:
     root = InferenceSignalNode(None, "UNKNOWN")
     id = InferenceSignalNode(root, "IDENTIFIER")
     foreign_id = InferenceSignalNode(id, "FOREIGN_IDENTIFIER")

--- a/metricflow/inference/renderer/config_file.py
+++ b/metricflow/inference/renderer/config_file.py
@@ -16,11 +16,11 @@ from metricflow.sql.sql_table import SqlTable
 yaml = YAML()
 
 
-class RenderedTimeColumnConfigTypeParams(TypedDict):  # noqa: D
+class RenderedTimeColumnConfigTypeParams(TypedDict):  # noqa: D101
     time_granularity: Literal["day"]
 
 
-class RenderedColumnConfig(TypedDict):  # noqa: D
+class RenderedColumnConfig(TypedDict):  # noqa: D101
     name: str
     type: str
     type_params: NotRequired[RenderedTimeColumnConfigTypeParams]

--- a/metricflow/inference/rule/defaults.py
+++ b/metricflow/inference/rule/defaults.py
@@ -34,7 +34,7 @@ class AnyEntityByNameRule(ColumnMatcherRule):
     only_applies_to_parent_signal = False
     match_reason = "Column name ends with `id`"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         return props.column.column_name.lower().endswith("id")
 
 
@@ -52,7 +52,7 @@ class PrimaryEntityByNameRule(ColumnMatcherRule):
     only_applies_to_parent_signal = False
     match_reason = "Column name matches `(table_name?)(_?)id`"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         col_lower = props.column.column_name.lower()
         table_lower = props.column.table_name.lower().rstrip("s")
 
@@ -73,7 +73,7 @@ class UniqueEntityByDistinctCountRule(ColumnMatcherRule):
     only_applies_to_parent_signal = True
     match_reason = "The values in the column are unique"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         return props.distinct_row_count == props.row_count
 
 
@@ -104,7 +104,7 @@ class TimeDimensionByTimeTypeRule(ColumnMatcherRule):
     only_applies_to_parent_signal = False
     match_reason = "Column type is time (TIME, DATE, DATETIME, TIMESTAMP)"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         return props.type == InferenceColumnType.DATETIME
 
 
@@ -119,7 +119,7 @@ class PrimaryTimeDimensionByNameRule(ColumnMatcherRule):
     only_applies_to_parent_signal = False
     match_reason = "Column name is either of 'ds', 'created_at', 'created_date' or 'created_time'"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         return props.column.column_name in ["ds", "created_at", "created_date", "created_time"]
 
 
@@ -129,7 +129,7 @@ class PrimaryTimeDimensionIfOnlyTimeRule(InferenceRule):
     It will always produce DIMENSION.PRIMARY_TIME signal with VERY_HIGH confidence.
     """
 
-    def process(self, warehouse: DataWarehouseInferenceContext) -> List[InferenceSignal]:  # noqa: D
+    def process(self, warehouse: DataWarehouseInferenceContext) -> List[InferenceSignal]:  # noqa: D102
         signals: List[InferenceSignal] = []
         for table_props in warehouse.tables.values():
             time_cols = [
@@ -159,7 +159,7 @@ class CategoricalDimensionByBooleanTypeRule(ColumnMatcherRule):
     only_applies_to_parent_signal = False
     match_reason = "Column type is BOOLEAN"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         return props.type == InferenceColumnType.BOOLEAN
 
 
@@ -192,7 +192,7 @@ class CategoricalDimensionByStringTypeRule(ColumnMatcherRule):
     only_applies_to_parent_signal = True
     match_reason = "Column type is STRING"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         return props.type == InferenceColumnType.STRING
 
 
@@ -207,7 +207,7 @@ class CategoricalDimensionByIntegerTypeRule(ColumnMatcherRule):
     only_applies_to_parent_signal = True
     match_reason = "Column type is INTEGER"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         return props.type == InferenceColumnType.INTEGER
 
 
@@ -238,7 +238,7 @@ class MeasureByRealTypeRule(ColumnMatcherRule):
     only_applies_to_parent_signal = False
     match_reason = "Column type is real (FLOAT, DOUBLE, DOUBLE PRECISION)"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         return props.type == InferenceColumnType.FLOAT
 
 
@@ -253,7 +253,7 @@ class MeasureByIntegerTypeRule(ColumnMatcherRule):
     only_applies_to_parent_signal = True
     match_reason = "Column type is INTEGER"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         return props.type == InferenceColumnType.INTEGER
 
 

--- a/metricflow/inference/rule/rules.py
+++ b/metricflow/inference/rule/rules.py
@@ -81,7 +81,7 @@ class LowCardinalityRatioRule(ColumnMatcherRule):
 
     match_reason = "Column has low cardinality"
 
-    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D
+    def match_column(self, props: ColumnProperties) -> bool:  # noqa: D102
         denom = props.row_count - props.null_count
 
         # undefined ratio

--- a/metricflow/inference/runner.py
+++ b/metricflow/inference/runner.py
@@ -62,27 +62,27 @@ class NoOpInferenceProgressReporter(InferenceProgressReporter):
 
     @staticmethod
     @contextlib.contextmanager
-    def warehouse() -> Iterator[None]:  # noqa: D
+    def warehouse() -> Iterator[None]:  # noqa: D102
         yield
 
     @staticmethod
     @contextlib.contextmanager
-    def table(table: SqlTable, index: int, total: int) -> Iterator[None]:  # noqa: D
+    def table(table: SqlTable, index: int, total: int) -> Iterator[None]:  # noqa: D102
         yield
 
     @staticmethod
     @contextlib.contextmanager
-    def rules() -> Iterator[None]:  # noqa: D
+    def rules() -> Iterator[None]:  # noqa: D102
         yield
 
     @staticmethod
     @contextlib.contextmanager
-    def solver() -> Iterator[None]:  # noqa: D
+    def solver() -> Iterator[None]:  # noqa: D102
         yield
 
     @staticmethod
     @contextlib.contextmanager
-    def renderers() -> Iterator[None]:  # noqa: D
+    def renderers() -> Iterator[None]:  # noqa: D102
         yield
 
 

--- a/metricflow/instances.py
+++ b/metricflow/instances.py
@@ -54,7 +54,7 @@ class MdoInstance(ABC, Generic[SpecT]):
 
 
 @dataclass(frozen=True)
-class SemanticModelElementInstance(SerializableDataclass):  # noqa: D
+class SemanticModelElementInstance(SerializableDataclass):  # noqa: D101
     # This instance is derived from something defined in a semantic model.
     defined_from: Tuple[SemanticModelElementReference, ...]
 
@@ -78,39 +78,39 @@ class SemanticModelElementInstance(SerializableDataclass):  # noqa: D
 
 
 @dataclass(frozen=True)
-class MeasureInstance(MdoInstance[MeasureSpec], SemanticModelElementInstance):  # noqa: D
+class MeasureInstance(MdoInstance[MeasureSpec], SemanticModelElementInstance):  # noqa: D101
     associated_columns: Tuple[ColumnAssociation, ...]
     spec: MeasureSpec
     aggregation_state: AggregationState
 
 
 @dataclass(frozen=True)
-class DimensionInstance(MdoInstance[DimensionSpec], SemanticModelElementInstance):  # noqa: D
+class DimensionInstance(MdoInstance[DimensionSpec], SemanticModelElementInstance):  # noqa: D101
     associated_columns: Tuple[ColumnAssociation, ...]
     spec: DimensionSpec
 
 
 @dataclass(frozen=True)
-class TimeDimensionInstance(MdoInstance[TimeDimensionSpec], SemanticModelElementInstance):  # noqa: D
+class TimeDimensionInstance(MdoInstance[TimeDimensionSpec], SemanticModelElementInstance):  # noqa: D101
     associated_columns: Tuple[ColumnAssociation, ...]
     spec: TimeDimensionSpec
 
 
 @dataclass(frozen=True)
-class EntityInstance(MdoInstance[EntitySpec], SemanticModelElementInstance):  # noqa: D
+class EntityInstance(MdoInstance[EntitySpec], SemanticModelElementInstance):  # noqa: D101
     associated_columns: Tuple[ColumnAssociation, ...]
     spec: EntitySpec
 
 
 @dataclass(frozen=True)
-class MetricInstance(MdoInstance[MetricSpec], SerializableDataclass):  # noqa: D
+class MetricInstance(MdoInstance[MetricSpec], SerializableDataclass):  # noqa: D101
     associated_columns: Tuple[ColumnAssociation, ...]
     spec: MetricSpec
     defined_from: MetricModelReference
 
 
 @dataclass(frozen=True)
-class MetadataInstance(MdoInstance[MetadataSpec], SerializableDataclass):  # noqa: D
+class MetadataInstance(MdoInstance[MetadataSpec], SerializableDataclass):  # noqa: D101
     associated_columns: Tuple[ColumnAssociation, ...]
     spec: MetadataSpec
 
@@ -128,7 +128,7 @@ class InstanceSetTransform(Generic[TransformOutputT], ABC):
     """
 
     @abstractmethod
-    def transform(self, instance_set: InstanceSet) -> TransformOutputT:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> TransformOutputT:  # noqa: D102
         pass
 
 
@@ -146,7 +146,7 @@ class InstanceSet(SerializableDataclass):
     metric_instances: Tuple[MetricInstance, ...] = ()
     metadata_instances: Tuple[MetadataInstance, ...] = ()
 
-    def transform(self, transform_function: InstanceSetTransform[TransformOutputT]) -> TransformOutputT:  # noqa: D
+    def transform(self, transform_function: InstanceSetTransform[TransformOutputT]) -> TransformOutputT:  # noqa: D102
         return transform_function.transform(self)
 
     @staticmethod
@@ -192,7 +192,7 @@ class InstanceSet(SerializableDataclass):
         )
 
     @property
-    def spec_set(self) -> InstanceSpecSet:  # noqa: D
+    def spec_set(self) -> InstanceSpecSet:  # noqa: D102
         return InstanceSpecSet(
             measure_specs=tuple(x.spec for x in self.measure_instances),
             dimension_specs=tuple(x.spec for x in self.dimension_instances),

--- a/metricflow/mf_logging/formatting.py
+++ b/metricflow/mf_logging/formatting.py
@@ -3,5 +3,5 @@ from __future__ import annotations
 import textwrap
 
 
-def indent(message: str, indent_level: int = 1, indent_prefix: str = "  ") -> str:  # noqa: D
+def indent(message: str, indent_level: int = 1, indent_prefix: str = "  ") -> str:  # noqa: D103
     return textwrap.indent(message, prefix=indent_prefix * indent_level)

--- a/metricflow/model/data_warehouse_model_validator.py
+++ b/metricflow/model/data_warehouse_model_validator.py
@@ -59,7 +59,7 @@ class QueryRenderingTools:
     time_spine_source: TimeSpineSource
     plan_converter: DataflowToSqlQueryPlanConverter
 
-    def __init__(self, manifest: SemanticManifest) -> None:  # noqa: D
+    def __init__(self, manifest: SemanticManifest) -> None:  # noqa: D107
         self.semantic_manifest_lookup = SemanticManifestLookup(semantic_manifest=manifest)
         self.source_node_builder = SourceNodeBuilder(
             column_association_resolver=DunderColumnAssociationResolver(self.semantic_manifest_lookup),
@@ -412,9 +412,7 @@ class DataWarehouseTaskBuilder:
         return tasks
 
     @staticmethod
-    def _gen_metric_task_query_and_params(
-        metric: Metric, mf_engine: MetricFlowEngine
-    ) -> Tuple[str, SqlBindParameters]:  # noqa: D
+    def _gen_metric_task_query_and_params(metric: Metric, mf_engine: MetricFlowEngine) -> Tuple[str, SqlBindParameters]:
         mf_query = MetricFlowQueryRequest.create_with_random_request_id(
             metric_names=[metric.name], group_by_names=[DataSet.metric_time_dimension_name()]
         )
@@ -456,7 +454,7 @@ class DataWarehouseModelValidator:
     them (assuming the manifest has passed these validations before use).
     """
 
-    def __init__(self, sql_client: SqlClient) -> None:  # noqa: D
+    def __init__(self, sql_client: SqlClient) -> None:  # noqa: D107
         self._sql_client = sql_client
 
     def run_tasks(

--- a/metricflow/model/object_to_reference.py
+++ b/metricflow/model/object_to_reference.py
@@ -25,21 +25,21 @@ class ObjectToReference:
     """
 
     @staticmethod
-    def from_semantic_model(semantic_model: SemanticModel) -> SemanticModelReference:  # noqa: D
+    def from_semantic_model(semantic_model: SemanticModel) -> SemanticModelReference:  # noqa: D102
         return SemanticModelReference(semantic_model_name=semantic_model.name)
 
     @staticmethod
-    def from_measure(measure: Measure) -> MeasureReference:  # noqa: D
+    def from_measure(measure: Measure) -> MeasureReference:  # noqa: D102
         return MeasureReference(element_name=measure.name)
 
     @staticmethod
-    def from_entity(entity: Entity) -> EntityReference:  # noqa: D
+    def from_entity(entity: Entity) -> EntityReference:  # noqa: D102
         return EntityReference(element_name=entity.name)
 
     @staticmethod
-    def from_metric(metric: Metric) -> MetricReference:  # noqa: D
+    def from_metric(metric: Metric) -> MetricReference:  # noqa: D102
         return MetricReference(element_name=metric.name)
 
     @staticmethod
-    def from_dimension(dimension: Dimension) -> DimensionReference:  # noqa: D
+    def from_dimension(dimension: Dimension) -> DimensionReference:  # noqa: D102
         return DimensionReference(element_name=dimension.name)

--- a/metricflow/model/semantic_manifest_lookup.py
+++ b/metricflow/model/semantic_manifest_lookup.py
@@ -18,25 +18,25 @@ logger = logging.getLogger(__name__)
 class SemanticManifestLookup:
     """Adds semantics information to the user configured model."""
 
-    def __init__(self, semantic_manifest: SemanticManifest) -> None:  # noqa: D
+    def __init__(self, semantic_manifest: SemanticManifest) -> None:  # noqa: D107
         self._semantic_manifest = semantic_manifest
         self._semantic_model_lookup = SemanticModelLookup(semantic_manifest)
         self._metric_lookup = MetricLookup(self._semantic_manifest, self._semantic_model_lookup)
 
     @property
-    def semantic_manifest(self) -> SemanticManifest:  # noqa: D
+    def semantic_manifest(self) -> SemanticManifest:  # noqa: D102
         return self._semantic_manifest
 
     @property
-    def semantic_model_lookup(self) -> SemanticModelAccessor:  # noqa: D
+    def semantic_model_lookup(self) -> SemanticModelAccessor:  # noqa: D102
         return self._semantic_model_lookup
 
     @property
-    def metric_lookup(self) -> MetricLookup:  # noqa: D
+    def metric_lookup(self) -> MetricLookup:  # noqa: D102
         return self._metric_lookup
 
     @property
-    def time_spine_source(self) -> TimeSpineSource:  # noqa: D
+    def time_spine_source(self) -> TimeSpineSource:  # noqa: D102
         time_spine_table_configurations = self._semantic_manifest.project_configuration.time_spine_table_configurations
 
         if not (

--- a/metricflow/model/semantics/element_group.py
+++ b/metricflow/model/semantics/element_group.py
@@ -10,13 +10,13 @@ ElementY = TypeVar("ElementY")
 class ElementGrouper(Generic[ElementX, ElementY]):
     """Groups an Element pair such that we have (ElementX, List[ElementY])."""
 
-    def __init__(self) -> None:  # noqa: D
+    def __init__(self) -> None:  # noqa: D107
         self._groups: Dict[ElementX, List[ElementY]] = collections.defaultdict(list)
 
-    def add_value(self, key: ElementX, value: ElementY) -> None:  # noqa: D
+    def add_value(self, key: ElementX, value: ElementY) -> None:  # noqa: D102
         self._groups[key].append(value)
 
-    def get_values(self, key: ElementX) -> List[ElementY]:  # noqa: D
+    def get_values(self, key: ElementX) -> List[ElementY]:  # noqa: D102
         if key not in self._groups:
             raise KeyError(f"Unable to find `{key}` in ElementGrouper")
         return self._groups[key]

--- a/metricflow/model/semantics/linkable_element_properties.py
+++ b/metricflow/model/semantics/linkable_element_properties.py
@@ -27,7 +27,7 @@ class LinkableElementProperties(Enum):
     METRIC_TIME = "metric_time"
 
     @staticmethod
-    def all_properties() -> FrozenSet[LinkableElementProperties]:  # noqa: D
+    def all_properties() -> FrozenSet[LinkableElementProperties]:  # noqa: D102
         return frozenset(
             {
                 LinkableElementProperties.LOCAL,

--- a/metricflow/model/semantics/linkable_spec_resolver.py
+++ b/metricflow/model/semantics/linkable_spec_resolver.py
@@ -63,7 +63,7 @@ class LinkableDimension:
     date_part: Optional[DatePart]
 
     @property
-    def path_key(self) -> ElementPathKey:  # noqa: D
+    def path_key(self) -> ElementPathKey:  # noqa: D102
         return ElementPathKey(
             element_name=self.element_name,
             entity_links=self.entity_links,
@@ -72,7 +72,7 @@ class LinkableDimension:
         )
 
     @property
-    def reference(self) -> DimensionReference:  # noqa: D
+    def reference(self) -> DimensionReference:  # noqa: D102
         return DimensionReference(element_name=self.element_name)
 
 
@@ -88,7 +88,7 @@ class LinkableEntity:
     join_path: Tuple[SemanticModelJoinPathElement, ...]
 
     @property
-    def path_key(self) -> ElementPathKey:  # noqa: D
+    def path_key(self) -> ElementPathKey:  # noqa: D102
         return ElementPathKey(
             element_name=self.element_name,
             entity_links=self.entity_links,
@@ -256,7 +256,7 @@ class LinkableElementSet:
         )
 
     @property
-    def as_spec_set(self) -> LinkableSpecSet:  # noqa: D
+    def as_spec_set(self) -> LinkableSpecSet:  # noqa: D102
         return LinkableSpecSet(
             dimension_specs=tuple(
                 DimensionSpec(
@@ -532,7 +532,7 @@ class ValidLinkableSpecResolver:
 
         logger.info(f"Building valid group-by-item indexes took: {time.time() - start_time:.2f}s")
 
-    def _get_semantic_model_for_measure(self, measure_reference: MeasureReference) -> SemanticModel:  # noqa: D
+    def _get_semantic_model_for_measure(self, measure_reference: MeasureReference) -> SemanticModel:
         semantic_models_where_measure_was_found = []
         for semantic_model in self._semantic_models:
             if any([x.reference.element_name == measure_reference.element_name for x in semantic_model.measures]):
@@ -708,13 +708,15 @@ class ValidLinkableSpecResolver:
                         join_path=(),
                         # Anything that's not at the base time granularity of the measure's aggregation time dimension
                         # should be considered derived.
-                        properties=frozenset({LinkableElementProperties.METRIC_TIME})
-                        if time_granularity is defined_granularity and date_part is None
-                        else frozenset(
-                            {
-                                LinkableElementProperties.METRIC_TIME,
-                                LinkableElementProperties.DERIVED_TIME_GRANULARITY,
-                            }
+                        properties=(
+                            frozenset({LinkableElementProperties.METRIC_TIME})
+                            if time_granularity is defined_granularity and date_part is None
+                            else frozenset(
+                                {
+                                    LinkableElementProperties.METRIC_TIME,
+                                    LinkableElementProperties.DERIVED_TIME_GRANULARITY,
+                                }
+                            )
                         ),
                         time_granularity=time_granularity,
                         date_part=date_part,

--- a/metricflow/model/semantics/metric_lookup.py
+++ b/metricflow/model/semantics/metric_lookup.py
@@ -23,10 +23,10 @@ from metricflow.specs.specs import LinkableInstanceSpec, TimeDimensionSpec
 logger = logging.getLogger(__name__)
 
 
-class MetricLookup(MetricAccessor):  # noqa: D
-    def __init__(  # noqa: D
+class MetricLookup(MetricAccessor):  # noqa: D101
+    def __init__(  # noqa: D107
         self, semantic_manifest: SemanticManifest, semantic_model_lookup: SemanticModelLookup
-    ) -> None:
+    ) -> None:  # noqa: D107
         self._semantic_manifest = semantic_manifest
         self._metrics: Dict[MetricReference, Metric] = {}
         self._semantic_model_lookup = semantic_model_lookup
@@ -104,7 +104,7 @@ class MetricLookup(MetricAccessor):  # noqa: D
             without_any_of=without_any_property,
         )
 
-    def get_metrics(self, metric_references: Sequence[MetricReference]) -> Sequence[Metric]:  # noqa: D
+    def get_metrics(self, metric_references: Sequence[MetricReference]) -> Sequence[Metric]:  # noqa: D102
         res = []
         for metric_reference in metric_references:
             if metric_reference not in self._metrics:
@@ -116,10 +116,10 @@ class MetricLookup(MetricAccessor):  # noqa: D
         return res
 
     @property
-    def metric_references(self) -> Sequence[MetricReference]:  # noqa: D
+    def metric_references(self) -> Sequence[MetricReference]:  # noqa: D102
         return list(self._metrics.keys())
 
-    def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa:D
+    def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa: D102
         if metric_reference not in self._metrics:
             raise MetricNotFoundError(f"Unable to find metric `{metric_reference}`. Perhaps it has not been registered")
         return self._metrics[metric_reference]
@@ -136,9 +136,9 @@ class MetricLookup(MetricAccessor):  # noqa: D
                 )
         self._metrics[metric_reference] = metric
 
-    def configured_input_measure_for_metric(  # noqa: D
+    def configured_input_measure_for_metric(  # noqa: D102
         self, metric_reference: MetricReference
-    ) -> Optional[MetricInputMeasure]:
+    ) -> Optional[MetricInputMeasure]:  # noqa: D102
         metric = self.get_metric(metric_reference=metric_reference)
         if metric.type is MetricType.CUMULATIVE or metric.type is MetricType.SIMPLE:
             assert len(metric.input_measures) == 1, "Simple and cumulative metrics should have one input measure."

--- a/metricflow/model/semantics/semantic_model_container.py
+++ b/metricflow/model/semantics/semantic_model_container.py
@@ -6,23 +6,23 @@ from typing import Generic, List, TypeVar
 T = TypeVar("T")
 
 
-class SemanticModelContainer(ABC, Generic[T]):  # noqa: D
+class SemanticModelContainer(ABC, Generic[T]):  # noqa: D101
     @abstractmethod
-    def get(self, semantic_model_name: str) -> T:  # noqa: D
+    def get(self, semantic_model_name: str) -> T:  # noqa: D102
         pass
 
     @abstractmethod
-    def values(self) -> List[T]:  # noqa: D
+    def values(self) -> List[T]:  # noqa: D102
         pass
 
     @abstractmethod
-    def keys(self) -> List[str]:  # noqa: D
+    def keys(self) -> List[str]:  # noqa: D102
         pass
 
     @abstractmethod
-    def __contains__(self, item: str) -> bool:  # noqa: D
+    def __contains__(self, item: str) -> bool:  # noqa: D105
         pass
 
     @abstractmethod
-    def put(self, key: str, value: T) -> None:  # noqa: D
+    def put(self, key: str, value: T) -> None:  # noqa: D102
         pass

--- a/metricflow/model/semantics/semantic_model_join_evaluator.py
+++ b/metricflow/model/semantics/semantic_model_join_evaluator.py
@@ -70,7 +70,7 @@ class SemanticModelJoinEvaluator:
         SemanticModelEntityJoinType(left_entity_type=EntityType.NATURAL, right_entity_type=EntityType.NATURAL),
     )
 
-    def __init__(self, semantic_model_lookup: SemanticModelAccessor) -> None:  # noqa: D
+    def __init__(self, semantic_model_lookup: SemanticModelAccessor) -> None:  # noqa: D107
         self._semantic_model_lookup = semantic_model_lookup
 
     def get_joinable_semantic_models(

--- a/metricflow/model/semantics/semantic_model_lookup.py
+++ b/metricflow/model/semantics/semantic_model_lookup.py
@@ -47,7 +47,7 @@ class SemanticModelLookup(SemanticModelAccessor):
     That interface prevents unwanted calls to methods for adding semantic models to the container.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         model: SemanticManifest,
     ) -> None:
@@ -74,7 +74,7 @@ class SemanticModelLookup(SemanticModelAccessor):
         for semantic_model in sorted(self._model.semantic_models, key=lambda semantic_model: semantic_model.name):
             self._add_semantic_model(semantic_model)
 
-    def get_dimension_references(self) -> Sequence[DimensionReference]:  # noqa: D
+    def get_dimension_references(self) -> Sequence[DimensionReference]:  # noqa: D102
         return tuple(self._dimension_index.keys())
 
     @staticmethod
@@ -110,11 +110,11 @@ class SemanticModelLookup(SemanticModelAccessor):
         return self.get_dimension(dimension_reference=time_dimension_reference.dimension_reference())
 
     @property
-    def measure_references(self) -> Sequence[MeasureReference]:  # noqa: D
+    def measure_references(self) -> Sequence[MeasureReference]:  # noqa: D102
         return list(self._measure_index.keys())
 
     @property
-    def non_additive_dimension_specs_by_measure(self) -> Dict[MeasureReference, NonAdditiveDimensionSpec]:  # noqa: D
+    def non_additive_dimension_specs_by_measure(self) -> Dict[MeasureReference, NonAdditiveDimensionSpec]:  # noqa: D102
         return self._measure_non_additive_dimension_specs
 
     @staticmethod
@@ -128,7 +128,7 @@ class SemanticModelLookup(SemanticModelAccessor):
             f"No dimension with name ({measure_reference.element_name}) in semantic_model with name ({semantic_model.name})"
         )
 
-    def get_measure(self, measure_reference: MeasureReference) -> Measure:  # noqa: D
+    def get_measure(self, measure_reference: MeasureReference) -> Measure:  # noqa: D102
         if measure_reference not in self._measure_index:
             raise ValueError(f"Could not find measure with name ({measure_reference}) in configured semantic models")
 
@@ -142,21 +142,21 @@ class SemanticModelLookup(SemanticModelAccessor):
             semantic_model=semantic_models[0], measure_reference=measure_reference
         )
 
-    def get_entity_references(self) -> Sequence[EntityReference]:  # noqa: D
+    def get_entity_references(self) -> Sequence[EntityReference]:  # noqa: D102
         return list(self._entity_index.keys())
 
     # DSC interface
-    def get_semantic_models_for_measure(  # noqa: D
+    def get_semantic_models_for_measure(  # noqa: D102
         self, measure_reference: MeasureReference
-    ) -> Sequence[SemanticModel]:
+    ) -> Sequence[SemanticModel]:  # noqa: D102
         return self._measure_index.get(measure_reference, [])
 
-    def get_agg_time_dimension_for_measure(  # noqa: D
+    def get_agg_time_dimension_for_measure(  # noqa: D102
         self, measure_reference: MeasureReference
-    ) -> TimeDimensionReference:
+    ) -> TimeDimensionReference:  # noqa: D102
         return self._measure_agg_time_dimension[measure_reference]
 
-    def get_entity_in_semantic_model(self, ref: SemanticModelElementReference) -> Optional[Entity]:  # Noqa: d
+    def get_entity_in_semantic_model(self, ref: SemanticModelElementReference) -> Optional[Entity]:  # noqa: D102
         semantic_model = self.get_by_reference(ref.semantic_model_reference)
         if not semantic_model:
             return None
@@ -167,7 +167,9 @@ class SemanticModelLookup(SemanticModelAccessor):
 
         return None
 
-    def get_by_reference(self, semantic_model_reference: SemanticModelReference) -> Optional[SemanticModel]:  # noqa: D
+    def get_by_reference(  # noqa: D102
+        self, semantic_model_reference: SemanticModelReference
+    ) -> Optional[SemanticModel]:  # noqa: D102
         return self._semantic_model_reference_to_semantic_model.get(semantic_model_reference)
 
     def _add_semantic_model(self, semantic_model: SemanticModel) -> None:
@@ -261,7 +263,7 @@ class SemanticModelLookup(SemanticModelAccessor):
         self._semantic_model_reference_to_semantic_model[semantic_model.reference] = semantic_model
 
     @property
-    def semantic_model_references(self) -> Sequence[SemanticModelReference]:  # noqa: D
+    def semantic_model_references(self) -> Sequence[SemanticModelReference]:  # noqa: D102
         semantic_model_names_sorted = sorted(self._semantic_model_names)
         return tuple(SemanticModelReference(semantic_model_name=x) for x in semantic_model_names_sorted)
 
@@ -329,7 +331,7 @@ class SemanticModelLookup(SemanticModelAccessor):
 
         return sorted(possible_entity_links, key=lambda entity_reference: entity_reference.element_name)
 
-    def get_element_spec_for_name(self, element_name: str) -> LinkableInstanceSpec:  # noqa: D
+    def get_element_spec_for_name(self, element_name: str) -> LinkableInstanceSpec:  # noqa: D102
         if TimeDimensionReference(element_name=element_name) in self._dimension_ref_to_spec:
             return self._dimension_ref_to_spec[TimeDimensionReference(element_name=element_name)]
         elif DimensionReference(element_name=element_name) in self._dimension_ref_to_spec:

--- a/metricflow/model/transformations/dedupe_metric_input_measures.py
+++ b/metricflow/model/transformations/dedupe_metric_input_measures.py
@@ -17,11 +17,11 @@ class DedupeMetricInputMeasuresRule(ProtocolHint[SemanticManifestTransformRule[P
     """
 
     @override
-    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:
         return self
 
     @staticmethod
-    def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
+    def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D102
         for metric in semantic_manifest.metrics:
             metric.type_params.input_measures = list(dict.fromkeys(metric.input_measures).keys())
         return semantic_manifest

--- a/metricflow/naming/object_builder_str.py
+++ b/metricflow/naming/object_builder_str.py
@@ -25,7 +25,7 @@ class ObjectBuilderNameConverter:
     """
 
     @staticmethod
-    def input_str_from_entity_call_parameter_set(parameter_set: EntityCallParameterSet) -> str:  # noqa: D
+    def input_str_from_entity_call_parameter_set(parameter_set: EntityCallParameterSet) -> str:  # noqa: D102
         initializer_parameter_str = ObjectBuilderNameConverter.initializer_parameter_str(
             element_name=parameter_set.entity_reference.element_name,
             entity_links=parameter_set.entity_path,
@@ -101,7 +101,7 @@ class ObjectBuilderNameConverter:
             return names_to_return
 
     @staticmethod
-    def input_str_from_spec(instance_spec: InstanceSpec) -> str:  # noqa: D
+    def input_str_from_spec(instance_spec: InstanceSpec) -> str:  # noqa: D102
         names = ObjectBuilderNameConverter._ObjectBuilderNameTransform().transform(
             InstanceSpecSet.from_specs((instance_spec,))
         )
@@ -112,7 +112,7 @@ class ObjectBuilderNameConverter:
         return names[0]
 
     @staticmethod
-    def input_str_from_dimension_call_parameter_set(parameter_set: DimensionCallParameterSet) -> str:  # noqa: D
+    def input_str_from_dimension_call_parameter_set(parameter_set: DimensionCallParameterSet) -> str:  # noqa: D102
         initializer_parameter_str = ObjectBuilderNameConverter.initializer_parameter_str(
             element_name=parameter_set.dimension_reference.element_name,
             entity_links=parameter_set.entity_path,
@@ -122,7 +122,7 @@ class ObjectBuilderNameConverter:
         return f"Dimension({initializer_parameter_str})"
 
     @staticmethod
-    def input_str_from_time_dimension_call_parameter_set(  # noqa: D
+    def input_str_from_time_dimension_call_parameter_set(  # noqa: D102
         parameter_set: TimeDimensionCallParameterSet,
     ) -> str:
         initializer_parameter_str = ObjectBuilderNameConverter.initializer_parameter_str(

--- a/metricflow/plan_conversion/column_resolver.py
+++ b/metricflow/plan_conversion/column_resolver.py
@@ -26,22 +26,22 @@ logger = logging.getLogger(__name__)
 class DunderColumnAssociationResolverVisitor(InstanceSpecVisitor[ColumnAssociation]):
     """Visitor helper class for DefaultColumnAssociationResolver2."""
 
-    def __init__(self, semantic_manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
+    def __init__(self, semantic_manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
         self._semantic_manifest_lookup = semantic_manifest_lookup
 
-    def visit_metric_spec(self, metric_spec: MetricSpec) -> ColumnAssociation:  # noqa: D
+    def visit_metric_spec(self, metric_spec: MetricSpec) -> ColumnAssociation:  # noqa: D102
         return ColumnAssociation(
             column_name=metric_spec.element_name if metric_spec.alias is None else metric_spec.alias,
             single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 
-    def visit_measure_spec(self, measure_spec: MeasureSpec) -> ColumnAssociation:  # noqa: D
+    def visit_measure_spec(self, measure_spec: MeasureSpec) -> ColumnAssociation:  # noqa: D102
         return ColumnAssociation(
             column_name=measure_spec.element_name,
             single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 
-    def visit_dimension_spec(self, dimension_spec: DimensionSpec) -> ColumnAssociation:  # noqa: D
+    def visit_dimension_spec(self, dimension_spec: DimensionSpec) -> ColumnAssociation:  # noqa: D102
         return ColumnAssociation(
             column_name=StructuredLinkableSpecName(
                 entity_link_names=tuple(x.element_name for x in dimension_spec.entity_links),
@@ -50,7 +50,7 @@ class DunderColumnAssociationResolverVisitor(InstanceSpecVisitor[ColumnAssociati
             single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 
-    def visit_time_dimension_spec(self, time_dimension_spec: TimeDimensionSpec) -> ColumnAssociation:  # noqa: D
+    def visit_time_dimension_spec(self, time_dimension_spec: TimeDimensionSpec) -> ColumnAssociation:  # noqa: D102
         column_name = StructuredLinkableSpecName(
             entity_link_names=tuple(x.element_name for x in time_dimension_spec.entity_links),
             element_name=time_dimension_spec.element_name,
@@ -68,7 +68,7 @@ class DunderColumnAssociationResolverVisitor(InstanceSpecVisitor[ColumnAssociati
             single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 
-    def visit_entity_spec(self, entity_spec: EntitySpec) -> ColumnAssociation:  # noqa: D
+    def visit_entity_spec(self, entity_spec: EntitySpec) -> ColumnAssociation:  # noqa: D102
         return ColumnAssociation(
             column_name=StructuredLinkableSpecName(
                 entity_link_names=tuple(x.element_name for x in entity_spec.entity_links),
@@ -77,7 +77,7 @@ class DunderColumnAssociationResolverVisitor(InstanceSpecVisitor[ColumnAssociati
             single_column_correlation_key=SingleColumnCorrelationKey(),
         )
 
-    def visit_metadata_spec(self, metadata_spec: MetadataSpec) -> ColumnAssociation:  # noqa: D
+    def visit_metadata_spec(self, metadata_spec: MetadataSpec) -> ColumnAssociation:  # noqa: D102
         return ColumnAssociation(
             column_name=metadata_spec.qualified_name,
             single_column_correlation_key=SingleColumnCorrelationKey(),
@@ -96,8 +96,8 @@ class DunderColumnAssociationResolver(ColumnAssociationResolver):
     listing__country
     """
 
-    def __init__(self, semantic_manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
+    def __init__(self, semantic_manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
         self._visitor_helper = DunderColumnAssociationResolverVisitor(semantic_manifest_lookup)
 
-    def resolve_spec(self, spec: InstanceSpec) -> ColumnAssociation:  # noqa: D
+    def resolve_spec(self, spec: InstanceSpec) -> ColumnAssociation:  # noqa: D102
         return spec.accept(self._visitor_helper)

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -173,7 +173,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         self._time_spine_source = semantic_manifest_lookup.time_spine_source
 
     @property
-    def column_association_resolver(self) -> ColumnAssociationResolver:  # noqa: D
+    def column_association_resolver(self) -> ColumnAssociationResolver:  # noqa: D102
         return self._column_association_resolver
 
     def convert_to_sql_query_plan(
@@ -749,7 +749,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             )
         return metric_expr
 
-    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> SqlDataSet:  # noqa: D
+    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> SqlDataSet:  # noqa: D102
         from_data_set: SqlDataSet = node.parent_node.accept(self)
         output_instance_set = from_data_set.instance_set
         from_data_set_alias = self._next_unique_table_alias()
@@ -791,11 +791,11 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             ),
         )
 
-    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> SqlDataSet:  # noqa: D
+    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> SqlDataSet:  # noqa: D102
         # Returning the parent-node SQL as an approximation since you can't write to a dataframe via SQL.
         return node.parent_node.accept(self)
 
-    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> SqlDataSet:  # noqa: D
+    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> SqlDataSet:  # noqa: D102
         input_data_set: SqlDataSet = node.parent_node.accept(self)
         input_instance_set: InstanceSet = input_data_set.instance_set
         return SqlDataSet(
@@ -1254,7 +1254,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             ),
         )
 
-    def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> SqlDataSet:  # noqa: D
+    def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> SqlDataSet:  # noqa: D102
         parent_data_set = node.parent_node.accept(self)
         parent_alias = self._next_unique_table_alias()
 
@@ -1432,7 +1432,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             ),
         )
 
-    def visit_min_max_node(self, node: MinMaxNode) -> SqlDataSet:  # noqa: D
+    def visit_min_max_node(self, node: MinMaxNode) -> SqlDataSet:  # noqa: D102
         parent_data_set = node.parent_node.accept(self)
         parent_table_alias = self._next_unique_table_alias()
         assert (

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -83,7 +83,7 @@ class CreateSelectColumnsForInstances(InstanceSetTransform[SelectColumnSet]):
         self._column_resolver = column_resolver
         self._output_to_input_column_mapping = output_to_input_column_mapping or OrderedDict()
 
-    def transform(self, instance_set: InstanceSet) -> SelectColumnSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> SelectColumnSet:  # noqa: D102
         metric_cols = list(
             chain.from_iterable([self._make_sql_column_expression(x) for x in instance_set.metric_instances])
         )
@@ -171,7 +171,7 @@ class CreateSelectColumnsWithMeasuresAggregated(CreateSelectColumnsForInstances)
     Also add an output alias that conforms to the alias
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         table_alias: str,
         column_resolver: ColumnAssociationResolver,
@@ -204,7 +204,7 @@ class CreateSelectColumnsWithMeasuresAggregated(CreateSelectColumnsForInstances)
 
         return output_columns
 
-    def _make_sql_column_expression_to_aggregate_measure(  # noqa: D
+    def _make_sql_column_expression_to_aggregate_measure(
         self, measure_instance: MeasureInstance, output_measure_spec: MeasureSpec
     ) -> SqlSelectColumn:
         """Convert one measure instance into a SQL column."""
@@ -236,7 +236,7 @@ class CreateSelectColumnsWithMeasuresAggregated(CreateSelectColumnsForInstances)
             column_alias=new_column_name_for_aggregated_measure,
         )
 
-    def transform(self, instance_set: InstanceSet) -> SelectColumnSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> SelectColumnSet:  # noqa: D102
         metric_cols = list(
             chain.from_iterable([self._make_sql_column_expression(x) for x in instance_set.metric_instances])
         )
@@ -380,10 +380,10 @@ class AddLinkToLinkableElements(InstanceSetTransform[InstanceSet]):
     e.g. "country" -> "user_id__country" after a data set has been joined by entity.
     """
 
-    def __init__(self, join_on_entity: LinklessEntitySpec) -> None:  # noqa: D
+    def __init__(self, join_on_entity: LinklessEntitySpec) -> None:  # noqa: D107
         self._join_on_entity = join_on_entity
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         assert len(instance_set.metric_instances) == 0, "Can't add links to instance sets with metrics"
         assert len(instance_set.measure_instances) == 0, "Can't add links to instance sets with measures"
 
@@ -460,7 +460,7 @@ class FilterLinkableInstancesWithLeadingLink(InstanceSetTransform[InstanceSet]):
     e.g. Remove "listing__country" if the specified link is "listing".
     """
 
-    def __init__(  # noqa: D
+    def __init__(
         self,
         entity_link: LinklessEntitySpec,
     ) -> None:
@@ -471,13 +471,13 @@ class FilterLinkableInstancesWithLeadingLink(InstanceSetTransform[InstanceSet]):
         """
         self._entity_link = entity_link
 
-    def _should_pass(self, linkable_spec: LinkableInstanceSpec) -> bool:  # noqa: D
+    def _should_pass(self, linkable_spec: LinkableInstanceSpec) -> bool:
         return (
             len(linkable_spec.entity_links) == 0
             or LinklessEntitySpec.from_reference(linkable_spec.entity_links[0]) != self._entity_link
         )
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         # Normal to not filter anything if the instance set has no instances with links.
         filtered_dimension_instances = tuple(x for x in instance_set.dimension_instances if self._should_pass(x.spec))
         filtered_time_dimension_instances = tuple(
@@ -499,7 +499,7 @@ class FilterLinkableInstancesWithLeadingLink(InstanceSetTransform[InstanceSet]):
 class FilterElements(InstanceSetTransform[InstanceSet]):
     """Return an instance set with the elements that don't match any of the pass specs removed."""
 
-    def __init__(  # noqa: D
+    def __init__(
         self,
         include_specs: Optional[InstanceSpecSet] = None,
         exclude_specs: Optional[InstanceSpecSet] = None,
@@ -514,7 +514,7 @@ class FilterElements(InstanceSetTransform[InstanceSet]):
         self._include_specs = include_specs
         self._exclude_specs = exclude_specs
 
-    def _should_pass(self, element_spec: InstanceSpec) -> bool:  # noqa: D
+    def _should_pass(self, element_spec: InstanceSpec) -> bool:
         # TODO: Use better matching function
         if self._include_specs:
             return any(x == element_spec for x in self._include_specs.all_specs)
@@ -522,7 +522,7 @@ class FilterElements(InstanceSetTransform[InstanceSet]):
             return not any(x == element_spec for x in self._exclude_specs.all_specs)
         assert False
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         # Sanity check to make sure the specs are in the instance set
 
         if self._include_specs:
@@ -566,7 +566,7 @@ class ChangeMeasureAggregationState(InstanceSetTransform[InstanceSet]):
         """
         self._aggregation_state_changes = aggregation_state_changes
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         for measure_instance in instance_set.measure_instances:
             assert measure_instance.aggregation_state in self._aggregation_state_changes, (
                 f"Aggregation state: {measure_instance.aggregation_state} not handled in change dict: "
@@ -623,7 +623,7 @@ class UpdateMeasureFillNullsWith(InstanceSetTransform[InstanceSet]):
 
         return tuple(updated_instances)
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         return InstanceSet(
             measure_instances=self._update_fill_nulls_with(instance_set.measure_instances),
             dimension_instances=instance_set.dimension_instances,
@@ -677,7 +677,7 @@ class AliasAggregatedMeasures(InstanceSetTransform[InstanceSet]):
 
         return tuple(aliased_instances)
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         return InstanceSet(
             measure_instances=self._alias_measure_instances(instance_set.measure_instances),
             dimension_instances=instance_set.dimension_instances,
@@ -691,10 +691,10 @@ class AliasAggregatedMeasures(InstanceSetTransform[InstanceSet]):
 class AddMetrics(InstanceSetTransform[InstanceSet]):
     """Adds the given metric instances to the instance set."""
 
-    def __init__(self, metric_instances: List[MetricInstance]) -> None:  # noqa: D
+    def __init__(self, metric_instances: List[MetricInstance]) -> None:  # noqa: D107
         self._metric_instances = metric_instances
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         return InstanceSet(
             measure_instances=instance_set.measure_instances,
             dimension_instances=instance_set.dimension_instances,
@@ -708,7 +708,7 @@ class AddMetrics(InstanceSetTransform[InstanceSet]):
 class RemoveMeasures(InstanceSetTransform[InstanceSet]):
     """Remove measures from the instance set."""
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         return InstanceSet(
             measure_instances=(),
             dimension_instances=instance_set.dimension_instances,
@@ -722,7 +722,7 @@ class RemoveMeasures(InstanceSetTransform[InstanceSet]):
 class RemoveMetrics(InstanceSetTransform[InstanceSet]):
     """Remove metrics from the instance set."""
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         return InstanceSet(
             measure_instances=instance_set.measure_instances,
             dimension_instances=instance_set.dimension_instances,
@@ -754,7 +754,7 @@ class CreateSqlColumnReferencesForInstances(InstanceSetTransform[Tuple[SqlColumn
         self._table_alias = table_alias
         self._column_resolver = column_resolver
 
-    def transform(self, instance_set: InstanceSet) -> Tuple[SqlColumnReferenceExpression, ...]:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> Tuple[SqlColumnReferenceExpression, ...]:  # noqa: D102
         column_names = [
             self._column_resolver.resolve_spec(spec).column_name for spec in instance_set.spec_set.all_specs
         ]
@@ -776,7 +776,7 @@ class CreateSelectColumnForCombineOutputNode(InstanceSetTransform[SelectColumnSe
     come from the given table alias.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         table_alias: str,
         column_resolver: ColumnAssociationResolver,
@@ -811,9 +811,7 @@ class CreateSelectColumnForCombineOutputNode(InstanceSetTransform[SelectColumnSe
             column_alias=column_name,
         )
 
-    def _create_select_columns_for_metrics(
-        self, metric_instances: Tuple[MetricInstance, ...]
-    ) -> List[SqlSelectColumn]:  # noqa: D
+    def _create_select_columns_for_metrics(self, metric_instances: Tuple[MetricInstance, ...]) -> List[SqlSelectColumn]:
         select_columns: List[SqlSelectColumn] = []
         for metric_instance in metric_instances:
             metric_reference = MetricReference(element_name=metric_instance.defined_from.metric_name)
@@ -826,7 +824,7 @@ class CreateSelectColumnForCombineOutputNode(InstanceSetTransform[SelectColumnSe
             )
         return select_columns
 
-    def _create_select_columns_for_measures(  # noqa: D
+    def _create_select_columns_for_measures(
         self, measure_instances: Tuple[MeasureInstance, ...]
     ) -> List[SqlSelectColumn]:
         select_columns: List[SqlSelectColumn] = []
@@ -837,7 +835,7 @@ class CreateSelectColumnForCombineOutputNode(InstanceSetTransform[SelectColumnSe
             )
         return select_columns
 
-    def transform(self, instance_set: InstanceSet) -> SelectColumnSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> SelectColumnSet:  # noqa: D102
         return SelectColumnSet(
             metric_columns=self._create_select_columns_for_metrics(instance_set.metric_instances),
             measure_columns=self._create_select_columns_for_measures(instance_set.measure_instances),
@@ -874,10 +872,10 @@ class ChangeAssociatedColumns(InstanceSetTransform[InstanceSet]):
             DimensionInstance(column_name="is_lux_latest")
     """
 
-    def __init__(self, column_association_resolver: ColumnAssociationResolver) -> None:  # noqa: D
+    def __init__(self, column_association_resolver: ColumnAssociationResolver) -> None:  # noqa: D107
         self._column_association_resolver = column_association_resolver
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         output_measure_instances = []
         for input_measure_instance in instance_set.measure_instances:
             output_measure_instances.append(
@@ -953,10 +951,10 @@ class ChangeAssociatedColumns(InstanceSetTransform[InstanceSet]):
 class ConvertToMetadata(InstanceSetTransform[InstanceSet]):
     """Removes all instances from old instance set and replaces them with a set of metadata instances."""
 
-    def __init__(self, metadata_instances: Sequence[MetadataInstance]) -> None:  # noqa: D
+    def __init__(self, metadata_instances: Sequence[MetadataInstance]) -> None:  # noqa: D107
         self._metadata_instances = metadata_instances
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         return InstanceSet(
             metadata_instances=tuple(self._metadata_instances),
         )
@@ -987,10 +985,10 @@ def create_select_columns_for_instance_sets(
 class AddMetadata(InstanceSetTransform[InstanceSet]):
     """Adds the given metric instances to the instance set."""
 
-    def __init__(self, metadata_instances: Sequence[MetadataInstance]) -> None:  # noqa: D
+    def __init__(self, metadata_instances: Sequence[MetadataInstance]) -> None:  # noqa: D107
         self._metadata_instances = metadata_instances
 
-    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D
+    def transform(self, instance_set: InstanceSet) -> InstanceSet:  # noqa: D102
         return InstanceSet(
             measure_instances=instance_set.measure_instances,
             dimension_instances=instance_set.dimension_instances,

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -76,7 +76,7 @@ class PreJoinNodeProcessor:
 
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         semantic_model_lookup: SemanticModelAccessor,
         node_data_set_resolver: DataflowPlanNodeOutputDataSetResolver,

--- a/metricflow/plan_conversion/spec_transforms.py
+++ b/metricflow/plan_conversion/spec_transforms.py
@@ -25,7 +25,7 @@ class CreateSelectCoalescedColumnsForLinkableSpecs(InstanceSpecSetTransform[Sele
     COALESCE(a.is_instant, b.is_instant) AS is_instant
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         column_association_resolver: ColumnAssociationResolver,
         table_aliases: Sequence[str],
@@ -33,7 +33,7 @@ class CreateSelectCoalescedColumnsForLinkableSpecs(InstanceSpecSetTransform[Sele
         self._column_association_resolver = column_association_resolver
         self._table_aliases = table_aliases
 
-    def transform(self, spec_set: InstanceSpecSet) -> SelectColumnSet:  # noqa: D
+    def transform(self, spec_set: InstanceSpecSet) -> SelectColumnSet:  # noqa: D102
         dimension_columns: List[SqlSelectColumn] = []
         time_dimension_columns: List[SqlSelectColumn] = []
         entity_columns: List[SqlSelectColumn] = []
@@ -76,7 +76,7 @@ class CreateSelectCoalescedColumnsForLinkableSpecs(InstanceSpecSetTransform[Sele
 class SelectOnlyLinkableSpecs(InstanceSpecSetTransform[InstanceSpecSet]):
     """Removes metrics and measures from the spec set."""
 
-    def transform(self, spec_set: InstanceSpecSet) -> InstanceSpecSet:  # noqa: D
+    def transform(self, spec_set: InstanceSpecSet) -> InstanceSpecSet:  # noqa: D102
         return InstanceSpecSet(
             metric_specs=(),
             measure_specs=(),
@@ -92,8 +92,8 @@ class CreateColumnAssociations(InstanceSpecSetTransform[Sequence[ColumnAssociati
     Initial use case is to figure out names of the columns present in the SQL of a WhereFilter.
     """
 
-    def __init__(self, column_association_resolver: ColumnAssociationResolver) -> None:  # noqa: D
+    def __init__(self, column_association_resolver: ColumnAssociationResolver) -> None:  # noqa: D107
         self._column_association_resolver = column_association_resolver
 
-    def transform(self, spec_set: InstanceSpecSet) -> Sequence[ColumnAssociation]:  # noqa: D
+    def transform(self, spec_set: InstanceSpecSet) -> Sequence[ColumnAssociation]:  # noqa: D102
         return tuple(self._column_association_resolver.resolve_spec(spec) for spec in spec_set.all_specs)

--- a/metricflow/protocols/query_parameter.py
+++ b/metricflow/protocols/query_parameter.py
@@ -23,7 +23,7 @@ class MetricQueryParameter(Protocol):
         raise NotImplementedError
 
     @property
-    def query_resolver_input(self) -> ResolverInputForMetric:  # noqa: D
+    def query_resolver_input(self) -> ResolverInputForMetric:  # noqa: D102
         raise NotImplementedError
 
 
@@ -37,12 +37,12 @@ class DimensionOrEntityQueryParameter(Protocol):
         raise NotImplementedError
 
     @property
-    def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D
+    def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D102
         raise NotImplementedError
 
 
 @runtime_checkable
-class TimeDimensionQueryParameter(Protocol):  # noqa: D
+class TimeDimensionQueryParameter(Protocol):  # noqa: D101
     @property
     def name(self) -> str:
         """The name of the item."""
@@ -59,7 +59,7 @@ class TimeDimensionQueryParameter(Protocol):  # noqa: D
         raise NotImplementedError
 
     @property
-    def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D
+    def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D102
         raise NotImplementedError
 
 
@@ -81,7 +81,7 @@ class OrderByQueryParameter(Protocol):
         raise NotImplementedError
 
     @property
-    def query_resolver_input(self) -> ResolverInputForOrderByItem:  # noqa: D
+    def query_resolver_input(self) -> ResolverInputForOrderByItem:  # noqa: D102
         raise NotImplementedError
 
 
@@ -89,5 +89,5 @@ class SavedQueryParameter(Protocol):
     """Name of the saved query to execute."""
 
     @property
-    def name(self) -> str:  # noqa: D
+    def name(self) -> str:  # noqa: D102
         raise NotImplementedError

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -181,7 +181,7 @@ class MetricAccessor(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa:D
+    def get_metric(self, metric_reference: MetricReference) -> Metric:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -75,7 +75,7 @@ class SqlClient(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def close(self) -> None:  # noqa: D
+    def close(self) -> None:
         """Close the connections / engines used by this client."""
         raise NotImplementedError
 

--- a/metricflow/query/group_by_item/candidate_push_down/group_by_item_candidate.py
+++ b/metricflow/query/group_by_item/candidate_push_down/group_by_item_candidate.py
@@ -33,7 +33,7 @@ class GroupByItemCandidateSet(PathPrefixable):
     measure_paths: Tuple[MetricFlowQueryResolutionPath, ...]
     path_from_leaf_node: MetricFlowQueryResolutionPath
 
-    def __post_init__(self) -> None:  # noqa: D
+    def __post_init__(self) -> None:  # noqa: D105
         # If there are no specs, there shouldn't be any measure paths.
         assert (len(self.specs) > 0 and len(self.measure_paths) > 0) or (
             len(self.specs) == 0 and len(self.measure_paths) == 0
@@ -62,15 +62,15 @@ class GroupByItemCandidateSet(PathPrefixable):
         )
 
     @property
-    def is_empty(self) -> bool:  # noqa: D
+    def is_empty(self) -> bool:  # noqa: D102
         return len(self.specs) == 0
 
     @property
-    def num_candidates(self) -> int:  # noqa: D
+    def num_candidates(self) -> int:  # noqa: D102
         return len(self.specs)
 
     @staticmethod
-    def empty_instance() -> GroupByItemCandidateSet:  # noqa: D
+    def empty_instance() -> GroupByItemCandidateSet:  # noqa: D102
         return GroupByItemCandidateSet(
             specs=(), measure_paths=(), path_from_leaf_node=MetricFlowQueryResolutionPath.empty_instance()
         )

--- a/metricflow/query/group_by_item/candidate_push_down/push_down_visitor.py
+++ b/metricflow/query/group_by_item/candidate_push_down/push_down_visitor.py
@@ -59,7 +59,7 @@ class PushDownResult:
     # The issues seen so far while pushing down the result / resolving the ambiguity.
     issue_set: MetricFlowQueryResolutionIssueSet
 
-    def __post_init__(self) -> None:  # noqa: D
+    def __post_init__(self) -> None:  # noqa: D105
         # If there are no errors, there should be a candidate spec in each candidate set.
         # If there are errors, there shouldn't be any candidate sets.
         assert (not self.issue_set.has_errors and not self.candidate_set.is_empty) or (
@@ -93,7 +93,7 @@ class PushDownResult:
 class DagTraversalPathTracker:
     """Helps track the path traveled by a visitor through the nodes in a group-by-tem resolution DAG."""
 
-    def __init__(self) -> None:  # noqa: D
+    def __init__(self) -> None:  # noqa: D107
         self._current_path: List[GroupByItemResolutionNode] = []
 
     @contextmanager
@@ -121,7 +121,7 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
     parents, the candidates from each parent are intersected and passed to the child node.
     """
 
-    def __init__(  # noqa: D
+    def __init__(
         self,
         manifest_lookup: SemanticManifestLookup,
         suggestion_generator: Optional[QueryItemSuggestionGenerator],
@@ -220,13 +220,15 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
                         NoMatchingItemsForMeasure.from_parameters(
                             parent_issues=(),
                             query_resolution_path=current_traversal_path,
-                            input_suggestions=tuple(
-                                self._suggestion_generator.input_suggestions(
-                                    specs_available_for_measure_given_child_metric
+                            input_suggestions=(
+                                tuple(
+                                    self._suggestion_generator.input_suggestions(
+                                        specs_available_for_measure_given_child_metric
+                                    )
                                 )
-                            )
-                            if self._suggestion_generator is not None
-                            else (),
+                                if self._suggestion_generator is not None
+                                else ()
+                            ),
                         )
                     ),
                 )
@@ -368,9 +370,9 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
             return PushDownResult(
                 candidate_set=GroupByItemCandidateSet(
                     specs=tuple(matched_specs),
-                    measure_paths=merged_result_from_parents.candidate_set.measure_paths
-                    if len(matched_specs) > 0
-                    else (),
+                    measure_paths=(
+                        merged_result_from_parents.candidate_set.measure_paths if len(matched_specs) > 0 else ()
+                    ),
                     path_from_leaf_node=current_traversal_path,
                 ),
                 issue_set=MetricFlowQueryResolutionIssueSet.merge_iterable(issue_sets_to_merge),

--- a/metricflow/query/group_by_item/filter_spec_resolution/filter_location.py
+++ b/metricflow/query/group_by_item/filter_spec_resolution/filter_location.py
@@ -21,13 +21,13 @@ class WhereFilterLocation:
     # These should be sorted for consistency in comparisons.
     metric_references: Tuple[MetricReference, ...]
 
-    def __post_init__(self) -> None:  # noqa: D
+    def __post_init__(self) -> None:  # noqa: D105
         assert is_sorted(self.metric_references)
 
     @staticmethod
-    def for_query(metric_references: Sequence[MetricReference]) -> WhereFilterLocation:  # noqa: D
+    def for_query(metric_references: Sequence[MetricReference]) -> WhereFilterLocation:  # noqa: D102
         return WhereFilterLocation(metric_references=tuple(sorted(metric_references)))
 
     @staticmethod
-    def for_metric(metric_reference: MetricReference) -> WhereFilterLocation:  # noqa: D
+    def for_metric(metric_reference: MetricReference) -> WhereFilterLocation:  # noqa: D102
         return WhereFilterLocation(metric_references=(metric_reference,))

--- a/metricflow/query/group_by_item/filter_spec_resolution/filter_pattern_factory.py
+++ b/metricflow/query/group_by_item/filter_spec_resolution/filter_pattern_factory.py
@@ -17,21 +17,21 @@ class WhereFilterPatternFactory(ABC):
     """Interface that defines how spec patterns should be generated for the group-by-items specified in filters."""
 
     @abstractmethod
-    def create_for_dimension_call_parameter_set(  # noqa: D
+    def create_for_dimension_call_parameter_set(  # noqa: D102
         self, dimension_call_parameter_set: DimensionCallParameterSet
     ) -> SpecPattern:
         raise NotImplementedError
 
     @abstractmethod
-    def create_for_time_dimension_call_parameter_set(  # noqa: D
+    def create_for_time_dimension_call_parameter_set(  # noqa: D102
         self, time_dimension_call_parameter_set: TimeDimensionCallParameterSet
     ) -> SpecPattern:
         raise NotImplementedError
 
     @abstractmethod
-    def create_for_entity_call_parameter_set(  # noqa: D
+    def create_for_entity_call_parameter_set(  # noqa: D102
         self, entity_call_parameter_set: EntityCallParameterSet
-    ) -> SpecPattern:
+    ) -> SpecPattern:  # noqa: D102
         raise NotImplementedError
 
 

--- a/metricflow/query/group_by_item/filter_spec_resolution/filter_spec_lookup.py
+++ b/metricflow/query/group_by_item/filter_spec_resolution/filter_spec_lookup.py
@@ -40,13 +40,13 @@ class FilterSpecResolutionLookUp(Mergeable):
     non_parsable_resolutions: Tuple[NonParsableFilterResolution, ...]
 
     @property
-    def has_errors(self) -> bool:  # noqa: D
+    def has_errors(self) -> bool:  # noqa: D102
         return any(
             non_parsable_resolution.issue_set.has_errors for non_parsable_resolution in self.non_parsable_resolutions
         ) or any(spec_resolution.issue_set.has_errors for spec_resolution in self.spec_resolutions)
 
     @property
-    def has_issues(self) -> bool:  # noqa: D
+    def has_issues(self) -> bool:  # noqa: D102
         return any(
             non_parsable_resolution.issue_set.has_issues for non_parsable_resolution in self.non_parsable_resolutions
         ) or any(spec_resolution.issue_set.has_issues for spec_resolution in self.spec_resolutions)
@@ -132,7 +132,7 @@ class ResolvedSpecLookUpKey:
     call_parameter_set: CallParameterSet
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         filter_location: WhereFilterLocation, call_parameter_set: CallParameterSet
     ) -> ResolvedSpecLookUpKey:
         return ResolvedSpecLookUpKey(
@@ -141,7 +141,7 @@ class ResolvedSpecLookUpKey:
         )
 
     @staticmethod
-    def for_metric_filter(  # noqa: D
+    def for_metric_filter(
         metric_reference: MetricReference, call_parameter_set: CallParameterSet
     ) -> ResolvedSpecLookUpKey:
         """Create a key related to a filter in a metric definition."""
@@ -153,7 +153,7 @@ class ResolvedSpecLookUpKey:
         )
 
     @staticmethod
-    def for_query_filter(  # noqa: D
+    def for_query_filter(
         metrics_in_query: Sequence[MetricReference], call_parameter_set: CallParameterSet
     ) -> ResolvedSpecLookUpKey:
         """Create a key related to a filter for a query."""

--- a/metricflow/query/group_by_item/filter_spec_resolution/filter_spec_resolver.py
+++ b/metricflow/query/group_by_item/filter_spec_resolution/filter_spec_resolver.py
@@ -63,7 +63,7 @@ class WhereFilterSpecResolver:
     The concrete specs for the group-by-items are returned in a lookup.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         manifest_lookup: SemanticManifestLookup,
         resolution_dag: GroupByItemResolutionDag,
@@ -96,7 +96,7 @@ class _ResolveWhereFilterSpecVisitor(GroupByItemResolutionNodeVisitor[FilterSpec
     collected and returned in a lookup object.
     """
 
-    def __init__(  # noqa: D
+    def __init__(
         self, manifest_lookup: SemanticManifestLookup, spec_pattern_factory: WhereFilterPatternFactory
     ) -> None:
         self._manifest_lookup = manifest_lookup

--- a/metricflow/query/group_by_item/group_by_item_resolver.py
+++ b/metricflow/query/group_by_item/group_by_item_resolver.py
@@ -57,7 +57,7 @@ class AvailableGroupByItemsResolution:
 class GroupByItemResolver:
     """Resolves group-by items for potentially ambiguous inputs that are specified in queries / filters."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         manifest_lookup: SemanticManifestLookup,
         resolution_dag: GroupByItemResolutionDag,

--- a/metricflow/query/group_by_item/resolution_dag/dag.py
+++ b/metricflow/query/group_by_item/resolution_dag/dag.py
@@ -28,7 +28,7 @@ class GroupByItemResolutionDag(MetricFlowDag[GroupByItemResolutionNode]):
     realize limitations appropriate to that node.
     """
 
-    def __init__(self, sink_node: ResolutionDagSinkNode) -> None:  # noqa: D
+    def __init__(self, sink_node: ResolutionDagSinkNode) -> None:  # noqa: D107
         super().__init__(
             dag_id=DagId.from_id_prefix(StaticIdPrefix.GROUP_BY_ITEM_RESOLUTION_DAG),
             sink_nodes=[sink_node],
@@ -36,5 +36,5 @@ class GroupByItemResolutionDag(MetricFlowDag[GroupByItemResolutionNode]):
         self._sink_node = sink_node
 
     @property
-    def sink_node(self) -> ResolutionDagSinkNode:  # noqa: D
+    def sink_node(self) -> ResolutionDagSinkNode:  # noqa: D102
         return self._sink_node

--- a/metricflow/query/group_by_item/resolution_dag/dag_builder.py
+++ b/metricflow/query/group_by_item/resolution_dag/dag_builder.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class GroupByItemResolutionDagBuilder:
     """Builds a GroupByItemResolutionDag that can be used to resolve group-by-item specs from spec patterns."""
 
-    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
+    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
         self._manifest_lookup = manifest_lookup
 
     def _build_dag_component_for_metric(

--- a/metricflow/query/group_by_item/resolution_dag/resolution_nodes/base_node.py
+++ b/metricflow/query/group_by_item/resolution_dag/resolution_nodes/base_node.py
@@ -27,7 +27,7 @@ class GroupByItemResolutionNode(DagNode, Visitable, ABC):
     See GroupByItemResolutionDag for more details.
     """
 
-    def __init__(self) -> None:  # noqa: D
+    def __init__(self) -> None:  # noqa: D107
         super().__init__(node_id=NodeId.create_unique(self.__class__.id_prefix()))
 
     @abstractmethod
@@ -43,7 +43,7 @@ class GroupByItemResolutionNode(DagNode, Visitable, ABC):
 
     @property
     @abstractmethod
-    def parent_nodes(self) -> Sequence[GroupByItemResolutionNode]:  # noqa: D
+    def parent_nodes(self) -> Sequence[GroupByItemResolutionNode]:  # noqa: D102
         raise NotImplementedError
 
 
@@ -51,17 +51,17 @@ class GroupByItemResolutionNodeVisitor(Generic[VisitorOutputT], ABC):
     """Visitor for traversing GroupByItemResolutionNodes."""
 
     @abstractmethod
-    def visit_measure_node(self, node: MeasureGroupByItemSourceNode) -> VisitorOutputT:  # noqa: D
+    def visit_measure_node(self, node: MeasureGroupByItemSourceNode) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_no_metrics_query_node(self, node: NoMetricsGroupByItemSourceNode) -> VisitorOutputT:  # noqa: D
+    def visit_no_metrics_query_node(self, node: NoMetricsGroupByItemSourceNode) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_metric_node(self, node: MetricGroupByItemResolutionNode) -> VisitorOutputT:  # noqa: D
+    def visit_metric_node(self, node: MetricGroupByItemResolutionNode) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_query_node(self, node: QueryGroupByItemResolutionNode) -> VisitorOutputT:  # noqa: D
+    def visit_query_node(self, node: QueryGroupByItemResolutionNode) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError

--- a/metricflow/query/group_by_item/resolution_dag/resolution_nodes/measure_source_node.py
+++ b/metricflow/query/group_by_item/resolution_dag/resolution_nodes/measure_source_node.py
@@ -17,7 +17,7 @@ from metricflow.visitor import VisitorOutputT
 class MeasureGroupByItemSourceNode(GroupByItemResolutionNode):
     """Outputs group-by-items for a measure."""
 
-    def __init__(  # noqa: D
+    def __init__(
         self,
         measure_reference: MeasureReference,
         child_metric_reference: MetricReference,
@@ -66,7 +66,7 @@ class MeasureGroupByItemSourceNode(GroupByItemResolutionNode):
         )
 
     @property
-    def measure_reference(self) -> MeasureReference:  # noqa: D
+    def measure_reference(self) -> MeasureReference:  # noqa: D102
         return self._measure_reference
 
     @property

--- a/metricflow/query/group_by_item/resolution_dag/resolution_nodes/metric_resolution_node.py
+++ b/metricflow/query/group_by_item/resolution_dag/resolution_nodes/metric_resolution_node.py
@@ -21,7 +21,7 @@ from metricflow.visitor import VisitorOutputT
 class MetricGroupByItemResolutionNode(GroupByItemResolutionNode):
     """Outputs group-by-items relevant to a metric based on the input group-by-items."""
 
-    def __init__(  # noqa: D
+    def __init__(
         self,
         metric_reference: MetricReference,
         metric_input_location: Optional[InputMetricDefinitionLocation],
@@ -70,11 +70,11 @@ class MetricGroupByItemResolutionNode(GroupByItemResolutionNode):
         )
 
     @property
-    def metric_reference(self) -> MetricReference:  # noqa: D
+    def metric_reference(self) -> MetricReference:  # noqa: D102
         return self._metric_reference
 
     @property
-    def metric_input_location(self) -> Optional[InputMetricDefinitionLocation]:  # noqa: D
+    def metric_input_location(self) -> Optional[InputMetricDefinitionLocation]:  # noqa: D102
         return self._metric_input_location
 
     @property

--- a/metricflow/query/group_by_item/resolution_dag/resolution_nodes/no_metrics_query_source_node.py
+++ b/metricflow/query/group_by_item/resolution_dag/resolution_nodes/no_metrics_query_source_node.py
@@ -18,7 +18,7 @@ from metricflow.visitor import VisitorOutputT
 class NoMetricsGroupByItemSourceNode(GroupByItemResolutionNode):
     """Outputs group-by-items that can be queried without any metrics."""
 
-    def __init__(self) -> None:  # noqa: D
+    def __init__(self) -> None:  # noqa: D107
         super().__init__()
 
     @override

--- a/metricflow/query/group_by_item/resolution_dag/resolution_nodes/query_resolution_node.py
+++ b/metricflow/query/group_by_item/resolution_dag/resolution_nodes/query_resolution_node.py
@@ -24,7 +24,7 @@ from metricflow.visitor import VisitorOutputT
 class QueryGroupByItemResolutionNode(GroupByItemResolutionNode):
     """Output the group-by-items relevant to the query and based on the inputs."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         parent_nodes: Sequence[Union[MetricGroupByItemResolutionNode, NoMetricsGroupByItemSourceNode]],
         metrics_in_query: Sequence[MetricReference],
@@ -85,7 +85,7 @@ class QueryGroupByItemResolutionNode(GroupByItemResolutionNode):
         return properties
 
     @property
-    def where_filter_intersection(self) -> WhereFilterIntersection:  # noqa: D
+    def where_filter_intersection(self) -> WhereFilterIntersection:  # noqa: D102
         return self._where_filter_intersection
 
     @property

--- a/metricflow/query/group_by_item/resolution_path.py
+++ b/metricflow/query/group_by_item/resolution_path.py
@@ -17,7 +17,7 @@ class MetricFlowQueryResolutionPath(PathPrefixable):
     resolution_path_nodes: Tuple[GroupByItemResolutionNode, ...]
 
     @staticmethod
-    def empty_instance() -> MetricFlowQueryResolutionPath:  # noqa: D
+    def empty_instance() -> MetricFlowQueryResolutionPath:  # noqa: D102
         return MetricFlowQueryResolutionPath(
             resolution_path_nodes=(),
         )
@@ -28,7 +28,7 @@ class MetricFlowQueryResolutionPath(PathPrefixable):
         return self.resolution_path_nodes[-1]
 
     @property
-    def ui_description(self) -> str:  # noqa: D
+    def ui_description(self) -> str:  # noqa: D102
         if len(self.resolution_path_nodes) == 0:
             return "[Empty Path]"
         descriptions = tuple(f"[Resolve {path_node.ui_description}]" for path_node in self.resolution_path_nodes)

--- a/metricflow/query/issues/filter_spec_resolver/invalid_where.py
+++ b/metricflow/query/issues/filter_spec_resolver/invalid_where.py
@@ -23,7 +23,7 @@ class WhereFilterParsingIssue(MetricFlowQueryResolutionIssue):
     parse_exception: Exception
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         where_filter: WhereFilter,
         parse_exception: Exception,
         query_resolution_path: MetricFlowQueryResolutionPath,

--- a/metricflow/query/issues/group_by_item_resolver/ambiguous_group_by_item.py
+++ b/metricflow/query/issues/group_by_item_resolver/ambiguous_group_by_item.py
@@ -24,7 +24,7 @@ class AmbiguousGroupByItemIssue(MetricFlowQueryResolutionIssue):
     candidate_set: GroupByItemCandidateSet
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         candidate_set: GroupByItemCandidateSet,
         query_resolution_path: MetricFlowQueryResolutionPath,
     ) -> AmbiguousGroupByItemIssue:

--- a/metricflow/query/issues/group_by_item_resolver/invalid_use_of_date_part.py
+++ b/metricflow/query/issues/group_by_item_resolver/invalid_use_of_date_part.py
@@ -22,7 +22,7 @@ class MetricExcludesDatePartIssue(MetricFlowQueryResolutionIssue):
     candidate_specs: Tuple[LinkableInstanceSpec, ...]
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         parent_issues: Sequence[MetricFlowQueryResolutionIssue],
         query_resolution_path: MetricFlowQueryResolutionPath,
         candidate_specs: Sequence[LinkableInstanceSpec],

--- a/metricflow/query/issues/group_by_item_resolver/multiple_join_paths.py
+++ b/metricflow/query/issues/group_by_item_resolver/multiple_join_paths.py
@@ -24,7 +24,7 @@ class MultipleMatchIssue(MetricFlowQueryResolutionIssue):
     candidate_set: GroupByItemCandidateSet
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         query_resolution_path: MetricFlowQueryResolutionPath,
         candidate_set: GroupByItemCandidateSet,
         parent_issues: Sequence[MetricFlowQueryResolutionIssue],

--- a/metricflow/query/issues/group_by_item_resolver/no_common_items.py
+++ b/metricflow/query/issues/group_by_item_resolver/no_common_items.py
@@ -37,7 +37,7 @@ class NoCommonItemsInParents(MetricFlowQueryResolutionIssue):
     parent_candidate_sets: Tuple[GroupByItemCandidateSet, ...]
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         query_resolution_path: MetricFlowQueryResolutionPath,
         parent_node_to_candidate_set: Dict[GroupByItemResolutionNode, GroupByItemCandidateSet],
         parent_issues: Sequence[MetricFlowQueryResolutionIssue],

--- a/metricflow/query/issues/group_by_item_resolver/no_matching_items_for_measure.py
+++ b/metricflow/query/issues/group_by_item_resolver/no_matching_items_for_measure.py
@@ -28,7 +28,7 @@ class NoMatchingItemsForMeasure(MetricFlowQueryResolutionIssue):
     suggestions: Tuple[str, ...]
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         parent_issues: Sequence[MetricFlowQueryResolutionIssue],
         query_resolution_path: MetricFlowQueryResolutionPath,
         input_suggestions: Sequence[str],

--- a/metricflow/query/issues/group_by_item_resolver/no_matching_items_for_no_metrics_query.py
+++ b/metricflow/query/issues/group_by_item_resolver/no_matching_items_for_no_metrics_query.py
@@ -18,7 +18,7 @@ class NoMatchingItemsForNoMetricsQuery(MetricFlowQueryResolutionIssue):
     """Describes an issue with the query where there are no matching items for a no-metrics / distinct values query."""
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         parent_issues: Sequence[MetricFlowQueryResolutionIssue],
         query_resolution_path: MetricFlowQueryResolutionPath,
     ) -> NoMatchingItemsForNoMetricsQuery:

--- a/metricflow/query/issues/group_by_item_resolver/no_parent_candidates.py
+++ b/metricflow/query/issues/group_by_item_resolver/no_parent_candidates.py
@@ -23,7 +23,7 @@ class NoParentCandidates(MetricFlowQueryResolutionIssue):
     """
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         query_resolution_path: MetricFlowQueryResolutionPath,
     ) -> NoParentCandidates:
         return NoParentCandidates(

--- a/metricflow/query/issues/issues_base.py
+++ b/metricflow/query/issues/issues_base.py
@@ -55,7 +55,7 @@ class MetricFlowQueryResolutionIssueSet(Mergeable, PathPrefixable, Sized):
     issues: Tuple[MetricFlowQueryResolutionIssue, ...] = ()
 
     @override
-    def merge(self, other: MetricFlowQueryResolutionIssueSet) -> MetricFlowQueryResolutionIssueSet:  # noqa: D
+    def merge(self, other: MetricFlowQueryResolutionIssueSet) -> MetricFlowQueryResolutionIssueSet:
         return MetricFlowQueryResolutionIssueSet(issues=tuple(self.issues) + tuple(other.issues))
 
     @override
@@ -64,11 +64,11 @@ class MetricFlowQueryResolutionIssueSet(Mergeable, PathPrefixable, Sized):
         return MetricFlowQueryResolutionIssueSet()
 
     @property
-    def errors(self) -> Sequence[MetricFlowQueryResolutionIssue]:  # noqa: D
+    def errors(self) -> Sequence[MetricFlowQueryResolutionIssue]:  # noqa: D102
         return tuple(issue for issue in self.issues if issue.issue_type is MetricFlowQueryIssueType.ERROR)
 
     @property
-    def has_errors(self) -> bool:  # noqa: D
+    def has_errors(self) -> bool:  # noqa: D102
         return len(self.errors) > 0
 
     def add_issue(self, issue: MetricFlowQueryResolutionIssue) -> MetricFlowQueryResolutionIssueSet:
@@ -81,7 +81,9 @@ class MetricFlowQueryResolutionIssueSet(Mergeable, PathPrefixable, Sized):
         return MetricFlowQueryResolutionIssueSet(issues=(issue,))
 
     @staticmethod
-    def from_issues(issues: Sequence[MetricFlowQueryResolutionIssue]) -> MetricFlowQueryResolutionIssueSet:  # noqa: D
+    def from_issues(  # noqa: D102
+        issues: Sequence[MetricFlowQueryResolutionIssue],
+    ) -> MetricFlowQueryResolutionIssueSet:  # noqa: D102
         return MetricFlowQueryResolutionIssueSet(issues=tuple(issues))
 
     @override
@@ -91,7 +93,7 @@ class MetricFlowQueryResolutionIssueSet(Mergeable, PathPrefixable, Sized):
         )
 
     @property
-    def has_issues(self) -> bool:  # noqa: D
+    def has_issues(self) -> bool:  # noqa: D102
         return len(self.issues) > 0
 
     @override

--- a/metricflow/query/issues/parsing/cumulative_metric_requires_metric_time.py
+++ b/metricflow/query/issues/parsing/cumulative_metric_requires_metric_time.py
@@ -38,7 +38,7 @@ class CumulativeMetricRequiresMetricTimeIssue(MetricFlowQueryResolutionIssue):
         )
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         metric_reference: MetricReference, query_resolution_path: MetricFlowQueryResolutionPath
     ) -> CumulativeMetricRequiresMetricTimeIssue:
         return CumulativeMetricRequiresMetricTimeIssue(

--- a/metricflow/query/issues/parsing/duplicate_metric.py
+++ b/metricflow/query/issues/parsing/duplicate_metric.py
@@ -21,7 +21,7 @@ class DuplicateMetricIssue(MetricFlowQueryResolutionIssue):
     duplicate_metric_references: Tuple[MetricReference, ...]
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         duplicate_metric_references: Sequence[MetricReference],
         query_resolution_path: MetricFlowQueryResolutionPath,
     ) -> DuplicateMetricIssue:

--- a/metricflow/query/issues/parsing/invalid_limit.py
+++ b/metricflow/query/issues/parsing/invalid_limit.py
@@ -19,9 +19,9 @@ class InvalidLimitIssue(MetricFlowQueryResolutionIssue):
     limit: int
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         limit: int, query_resolution_path: MetricFlowQueryResolutionPath
-    ) -> InvalidLimitIssue:
+    ) -> InvalidLimitIssue:  # noqa: D102
         return InvalidLimitIssue(
             issue_type=MetricFlowQueryIssueType.ERROR,
             parent_issues=(),

--- a/metricflow/query/issues/parsing/invalid_metric.py
+++ b/metricflow/query/issues/parsing/invalid_metric.py
@@ -22,7 +22,7 @@ class InvalidMetricIssue(MetricFlowQueryResolutionIssue):
     metric_suggestions: Tuple[str, ...]
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         metric_suggestions: Sequence[str],
         query_resolution_path: MetricFlowQueryResolutionPath,
     ) -> InvalidMetricIssue:

--- a/metricflow/query/issues/parsing/invalid_min_max_only.py
+++ b/metricflow/query/issues/parsing/invalid_min_max_only.py
@@ -19,7 +19,7 @@ class InvalidMinMaxOnlyIssue(MetricFlowQueryResolutionIssue):
     min_max_only: bool
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         min_max_only: bool, query_resolution_path: MetricFlowQueryResolutionPath
     ) -> InvalidMinMaxOnlyIssue:
         return InvalidMinMaxOnlyIssue(

--- a/metricflow/query/issues/parsing/invalid_order.py
+++ b/metricflow/query/issues/parsing/invalid_order.py
@@ -22,7 +22,7 @@ class InvalidOrderByItemIssue(MetricFlowQueryResolutionIssue):
     order_by_item_input: ResolverInputForOrderByItem
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         order_by_item_input: ResolverInputForOrderByItem,
         query_resolution_path: MetricFlowQueryResolutionPath,
     ) -> InvalidOrderByItemIssue:

--- a/metricflow/query/issues/parsing/no_metric_or_group_by.py
+++ b/metricflow/query/issues/parsing/no_metric_or_group_by.py
@@ -20,7 +20,7 @@ class NoMetricOrGroupByIssue(MetricFlowQueryResolutionIssue):
     resolver_input_for_query: ResolverInputForQuery
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         resolver_input_for_query: ResolverInputForQuery, query_resolution_path: MetricFlowQueryResolutionPath
     ) -> NoMetricOrGroupByIssue:
         return NoMetricOrGroupByIssue(

--- a/metricflow/query/issues/parsing/offset_metric_requires_metric_time.py
+++ b/metricflow/query/issues/parsing/offset_metric_requires_metric_time.py
@@ -45,7 +45,7 @@ class OffsetMetricRequiresMetricTimeIssue(MetricFlowQueryResolutionIssue):
         )
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         metric_reference: MetricReference,
         input_metrics: Sequence[MetricInput],
         query_resolution_path: MetricFlowQueryResolutionPath,

--- a/metricflow/query/issues/parsing/string_input_parsing_issue.py
+++ b/metricflow/query/issues/parsing/string_input_parsing_issue.py
@@ -19,7 +19,7 @@ class StringInputParsingIssue(MetricFlowQueryResolutionIssue):
     input_str: str
 
     @staticmethod
-    def from_parameters(input_str: str) -> StringInputParsingIssue:  # noqa: D
+    def from_parameters(input_str: str) -> StringInputParsingIssue:  # noqa: D102
         return StringInputParsingIssue(
             issue_type=MetricFlowQueryIssueType.ERROR,
             parent_issues=(),

--- a/metricflow/query/query_parser.py
+++ b/metricflow/query/query_parser.py
@@ -79,7 +79,7 @@ class MetricFlowQueryParser:
     TODO: Add fuzzy match results.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         semantic_manifest_lookup: SemanticManifestLookup,
         where_filter_pattern_factory: WhereFilterPatternFactory = DefaultWhereFilterPatternFactory(),

--- a/metricflow/query/query_resolution.py
+++ b/metricflow/query/query_resolution.py
@@ -32,7 +32,7 @@ class InputToIssueSetMapping(Mergeable, Sized):
     items: Tuple[InputToIssueSetMappingItem, ...]
 
     @property
-    def has_issues(self) -> bool:  # noqa: D
+    def has_issues(self) -> bool:  # noqa: D102
         return any(item.issue_set.has_issues for item in self.items)
 
     @property
@@ -52,7 +52,7 @@ class InputToIssueSetMapping(Mergeable, Sized):
         )
 
     @staticmethod
-    def from_one_item(  # noqa: D
+    def from_one_item(  # noqa: D102
         resolver_input: MetricFlowQueryResolverInput, issue_set: MetricFlowQueryResolutionIssueSet
     ) -> InputToIssueSetMapping:
         return InputToIssueSetMapping(
@@ -92,5 +92,5 @@ class MetricFlowQueryResolution:
         return self.query_spec
 
     @property
-    def has_errors(self) -> bool:  # noqa: D
+    def has_errors(self) -> bool:  # noqa: D102
         return self.input_to_issue_set.has_issues or self.filter_spec_lookup.has_errors

--- a/metricflow/query/query_resolver.py
+++ b/metricflow/query/query_resolver.py
@@ -111,7 +111,7 @@ class ResolveMetricOrGroupByItemsResult:
 class MetricFlowQueryResolver:
     """Resolves inputs to a query (e.g. metrics, group by items into concrete specs."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         manifest_lookup: SemanticManifestLookup,
         where_filter_pattern_factory: WhereFilterPatternFactory,

--- a/metricflow/query/similarity.py
+++ b/metricflow/query/similarity.py
@@ -8,7 +8,7 @@ import rapidfuzz.process
 
 
 @dataclass(frozen=True)
-class ScoredItem:  # noqa: D
+class ScoredItem:  # noqa: D101
     item_str: str
     # fuzz scores from 0..100, and the higher the score, the better the match.
     score: float

--- a/metricflow/query/suggestion_generator.py
+++ b/metricflow/query/suggestion_generator.py
@@ -25,7 +25,7 @@ class QueryItemSuggestionGenerator:
     # grains. Some additional thought is needed to tweak this as the base grain may not be the best suggestion.
     GROUP_BY_ITEM_CANDIDATE_FILTERS: Tuple[SpecPattern, ...] = (BaseTimeGrainPattern(), NoneDatePartPattern())
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self, input_naming_scheme: QueryItemNamingScheme, input_str: str, candidate_filters: Sequence[SpecPattern]
     ) -> None:
         self._input_naming_scheme = input_naming_scheme

--- a/metricflow/query/validation_rules/base_validation_rule.py
+++ b/metricflow/query/validation_rules/base_validation_rule.py
@@ -15,7 +15,7 @@ from metricflow.query.resolver_inputs.query_resolver_inputs import ResolverInput
 class PostResolutionQueryValidationRule(ABC):
     """A validation rule that runs after all query inputs have been resolved to specs."""
 
-    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
+    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
         self._manifest_lookup = manifest_lookup
 
     def _get_metric(self, metric_reference: MetricReference) -> Metric:

--- a/metricflow/query/validation_rules/duplicate_metric.py
+++ b/metricflow/query/validation_rules/duplicate_metric.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class DuplicateMetricValidationRule(PostResolutionQueryValidationRule):
     """Validates that a query does not include the same metric multiple times."""
 
-    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
+    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
         super().__init__(manifest_lookup=manifest_lookup)
 
     @override

--- a/metricflow/query/validation_rules/metric_time_requirements.py
+++ b/metricflow/query/validation_rules/metric_time_requirements.py
@@ -30,7 +30,7 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
     * Derived metrics with an offset time.g
     """
 
-    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
+    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
         super().__init__(manifest_lookup=manifest_lookup)
 
         self._metric_time_specs = tuple(

--- a/metricflow/query/validation_rules/query_validator.py
+++ b/metricflow/query/validation_rules/query_validator.py
@@ -33,7 +33,7 @@ from metricflow.query.validation_rules.metric_time_requirements import MetricTim
 class PostResolutionQueryValidator:
     """Runs query validation rules after query resolution is complete."""
 
-    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D
+    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
         self._manifest_lookup = manifest_lookup
         self._validation_rules = (
             MetricTimeQueryValidationRule(self._manifest_lookup),
@@ -55,7 +55,7 @@ class PostResolutionQueryValidator:
 class _PostResolutionQueryValidationVisitor(GroupByItemResolutionNodeVisitor[MetricFlowQueryResolutionIssueSet]):
     """Visitor that runs the validation rule when it visits a metric."""
 
-    def __init__(  # noqa: D
+    def __init__(
         self,
         resolver_input_for_query: ResolverInputForQuery,
         validation_rules: Sequence[PostResolutionQueryValidationRule],

--- a/metricflow/specs/column_assoc.py
+++ b/metricflow/specs/column_assoc.py
@@ -22,10 +22,10 @@ class SingleColumnCorrelationKey(ColumnCorrelationKey, SerializableDataclass):
     # Pydantic throws an error during serialization if a dataclass has no fields.
     PYDANTIC_BUG_WORKAROUND: bool = True
 
-    def __eq__(self, other: Any) -> bool:  # type: ignore[misc] # noqa: D
+    def __eq__(self, other: Any) -> bool:  # type: ignore[misc]  # noqa: D105
         return isinstance(other, SingleColumnCorrelationKey)
 
-    def __hash__(self) -> int:  # noqa: D
+    def __hash__(self) -> int:  # noqa: D105
         return hash(self.__class__.__name__)
 
 
@@ -40,7 +40,7 @@ class ColumnAssociation(SerializableDataclass):
     single_column_correlation_key: SingleColumnCorrelationKey
 
     @property
-    def column_correlation_key(self) -> ColumnCorrelationKey:  # noqa: D
+    def column_correlation_key(self) -> ColumnCorrelationKey:  # noqa: D102
         return self.single_column_correlation_key
 
 
@@ -62,5 +62,5 @@ class ColumnAssociationResolver(ABC):
     """
 
     @abstractmethod
-    def resolve_spec(self, spec: InstanceSpec) -> ColumnAssociation:  # noqa: D
+    def resolve_spec(self, spec: InstanceSpec) -> ColumnAssociation:  # noqa: D102
         raise NotImplementedError

--- a/metricflow/specs/patterns/entity_link_pattern.py
+++ b/metricflow/specs/patterns/entity_link_pattern.py
@@ -52,7 +52,7 @@ class EntityLinkPatternParameterSet:
     date_part: Optional[DatePart] = None
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         fields_to_compare: Sequence[ParameterSetField],
         element_name: Optional[str] = None,
         entity_links: Optional[Sequence[EntityReference]] = None,

--- a/metricflow/specs/patterns/match_list_pattern.py
+++ b/metricflow/specs/patterns/match_list_pattern.py
@@ -14,7 +14,7 @@ class MatchListSpecPattern(SpecPattern):
     This is useful for filtering possible group-by-items to ones valid for a query.
     """
 
-    def __init__(self, listed_specs: Sequence[InstanceSpec]) -> None:  # noqa: D
+    def __init__(self, listed_specs: Sequence[InstanceSpec]) -> None:  # noqa: D107
         self._listed_specs = set(listed_specs)
 
     @override

--- a/metricflow/specs/patterns/typed_patterns.py
+++ b/metricflow/specs/patterns/typed_patterns.py
@@ -32,7 +32,7 @@ class DimensionPattern(EntityLinkPattern):
         return super().match(filtered_specs)
 
     @staticmethod
-    def from_call_parameter_set(  # noqa: D
+    def from_call_parameter_set(  # noqa: D102
         dimension_call_parameter_set: DimensionCallParameterSet,
     ) -> DimensionPattern:
         return DimensionPattern(
@@ -101,7 +101,7 @@ class EntityPattern(EntityLinkPattern):
         return super().match(spec_set.entity_specs)
 
     @staticmethod
-    def from_call_parameter_set(entity_call_parameter_set: EntityCallParameterSet) -> EntityPattern:  # noqa: D
+    def from_call_parameter_set(entity_call_parameter_set: EntityCallParameterSet) -> EntityPattern:  # noqa: D102
         return EntityPattern(
             parameter_set=EntityLinkPatternParameterSet.from_parameters(
                 fields_to_compare=(

--- a/metricflow/specs/query_param_implementations.py
+++ b/metricflow/specs/query_param_implementations.py
@@ -41,13 +41,13 @@ class TimeDimensionParameter(ProtocolHint[TimeDimensionQueryParameter]):
     grain: Optional[TimeGranularity] = None
     date_part: Optional[DatePart] = None
 
-    def __post_init__(self) -> None:  # noqa: D
+    def __post_init__(self) -> None:  # noqa: D105
         parsed_name = StructuredLinkableSpecName.from_name(self.name)
         if parsed_name.time_granularity:
             raise ValueError("Must use object syntax for `grain` parameter if `date_part` is requested.")
 
     @property
-    def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D
+    def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D102
         fields_to_compare = [
             ParameterSetField.ELEMENT_NAME,
             ParameterSetField.ENTITY_LINKS,
@@ -87,7 +87,7 @@ class DimensionOrEntityParameter(ProtocolHint[DimensionOrEntityQueryParameter]):
         return self
 
     @property
-    def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D
+    def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D102
         name_structure = StructuredLinkableSpecName.from_name(self.name.lower())
 
         return ResolverInputForGroupByItem(
@@ -116,7 +116,7 @@ class MetricParameter:
     name: str
 
     @property
-    def query_resolver_input(self) -> ResolverInputForMetric:  # noqa: D
+    def query_resolver_input(self) -> ResolverInputForMetric:  # noqa: D102
         naming_scheme = MetricNamingScheme()
         return ResolverInputForMetric(
             input_obj=self,
@@ -133,7 +133,7 @@ class OrderByParameter:
     descending: bool = False
 
     @property
-    def query_resolver_input(self) -> ResolverInputForOrderByItem:  # noqa: D
+    def query_resolver_input(self) -> ResolverInputForOrderByItem:  # noqa: D102
         return ResolverInputForOrderByItem(
             input_obj=self,
             possible_inputs=(self.order_by.query_resolver_input,),

--- a/metricflow/specs/rendered_spec_tracker.py
+++ b/metricflow/specs/rendered_spec_tracker.py
@@ -11,7 +11,7 @@ class RenderedSpecTracker:
     This is useful for constructing a WhereFilterSpec as it includes a list of specs required by the filter.
     """
 
-    def __init__(self) -> None:  # noqa: D
+    def __init__(self) -> None:  # noqa: D107
         self._rendered_specs: List[LinkableInstanceSpec] = []
 
     def record_rendered_spec(self, spec: LinkableInstanceSpec) -> None:

--- a/metricflow/specs/spec_set_transforms.py
+++ b/metricflow/specs/spec_set_transforms.py
@@ -8,7 +8,7 @@ from metricflow.specs.specs import InstanceSpecSet, InstanceSpecSetTransform
 class ToElementNameSet(InstanceSpecSetTransform[Set[str]]):
     """Gets all element names for all specs in the set."""
 
-    def transform(self, spec_set: InstanceSpecSet) -> Set[str]:  # noqa: D
+    def transform(self, spec_set: InstanceSpecSet) -> Set[str]:  # noqa: D102
         return (
             {x.element_name for x in spec_set.metric_specs}
             .union({x.element_name for x in spec_set.measure_specs})

--- a/metricflow/specs/specs.py
+++ b/metricflow/specs/specs.py
@@ -62,27 +62,27 @@ class InstanceSpecVisitor(Generic[VisitorOutputT], ABC):
     """Visitor for the InstanceSpec classes."""
 
     @abstractmethod
-    def visit_measure_spec(self, measure_spec: MeasureSpec) -> VisitorOutputT:  # noqa: D
+    def visit_measure_spec(self, measure_spec: MeasureSpec) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_dimension_spec(self, dimension_spec: DimensionSpec) -> VisitorOutputT:  # noqa: D
+    def visit_dimension_spec(self, dimension_spec: DimensionSpec) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_time_dimension_spec(self, time_dimension_spec: TimeDimensionSpec) -> VisitorOutputT:  # noqa: D
+    def visit_time_dimension_spec(self, time_dimension_spec: TimeDimensionSpec) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_entity_spec(self, entity_spec: EntitySpec) -> VisitorOutputT:  # noqa: D
+    def visit_entity_spec(self, entity_spec: EntitySpec) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_metric_spec(self, metric_spec: MetricSpec) -> VisitorOutputT:  # noqa: D
+    def visit_metric_spec(self, metric_spec: MetricSpec) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_metadata_spec(self, metadata_spec: MetadataSpec) -> VisitorOutputT:  # noqa: D
+    def visit_metadata_spec(self, metadata_spec: MetadataSpec) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
 
@@ -134,14 +134,14 @@ class MetadataSpec(InstanceSpec):
     agg_type: Optional[AggregationType] = None
 
     @property
-    def qualified_name(self) -> str:  # noqa: D
+    def qualified_name(self) -> str:  # noqa: D102
         return f"{self.element_name}{DUNDER}{self.agg_type.value}" if self.agg_type else self.element_name
 
     @staticmethod
-    def from_name(name: str, agg_type: Optional[AggregationType] = None) -> MetadataSpec:  # noqa: D
+    def from_name(name: str, agg_type: Optional[AggregationType] = None) -> MetadataSpec:  # noqa: D102
         return MetadataSpec(element_name=name, agg_type=agg_type)
 
-    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_metadata_spec(self)
 
     @property
@@ -168,7 +168,7 @@ class LinkableInstanceSpec(InstanceSpec, ABC):
         raise NotImplementedError()
 
     @property
-    def without_entity_links(self: SelfTypeT) -> SelfTypeT:  # noqa: D
+    def without_entity_links(self: SelfTypeT) -> SelfTypeT:
         """e.g. user_id__device_id__platform -> platform."""
         raise NotImplementedError()
 
@@ -189,14 +189,14 @@ class LinkableInstanceSpec(InstanceSpec, ABC):
 
 
 @dataclass(frozen=True)
-class EntitySpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D
+class EntitySpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D101
     @property
-    def without_first_entity_link(self) -> EntitySpec:  # noqa: D
+    def without_first_entity_link(self) -> EntitySpec:  # noqa: D102
         assert len(self.entity_links) > 0, f"Spec does not have any entity links: {self}"
         return EntitySpec(element_name=self.element_name, entity_links=self.entity_links[1:])
 
     @property
-    def without_entity_links(self) -> EntitySpec:  # noqa: D
+    def without_entity_links(self) -> EntitySpec:  # noqa: D102
         return LinklessEntitySpec.from_element_name(self.element_name)
 
     @property
@@ -208,23 +208,23 @@ class EntitySpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D
         return (EntityReference(element_name=self.element_name),) + self.entity_links
 
     @staticmethod
-    def from_name(name: str) -> EntitySpec:  # noqa: D
+    def from_name(name: str) -> EntitySpec:  # noqa: D102
         structured_name = StructuredLinkableSpecName.from_name(name)
         return EntitySpec(
             entity_links=tuple(EntityReference(idl) for idl in structured_name.entity_link_names),
             element_name=structured_name.element_name,
         )
 
-    def __eq__(self, other: Any) -> bool:  # type: ignore[misc] # noqa: D
+    def __eq__(self, other: Any) -> bool:  # type: ignore[misc]  # noqa: D105
         if not isinstance(other, EntitySpec):
             return False
         return self.element_name == other.element_name and self.entity_links == other.entity_links
 
-    def __hash__(self) -> int:  # noqa: D
+    def __hash__(self) -> int:  # noqa: D105
         return hash((self.element_name, self.entity_links))
 
     @property
-    def reference(self) -> EntityReference:  # noqa: D
+    def reference(self) -> EntityReference:  # noqa: D102
         return EntityReference(element_name=self.element_name)
 
     @property
@@ -232,7 +232,7 @@ class EntitySpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D
     def as_spec_set(self) -> InstanceSpecSet:
         return InstanceSpecSet(entity_specs=(self,))
 
-    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_entity_spec(self)
 
 
@@ -241,42 +241,42 @@ class LinklessEntitySpec(EntitySpec, SerializableDataclass):
     """Similar to EntitySpec, but requires that it doesn't have entity links."""
 
     @staticmethod
-    def from_element_name(element_name: str) -> LinklessEntitySpec:  # noqa: D
+    def from_element_name(element_name: str) -> LinklessEntitySpec:  # noqa: D102
         return LinklessEntitySpec(element_name=element_name, entity_links=())
 
-    def __post_init__(self) -> None:  # noqa: D
+    def __post_init__(self) -> None:  # noqa: D105
         if len(self.entity_links) > 0:
             raise RuntimeError(f"{self.__class__.__name__} shouldn't have entity links. Got: {self}")
 
-    def __eq__(self, other: Any) -> bool:  # type: ignore[misc] # noqa: D
+    def __eq__(self, other: Any) -> bool:  # type: ignore[misc]  # noqa: D105
         if not isinstance(other, EntitySpec):
             return False
         return self.element_name == other.element_name and self.entity_links == other.entity_links
 
-    def __hash__(self) -> int:  # noqa: D
+    def __hash__(self) -> int:  # noqa: D105
         return hash((self.element_name, self.entity_links))
 
     @staticmethod
-    def from_reference(entity_reference: EntityReference) -> LinklessEntitySpec:  # noqa: D
+    def from_reference(entity_reference: EntityReference) -> LinklessEntitySpec:  # noqa: D102
         return LinklessEntitySpec(element_name=entity_reference.element_name, entity_links=())
 
 
 @dataclass(frozen=True)
-class DimensionSpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D
+class DimensionSpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D101
     element_name: str
     entity_links: Tuple[EntityReference, ...]
 
     @property
-    def without_first_entity_link(self) -> DimensionSpec:  # noqa: D
+    def without_first_entity_link(self) -> DimensionSpec:  # noqa: D102
         assert len(self.entity_links) > 0, f"Spec does not have any entity links: {self}"
         return DimensionSpec(element_name=self.element_name, entity_links=self.entity_links[1:])
 
     @property
-    def without_entity_links(self) -> DimensionSpec:  # noqa: D
+    def without_entity_links(self) -> DimensionSpec:  # noqa: D102
         return DimensionSpec(element_name=self.element_name, entity_links=())
 
     @staticmethod
-    def from_linkable(spec: LinkableInstanceSpec) -> DimensionSpec:  # noqa: D
+    def from_linkable(spec: LinkableInstanceSpec) -> DimensionSpec:  # noqa: D102
         return DimensionSpec(element_name=spec.element_name, entity_links=spec.entity_links)
 
     @staticmethod
@@ -289,7 +289,7 @@ class DimensionSpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D
         )
 
     @property
-    def reference(self) -> DimensionReference:  # noqa: D
+    def reference(self) -> DimensionReference:  # noqa: D102
         return DimensionReference(element_name=self.element_name)
 
     @property
@@ -297,7 +297,7 @@ class DimensionSpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D
     def as_spec_set(self) -> InstanceSpecSet:
         return InstanceSpecSet(dimension_specs=(self,))
 
-    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_dimension_spec(self)
 
 
@@ -344,7 +344,7 @@ class TimeDimensionSpecComparisonKey:
         self._spec_field_values_for_comparison = tuple(spec_field_values_for_comparison)
 
     @property
-    def source_spec(self) -> TimeDimensionSpec:  # noqa: D
+    def source_spec(self) -> TimeDimensionSpec:  # noqa: D102
         return self._source_spec
 
     @override
@@ -366,7 +366,7 @@ DEFAULT_TIME_GRANULARITY = TimeGranularity.DAY
 
 
 @dataclass(frozen=True)
-class TimeDimensionSpec(DimensionSpec):  # noqa: D
+class TimeDimensionSpec(DimensionSpec):  # noqa: D101
     time_granularity: TimeGranularity = DEFAULT_TIME_GRANULARITY
     date_part: Optional[DatePart] = None
 
@@ -374,7 +374,7 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D
     aggregation_state: Optional[AggregationState] = None
 
     @property
-    def without_first_entity_link(self) -> TimeDimensionSpec:  # noqa: D
+    def without_first_entity_link(self) -> TimeDimensionSpec:  # noqa: D102
         assert len(self.entity_links) > 0, f"Spec does not have any entity links: {self}"
         return TimeDimensionSpec(
             element_name=self.element_name,
@@ -384,11 +384,11 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D
         )
 
     @property
-    def without_entity_links(self) -> TimeDimensionSpec:  # noqa: D
+    def without_entity_links(self) -> TimeDimensionSpec:  # noqa: D102
         return TimeDimensionSpec.from_name(self.element_name)
 
     @staticmethod
-    def from_name(name: str) -> TimeDimensionSpec:  # noqa: D
+    def from_name(name: str) -> TimeDimensionSpec:  # noqa: D102
         structured_name = StructuredLinkableSpecName.from_name(name)
         return TimeDimensionSpec(
             entity_links=tuple(EntityReference(idl) for idl in structured_name.entity_link_names),
@@ -397,15 +397,15 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D
         )
 
     @property
-    def reference(self) -> TimeDimensionReference:  # noqa: D
+    def reference(self) -> TimeDimensionReference:  # noqa: D102
         return TimeDimensionReference(element_name=self.element_name)
 
     @property
-    def dimension_reference(self) -> DimensionReference:  # noqa: D
+    def dimension_reference(self) -> DimensionReference:  # noqa: D102
         return DimensionReference(element_name=self.element_name)
 
     @property
-    def qualified_name(self) -> str:  # noqa: D
+    def qualified_name(self) -> str:  # noqa: D102
         return StructuredLinkableSpecName(
             entity_link_names=tuple(x.element_name for x in self.entity_links),
             element_name=self.element_name,
@@ -423,10 +423,10 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D
     def as_spec_set(self) -> InstanceSpecSet:
         return InstanceSpecSet(time_dimension_specs=(self,))
 
-    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_time_dimension_spec(self)
 
-    def with_grain(self, time_granularity: TimeGranularity) -> TimeDimensionSpec:  # noqa: D
+    def with_grain(self, time_granularity: TimeGranularity) -> TimeDimensionSpec:  # noqa: D102
         return TimeDimensionSpec(
             element_name=self.element_name,
             entity_links=self.entity_links,
@@ -435,7 +435,7 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D
             aggregation_state=self.aggregation_state,
         )
 
-    def with_aggregation_state(self, aggregation_state: AggregationState) -> TimeDimensionSpec:  # noqa: D
+    def with_aggregation_state(self, aggregation_state: AggregationState) -> TimeDimensionSpec:  # noqa: D102
         return TimeDimensionSpec(
             element_name=self.element_name,
             entity_links=self.entity_links,
@@ -479,7 +479,7 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D
         return time_dimension_specs
 
     @property
-    def is_metric_time(self) -> bool:  # noqa: D
+    def is_metric_time(self) -> bool:  # noqa: D102
         return self.element_name == METRIC_TIME_ELEMENT_NAME
 
 
@@ -503,7 +503,7 @@ class NonAdditiveDimensionSpec(SerializableDataclass):
         return hash_items(values)
 
     @property
-    def linkable_specs(self) -> LinkableSpecSet:  # noqa: D
+    def linkable_specs(self) -> LinkableSpecSet:  # noqa: D102
         return LinkableSpecSet(
             dimension_specs=(),
             time_dimension_specs=(TimeDimensionSpec.from_name(self.name),),
@@ -512,14 +512,14 @@ class NonAdditiveDimensionSpec(SerializableDataclass):
             ),
         )
 
-    def __eq__(self, other: Any) -> bool:  # type: ignore[misc] # noqa: D
+    def __eq__(self, other: Any) -> bool:  # type: ignore[misc]  # noqa: D105
         if not isinstance(other, NonAdditiveDimensionSpec):
             return False
         return self.bucket_hash == other.bucket_hash
 
 
 @dataclass(frozen=True)
-class MeasureSpec(InstanceSpec):  # noqa: D
+class MeasureSpec(InstanceSpec):  # noqa: D101
     element_name: str
     non_additive_dimension_spec: Optional[NonAdditiveDimensionSpec] = None
     fill_nulls_with: Optional[int] = None
@@ -535,14 +535,14 @@ class MeasureSpec(InstanceSpec):  # noqa: D
         return MeasureSpec(element_name=reference.element_name)
 
     @property
-    def qualified_name(self) -> str:  # noqa: D
+    def qualified_name(self) -> str:  # noqa: D102
         return self.element_name
 
     @property
-    def reference(self) -> MeasureReference:  # noqa: D
+    def reference(self) -> MeasureReference:  # noqa: D102
         return MeasureReference(element_name=self.element_name)
 
-    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_measure_spec(self)
 
     @property
@@ -552,7 +552,7 @@ class MeasureSpec(InstanceSpec):  # noqa: D
 
 
 @dataclass(frozen=True)
-class MetricSpec(InstanceSpec):  # noqa: D
+class MetricSpec(InstanceSpec):  # noqa: D101
     # Time-over-time could go here
     element_name: str
     filter_specs: Tuple[WhereFilterSpec, ...] = ()
@@ -561,11 +561,11 @@ class MetricSpec(InstanceSpec):  # noqa: D
     offset_to_grain: Optional[TimeGranularity] = None
 
     @staticmethod
-    def from_element_name(element_name: str) -> MetricSpec:  # noqa: D
+    def from_element_name(element_name: str) -> MetricSpec:  # noqa: D102
         return MetricSpec(element_name=element_name)
 
     @property
-    def qualified_name(self) -> str:  # noqa: D
+    def qualified_name(self) -> str:  # noqa: D102
         return self.element_name
 
     @staticmethod
@@ -573,7 +573,7 @@ class MetricSpec(InstanceSpec):  # noqa: D
         """Initialize from a metric reference instance."""
         return MetricSpec(element_name=reference.element_name)
 
-    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_metric_spec(self)
 
     @property
@@ -587,7 +587,7 @@ class MetricSpec(InstanceSpec):  # noqa: D
         return MetricReference(element_name=self.element_name)
 
     @property
-    def has_time_offset(self) -> bool:  # noqa: D
+    def has_time_offset(self) -> bool:  # noqa: D102
         return bool(self.offset_window or self.offset_to_grain)
 
     def without_offset(self) -> MetricSpec:
@@ -638,13 +638,13 @@ class MetricInputMeasureSpec(SerializableDataclass):
 
 
 @dataclass(frozen=True)
-class OrderBySpec(SerializableDataclass):  # noqa: D
+class OrderBySpec(SerializableDataclass):  # noqa: D101
     instance_spec: InstanceSpec
     descending: bool
 
 
 @dataclass(frozen=True)
-class FilterSpec(SerializableDataclass):  # noqa: D
+class FilterSpec(SerializableDataclass):  # noqa: D101
     expr: str
     elements: Tuple[InstanceSpec, ...]
 
@@ -700,7 +700,7 @@ class LinkableSpecSet(Mergeable, SerializableDataclass):
         )
 
     @property
-    def as_tuple(self) -> Tuple[LinkableInstanceSpec, ...]:  # noqa: D
+    def as_tuple(self) -> Tuple[LinkableInstanceSpec, ...]:  # noqa: D102
         return tuple(itertools.chain(self.dimension_specs, self.time_dimension_specs, self.entity_specs))
 
     @override
@@ -716,7 +716,7 @@ class LinkableSpecSet(Mergeable, SerializableDataclass):
     def empty_instance(cls) -> LinkableSpecSet:
         return LinkableSpecSet()
 
-    def dedupe(self) -> LinkableSpecSet:  # noqa: D
+    def dedupe(self) -> LinkableSpecSet:  # noqa: D102
         # Use dictionaries to dedupe as it preserves insertion order.
 
         dimension_spec_dict: Dict[DimensionSpec, None] = {}
@@ -737,29 +737,29 @@ class LinkableSpecSet(Mergeable, SerializableDataclass):
             entity_specs=tuple(entity_spec_dict.keys()),
         )
 
-    def is_subset_of(self, other_set: LinkableSpecSet) -> bool:  # noqa: D
+    def is_subset_of(self, other_set: LinkableSpecSet) -> bool:  # noqa: D102
         return set(self.as_tuple).issubset(set(other_set.as_tuple))
 
     @property
-    def as_spec_set(self) -> InstanceSpecSet:  # noqa: D
+    def as_spec_set(self) -> InstanceSpecSet:  # noqa: D102
         return InstanceSpecSet(
             dimension_specs=self.dimension_specs,
             time_dimension_specs=self.time_dimension_specs,
             entity_specs=self.entity_specs,
         )
 
-    def difference(self, other: LinkableSpecSet) -> LinkableSpecSet:  # noqa: D
+    def difference(self, other: LinkableSpecSet) -> LinkableSpecSet:  # noqa: D102
         return LinkableSpecSet(
             dimension_specs=tuple(set(self.dimension_specs) - set(other.dimension_specs)),
             time_dimension_specs=tuple(set(self.time_dimension_specs) - set(other.time_dimension_specs)),
             entity_specs=tuple(set(self.entity_specs) - set(other.entity_specs)),
         )
 
-    def __len__(self) -> int:  # noqa: D
+    def __len__(self) -> int:  # noqa: D105
         return len(self.dimension_specs) + len(self.time_dimension_specs) + len(self.entity_specs)
 
     @staticmethod
-    def from_specs(specs: Sequence[LinkableInstanceSpec]) -> LinkableSpecSet:  # noqa: D
+    def from_specs(specs: Sequence[LinkableInstanceSpec]) -> LinkableSpecSet:  # noqa: D102
         instance_spec_set = InstanceSpecSet.from_specs(specs)
         return LinkableSpecSet(
             dimension_specs=instance_spec_set.dimension_specs,
@@ -784,7 +784,7 @@ class MetricFlowQuerySpec(SerializableDataclass):
     min_max_only: bool = False
 
     @property
-    def linkable_specs(self) -> LinkableSpecSet:  # noqa: D
+    def linkable_specs(self) -> LinkableSpecSet:  # noqa: D102
         return LinkableSpecSet(
             dimension_specs=self.dimension_specs,
             time_dimension_specs=self.time_dimension_specs,
@@ -813,7 +813,7 @@ class InstanceSpecSetTransform(Generic[TransformOutputT], ABC):
     """Function to use for transforming spec sets."""
 
     @abstractmethod
-    def transform(self, spec_set: InstanceSpecSet) -> TransformOutputT:  # noqa: D
+    def transform(self, spec_set: InstanceSpecSet) -> TransformOutputT:  # noqa: D102
         pass
 
 
@@ -888,7 +888,7 @@ class InstanceSpecSet(Mergeable, SerializableDataclass):
         return list(itertools.chain(self.dimension_specs, self.time_dimension_specs, self.entity_specs))
 
     @property
-    def all_specs(self) -> Sequence[InstanceSpec]:  # noqa: D
+    def all_specs(self) -> Sequence[InstanceSpec]:  # noqa: D102
         return tuple(
             itertools.chain(
                 self.measure_specs,
@@ -900,11 +900,13 @@ class InstanceSpecSet(Mergeable, SerializableDataclass):
             )
         )
 
-    def transform(self, transform_function: InstanceSpecSetTransform[TransformOutputT]) -> TransformOutputT:  # noqa: D
+    def transform(  # noqa: D102
+        self, transform_function: InstanceSpecSetTransform[TransformOutputT]
+    ) -> TransformOutputT:  # noqa: D102
         return transform_function.transform(self)
 
     @staticmethod
-    def from_specs(specs: Sequence[InstanceSpec]) -> InstanceSpecSet:  # noqa: D
+    def from_specs(specs: Sequence[InstanceSpec]) -> InstanceSpecSet:  # noqa: D102
         return InstanceSpecSet.merge_iterable(spec.as_spec_set for spec in specs)
 
 
@@ -919,7 +921,7 @@ class PartitionSpecSet(SerializableDataclass):
 logger = logging.getLogger(__name__)
 
 
-class WhereFilterResolutionException(Exception):  # noqa: D
+class WhereFilterResolutionException(Exception):  # noqa: D101
     pass
 
 
@@ -952,7 +954,7 @@ class WhereFilterSpec(Mergeable, SerializableDataclass):
     bind_parameters: SqlBindParameters
     linkable_spec_set: LinkableSpecSet
 
-    def merge(self, other: WhereFilterSpec) -> WhereFilterSpec:  # noqa: D
+    def merge(self, other: WhereFilterSpec) -> WhereFilterSpec:  # noqa: D102
         if self == WhereFilterSpec.empty_instance():
             return other
 

--- a/metricflow/specs/where_filter_transform.py
+++ b/metricflow/specs/where_filter_transform.py
@@ -20,14 +20,14 @@ from metricflow.sql.sql_bind_parameters import SqlBindParameters
 logger = logging.getLogger(__name__)
 
 
-class RenderSqlTemplateException(Exception):  # noqa: D
+class RenderSqlTemplateException(Exception):  # noqa: D101
     pass
 
 
 class WhereSpecFactory:
     """Renders the SQL template in the WhereFilter and converts it to a WhereFilterSpec."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         column_association_resolver: ColumnAssociationResolver,
         spec_resolution_lookup: FilterSpecResolutionLookUp,
@@ -35,7 +35,7 @@ class WhereSpecFactory:
         self._column_association_resolver = column_association_resolver
         self._spec_resolution_lookup = spec_resolution_lookup
 
-    def create_from_where_filter(  # noqa: D
+    def create_from_where_filter(  # noqa: D102
         self,
         filter_location: WhereFilterLocation,
         where_filter: WhereFilter,
@@ -45,7 +45,7 @@ class WhereSpecFactory:
             filter_intersection=PydanticWhereFilterIntersection(where_filters=[where_filter]),
         )[0]
 
-    def create_from_where_filter_intersection(  # noqa: D
+    def create_from_where_filter_intersection(  # noqa: D102
         self,
         filter_location: WhereFilterLocation,
         filter_intersection: Optional[WhereFilterIntersection],

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -111,7 +111,7 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=node.distinct,
         )
 
-    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         # Remove columns that are not needed from this SELECT statement because the parent SELECT statement doesn't
         # need them. However, keep columns that are in group bys because that changes the meaning of the query.
         # Similarly, if this node is a distinct select node, keep all columns as it may return a different result set.
@@ -191,15 +191,15 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=node.distinct,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:
         """This node is effectively a FROM statement inside a SELECT statement node, so pruning cannot apply."""
         return node
 
-    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:
         """Pruning cannot be done here since this is an arbitrary user-provided SQL query."""
         return node
 
-    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D102
         return SqlCreateTableAsNode(
             sql_table=node.sql_table,
             parent_node=node.parent_node.accept(self),
@@ -209,7 +209,7 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
 class SqlColumnPrunerOptimizer(SqlQueryPlanOptimizer):
     """Removes unnecessary columns in the SELECT clauses."""
 
-    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa: D
+    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa: D102
         # Can't prune columns without knowing the structure of the query.
         if not node.as_select_node:
             return node

--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -195,7 +195,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             and not node.where
         )
 
-    def _current_node_can_be_reduced(self, node: SqlSelectStatementNode) -> bool:  # noqa: D
+    def _current_node_can_be_reduced(self, node: SqlSelectStatementNode) -> bool:
         """Returns true if the given node can be reduced with the parent node.
 
         Reducing this node means eliminating the SELECT of this node and merging it with the parent SELECT. This
@@ -463,9 +463,9 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
                 SqlJoinDescription(
                     right_source=join_select_node.from_source,
                     right_source_alias=join_select_node.from_source_alias,
-                    on_condition=join_desc.on_condition.rewrite(column_replacements)
-                    if join_desc.on_condition
-                    else None,
+                    on_condition=(
+                        join_desc.on_condition.rewrite(column_replacements) if join_desc.on_condition else None
+                    ),
                     join_type=join_desc.join_type,
                 )
             )
@@ -482,9 +482,9 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
                 SqlJoinDescription(
                     right_source=x.right_source,
                     right_source_alias=x.right_source_alias,
-                    on_condition=x.on_condition.rewrite(column_replacements=column_replacements)
-                    if x.on_condition
-                    else None,
+                    on_condition=(
+                        x.on_condition.rewrite(column_replacements=column_replacements) if x.on_condition else None
+                    ),
                     join_type=x.join_type,
                 )
                 for x in new_join_descs
@@ -512,9 +512,9 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
                 SqlJoinDescription(
                     right_source=x.right_source,
                     right_source_alias=x.right_source_alias,
-                    on_condition=x.on_condition.rewrite(column_replacements=column_replacements)
-                    if x.on_condition
-                    else None,
+                    on_condition=(
+                        x.on_condition.rewrite(column_replacements=column_replacements) if x.on_condition else None
+                    ),
                     join_type=x.join_type,
                 )
                 for x in new_join_descs
@@ -533,7 +533,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             distinct=node.distinct,
         )
 
-    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         node_with_reduced_parents = self._reduce_parents(node)
 
         if len(node_with_reduced_parents.parent_nodes) > 1:
@@ -652,13 +652,13 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             distinct=parent_select_node.distinct,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
-    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
-    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D102
         return SqlCreateTableAsNode(
             sql_table=node.sql_table,
             parent_node=node.parent_node.accept(self),
@@ -678,7 +678,7 @@ class SqlGroupByRewritingVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
                 return select_column
         return None
 
-    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         new_group_bys = []
         for group_by in node.group_bys:
             matching_select_column = SqlGroupByRewritingVisitor._find_matching_select(
@@ -716,13 +716,13 @@ class SqlGroupByRewritingVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=node.distinct,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
-    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
-    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D102
         return SqlCreateTableAsNode(
             sql_table=node.sql_table,
             parent_node=node.parent_node.accept(self),
@@ -750,10 +750,10 @@ class SqlRewritingSubQueryReducer(SqlQueryPlanOptimizer):
     GROUP BY foo
     """
 
-    def __init__(self, use_column_alias_in_group_bys: bool = False) -> None:  # noqa: D
+    def __init__(self, use_column_alias_in_group_bys: bool = False) -> None:  # noqa: D107
         self._use_column_alias_in_group_bys = use_column_alias_in_group_bys
 
-    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa: D
+    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa: D102
         result = node.accept(SqlRewritingSubQueryReducerVisitor())
         if self._use_column_alias_in_group_bys:
             return result.accept(SqlGroupByRewritingVisitor())

--- a/metricflow/sql/optimizer/sub_query_reducer.py
+++ b/metricflow/sql/optimizer/sub_query_reducer.py
@@ -48,7 +48,7 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=node.distinct,
         )
 
-    def _reduce_is_possible(self, node: SqlSelectStatementNode) -> bool:  # noqa: D
+    def _reduce_is_possible(self, node: SqlSelectStatementNode) -> bool:
         """Returns true if the given node can be reduced with the parent node.
 
         Reducing this node means eliminating the SELECT of this node and merging it with the parent SELECT. This
@@ -121,7 +121,7 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
                     return column_reference_expr.col_ref.table_alias
         return None
 
-    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         node_with_reduced_parents = self._reduce_parents(node)
 
         if not self._reduce_is_possible(node_with_reduced_parents):
@@ -188,13 +188,13 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=parent_select_node.distinct,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
-    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
-    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D102
         return SqlCreateTableAsNode(
             sql_table=node.sql_table,
             parent_node=node.parent_node.accept(self),
@@ -216,5 +216,5 @@ class SqlSubQueryReducer(SqlQueryPlanOptimizer):
     SELECT a.foo FROM bar a
     """
 
-    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa: D
+    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa: D102
         return node.accept(SqlSubQueryReducerVisitor())

--- a/metricflow/sql/optimizer/table_alias_simplifier.py
+++ b/metricflow/sql/optimizer/table_alias_simplifier.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class SqlTableAliasSimplifierVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
     """Visits the SQL query plan to see if table aliases can be omitted when rendering column references."""
 
-    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         # If there is only a single parent, no table aliases are required since there's no ambiguity.
         should_simplify_table_aliases = len(node.parent_nodes) <= 1
 
@@ -69,13 +69,13 @@ class SqlTableAliasSimplifierVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=node.distinct,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
-    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
-    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D102
         return SqlCreateTableAsNode(
             sql_table=node.sql_table,
             parent_node=node.parent_node.accept(self),
@@ -100,5 +100,5 @@ class SqlTableAliasSimplifier(SqlQueryPlanOptimizer):
     ) b
     """
 
-    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa: D
+    def optimize(self, node: SqlQueryPlanNode) -> SqlQueryPlanNode:  # noqa: D102
         return node.accept(SqlTableAliasSimplifierVisitor())

--- a/metricflow/sql/render/expr_renderer.py
+++ b/metricflow/sql/render/expr_renderer.py
@@ -108,11 +108,11 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
     def supported_percentile_function_types(self) -> Collection[SqlPercentileFunctionType]:
         return {}
 
-    def visit_string_expr(self, node: SqlStringExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_string_expr(self, node: SqlStringExpression) -> SqlExpressionRenderResult:
         """Renders an arbitrary string expression like 1+1=2."""
         return SqlExpressionRenderResult(sql=node.sql_expr, bind_parameters=node.bind_parameters)
 
-    def visit_column_reference_expr(self, node: SqlColumnReferenceExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_column_reference_expr(self, node: SqlColumnReferenceExpression) -> SqlExpressionRenderResult:
         """Render a reference to a column in a table like my_table.my_col."""
         return SqlExpressionRenderResult(
             sql=(
@@ -123,9 +123,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
             bind_parameters=SqlBindParameters(),
         )
 
-    def visit_column_alias_reference_expr(  # noqa: D
-        self, node: SqlColumnAliasReferenceExpression
-    ) -> SqlExpressionRenderResult:
+    def visit_column_alias_reference_expr(self, node: SqlColumnAliasReferenceExpression) -> SqlExpressionRenderResult:
         """Render a reference to a column without a known table alias. e.g. foo.bar vs bar."""
         return SqlExpressionRenderResult(
             sql=node.column_alias,
@@ -154,7 +152,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
             bind_parameters=combined_params,
         )
 
-    def visit_function_expr(self, node: SqlAggregateFunctionExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_function_expr(self, node: SqlAggregateFunctionExpression) -> SqlExpressionRenderResult:
         """Render a function call like CONCAT(a, b)."""
         args_rendered = [self.render_sql_expr(x) for x in node.sql_function_args]
         combined_params = SqlBindParameters()
@@ -175,19 +173,19 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
             "Default expression render has no percentile implementation - an engine-specific renderer should be implemented."
         )
 
-    def visit_null_expr(self, node: SqlNullExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_null_expr(self, node: SqlNullExpression) -> SqlExpressionRenderResult:  # noqa: D102
         return SqlExpressionRenderResult(
             sql="NULL",
             bind_parameters=SqlBindParameters(),
         )
 
-    def visit_string_literal_expr(self, node: SqlStringLiteralExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_string_literal_expr(self, node: SqlStringLiteralExpression) -> SqlExpressionRenderResult:  # noqa: D102
         return SqlExpressionRenderResult(
             sql=f"'{node.literal_value}'",
             bind_parameters=SqlBindParameters(),
         )
 
-    def visit_logical_expr(self, node: SqlLogicalExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_logical_expr(self, node: SqlLogicalExpression) -> SqlExpressionRenderResult:  # noqa: D102
         RenderedExpr = namedtuple("RenderedExpr", ["expr", "requires_parenthesis"])
         args_rendered = [RenderedExpr(self.render_sql_expr(x), x.requires_parenthesis) for x in node.args]
         combined_parameters = SqlBindParameters()
@@ -248,7 +246,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
                 .rstrip()
             )
 
-    def visit_is_null_expr(self, node: SqlIsNullExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_is_null_expr(self, node: SqlIsNullExpression) -> SqlExpressionRenderResult:  # noqa: D102
         arg_rendered = self.render_sql_expr(node.arg)
 
         return SqlExpressionRenderResult(
@@ -256,14 +254,16 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
             bind_parameters=arg_rendered.bind_parameters,
         )
 
-    def visit_cast_to_timestamp_expr(self, node: SqlCastToTimestampExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_cast_to_timestamp_expr(  # noqa: D102
+        self, node: SqlCastToTimestampExpression
+    ) -> SqlExpressionRenderResult:  # noqa: D102
         arg_rendered = self.render_sql_expr(node.arg)
         return SqlExpressionRenderResult(
             sql=f"CAST({arg_rendered.sql} AS {self.timestamp_data_type})",
             bind_parameters=arg_rendered.bind_parameters,
         )
 
-    def visit_date_trunc_expr(self, node: SqlDateTruncExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_date_trunc_expr(self, node: SqlDateTruncExpression) -> SqlExpressionRenderResult:  # noqa: D102
         arg_rendered = self.render_sql_expr(node.arg)
 
         return SqlExpressionRenderResult(
@@ -271,7 +271,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
             bind_parameters=arg_rendered.bind_parameters,
         )
 
-    def visit_extract_expr(self, node: SqlExtractExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_extract_expr(self, node: SqlExtractExpression) -> SqlExpressionRenderResult:  # noqa: D102
         arg_rendered = self.render_sql_expr(node.arg)
 
         return SqlExpressionRenderResult(
@@ -289,7 +289,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
 
         return date_part.value
 
-    def visit_time_delta_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_time_delta_expr(self, node: SqlSubtractTimeIntervalExpression) -> SqlExpressionRenderResult:  # noqa: D102
         arg_rendered = node.arg.accept(self)
 
         count = node.count
@@ -323,7 +323,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
             bind_parameters=bind_parameters,
         )
 
-    def visit_between_expr(self, node: SqlBetweenExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_between_expr(self, node: SqlBetweenExpression) -> SqlExpressionRenderResult:  # noqa: D102
         rendered_column_arg = self.render_sql_expr(node.column_arg)
         rendered_start_expr = self.render_sql_expr(node.start_expr)
         rendered_end_expr = self.render_sql_expr(node.end_expr)
@@ -338,7 +338,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
             bind_parameters=bind_parameters,
         )
 
-    def visit_window_function_expr(self, node: SqlWindowFunctionExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_window_function_expr(self, node: SqlWindowFunctionExpression) -> SqlExpressionRenderResult:  # noqa: D102
         sql_function_args_rendered = [self.render_sql_expr(x) for x in node.sql_function_args]
         partition_by_args_rendered = [self.render_sql_expr(x) for x in node.partition_by_args]
         order_by_args_rendered = {self.render_sql_expr(x.expr): x for x in node.order_by_args}
@@ -402,7 +402,7 @@ class DefaultSqlExpressionRenderer(SqlExpressionRenderer):
                 bind_parameters=combined_params,
             )
 
-    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:  # noqa: D
+    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:  # noqa: D102
         return SqlExpressionRenderResult(
             sql="UUID()",
             bind_parameters=SqlBindParameters(),

--- a/metricflow/sql/render/sql_plan_renderer.py
+++ b/metricflow/sql/render/sql_plan_renderer.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class SqlPlanRenderResult:  # noqa: D
+class SqlPlanRenderResult:  # noqa: D101
     # The SQL string that could be run.
     sql: str
     # The execution parameters that should be specified along with the SQL str to execute()
@@ -41,15 +41,15 @@ class SqlPlanRenderResult:  # noqa: D
 class SqlQueryPlanRenderer(SqlQueryPlanNodeVisitor[SqlPlanRenderResult], ABC):
     """Renders SQL plans to a string."""
 
-    def _render_node(self, node: SqlQueryPlanNode) -> SqlPlanRenderResult:  # noqa: D
+    def _render_node(self, node: SqlQueryPlanNode) -> SqlPlanRenderResult:
         return node.accept(self)
 
-    def render_sql_query_plan(self, sql_query_plan: SqlQueryPlan) -> SqlPlanRenderResult:  # noqa: D
+    def render_sql_query_plan(self, sql_query_plan: SqlQueryPlan) -> SqlPlanRenderResult:  # noqa: D102
         return self._render_node(sql_query_plan.render_node)
 
     @property
     @abstractmethod
-    def expr_renderer(self) -> SqlExpressionRenderer:  # noqa: D
+    def expr_renderer(self) -> SqlExpressionRenderer:
         """Return the renderer that this uses to render expressions."""
         pass
 
@@ -223,7 +223,7 @@ class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
 
         return "\n".join(group_by_section_lines), params
 
-    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlPlanRenderResult:  # noqa: D
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlPlanRenderResult:  # noqa: D102
         # Keep track of all execution parameters for all expressions
         combined_params = SqlBindParameters()
 
@@ -300,19 +300,19 @@ class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
             bind_parameters=combined_params,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlPlanRenderResult:  # noqa: D
+    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlPlanRenderResult:  # noqa: D102
         return SqlPlanRenderResult(
             sql=node.sql_table.sql,
             bind_parameters=SqlBindParameters(),
         )
 
-    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlPlanRenderResult:  # noqa: D
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlPlanRenderResult:  # noqa: D102
         return SqlPlanRenderResult(
             sql=node.select_query.rstrip(),
             bind_parameters=SqlBindParameters(),
         )
 
-    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlPlanRenderResult:  # noqa: D
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlPlanRenderResult:  # noqa: D102
         inner_sql_render_result = node.parent_node.accept(self)
         inner_sql = inner_sql_render_result.sql
         # Using a substitution since inner_sql can have multiple lines, and then dedent() wouldn't dent due to the

--- a/metricflow/sql/sql_bind_parameters.py
+++ b/metricflow/sql/sql_bind_parameters.py
@@ -22,7 +22,7 @@ class SqlBindParameterValue(SerializableDataclass):
     date_value: Optional[datetime.date] = None
     bool_value: Optional[bool] = None
 
-    def __post_init__(self) -> None:  # noqa: D
+    def __post_init__(self) -> None:  # noqa: D105
         assert_exactly_one_arg_set(
             str_value=self.str_value,
             int_value=self.int_value,
@@ -33,7 +33,7 @@ class SqlBindParameterValue(SerializableDataclass):
         )
 
     @property
-    def union_value(self) -> SqlColumnType:  # noqa: D
+    def union_value(self) -> SqlColumnType:  # noqa: D102
         if self.str_value is not None:
             return self.str_value
         elif self.int_value is not None:
@@ -68,7 +68,7 @@ class SqlBindParameterValue(SerializableDataclass):
 
 
 @dataclass(frozen=True)
-class SqlBindParameter(SerializableDataclass):  # noqa: D
+class SqlBindParameter(SerializableDataclass):  # noqa: D101
     key: str
     value: SqlBindParameterValue
 
@@ -119,7 +119,7 @@ class SqlBindParameters(SerializableDataclass):
         return param_dict
 
     @staticmethod
-    def create_from_dict(param_dict: Mapping[str, SqlColumnType]) -> SqlBindParameters:  # noqa: D
+    def create_from_dict(param_dict: Mapping[str, SqlColumnType]) -> SqlBindParameters:  # noqa: D102
         return SqlBindParameters(
             tuple(
                 SqlBindParameter(key=key, value=SqlBindParameterValue.create_from_sql_column_type(value))
@@ -127,5 +127,5 @@ class SqlBindParameters(SerializableDataclass):
             )
         )
 
-    def __eq__(self, other: Any) -> bool:  # type: ignore  # noqa: D
+    def __eq__(self, other: Any) -> bool:  # type: ignore  # noqa: D105
         return isinstance(other, SqlBindParameters) and self.param_dict == other.param_dict

--- a/metricflow/sql/sql_column.py
+++ b/metricflow/sql/sql_column.py
@@ -25,21 +25,21 @@ class SqlColumn:
         return SqlColumn(table=table, column_name=column_name)
 
     @staticmethod
-    def from_string(sql_str: str) -> SqlColumn:  # noqa: D
+    def from_string(sql_str: str) -> SqlColumn:  # noqa: D102
         table_str, column_name = sql_str.rsplit(".", 1)
         table = SqlTable.from_string(table_str)
         return SqlColumn(table=table, column_name=column_name)
 
     @property
-    def db_name(self) -> Optional[str]:  # noqa: D
+    def db_name(self) -> Optional[str]:  # noqa: D102
         return self.table.db_name
 
     @property
-    def schema_name(self) -> str:  # noqa: D
+    def schema_name(self) -> str:  # noqa: D102
         return self.table.schema_name
 
     @property
-    def table_name(self) -> str:  # noqa: D
+    def table_name(self) -> str:  # noqa: D102
         return self.table.table_name
 
     @property
@@ -47,5 +47,5 @@ class SqlColumn:
         """Return the snippet that can be used for use in SQL queries."""
         return f"{self.table.sql}.{self.column_name}"
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"SqlColumn(full_name={self.sql})"

--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -24,7 +24,7 @@ from metricflow.visitor import Visitable, VisitorOutputT
 class SqlExpressionNode(DagNode, Visitable, ABC):
     """An SQL expression like my_table.my_column, CONCAT(a, b) or 1 + 1 that evaluates to a value."""
 
-    def __init__(self, node_id: NodeId, parent_nodes: List[SqlExpressionNode]) -> None:  # noqa: D
+    def __init__(self, node_id: NodeId, parent_nodes: List[SqlExpressionNode]) -> None:  # noqa: D107
         self._parent_nodes = parent_nodes
         super().__init__(node_id=node_id)
 
@@ -58,7 +58,7 @@ class SqlExpressionNode(DagNode, Visitable, ABC):
         return SqlBindParameters()
 
     @property
-    def parent_nodes(self) -> Sequence[SqlExpressionNode]:  # noqa: D
+    def parent_nodes(self) -> Sequence[SqlExpressionNode]:  # noqa: D102
         return self._parent_nodes
 
     @property
@@ -91,7 +91,7 @@ class SqlExpressionNode(DagNode, Visitable, ABC):
         """Returns all nodes in the paths from this node to the root nodes."""
         pass
 
-    def _parents_match(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def _parents_match(self, other: SqlExpressionNode) -> bool:
         return all(x == y for x, y in itertools.zip_longest(self.parent_nodes, other.parent_nodes))
 
     @abstractmethod
@@ -124,29 +124,29 @@ class SqlExpressionTreeLineage:
         )
 
     @property
-    def contains_string_exprs(self) -> bool:  # noqa: D
+    def contains_string_exprs(self) -> bool:  # noqa: D102
         return len(self.string_exprs) > 0
 
     @property
-    def contains_column_alias_exprs(self) -> bool:  # noqa: D
+    def contains_column_alias_exprs(self) -> bool:  # noqa: D102
         return len(self.column_alias_reference_exprs) > 0
 
     @property
-    def contains_ambiguous_exprs(self) -> bool:  # noqa: D
+    def contains_ambiguous_exprs(self) -> bool:  # noqa: D102
         return self.contains_string_exprs or self.contains_column_alias_exprs
 
     @property
-    def contains_aggregate_exprs(self) -> bool:  # noqa: D
+    def contains_aggregate_exprs(self) -> bool:  # noqa: D102
         return any(x.is_aggregate_function for x in self.function_exprs)
 
 
 class SqlColumnReplacements:
     """When re-writing column references in expressions, this storing the mapping."""
 
-    def __init__(self, column_replacements: Dict[SqlColumnReference, SqlExpressionNode]) -> None:  # noqa: D
+    def __init__(self, column_replacements: Dict[SqlColumnReference, SqlExpressionNode]) -> None:  # noqa: D107
         self._column_replacements = column_replacements
 
-    def get_replacement(self, column_reference: SqlColumnReference) -> Optional[SqlExpressionNode]:  # noqa: D
+    def get_replacement(self, column_reference: SqlColumnReference) -> Optional[SqlExpressionNode]:  # noqa: D102
         return self._column_replacements.get(column_reference)
 
 
@@ -157,75 +157,77 @@ class SqlExpressionNodeVisitor(Generic[VisitorOutputT], ABC):
     """
 
     @abstractmethod
-    def visit_string_expr(self, node: SqlStringExpression) -> VisitorOutputT:  # noqa: D
+    def visit_string_expr(self, node: SqlStringExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_column_reference_expr(self, node: SqlColumnReferenceExpression) -> VisitorOutputT:  # noqa: D
+    def visit_column_reference_expr(self, node: SqlColumnReferenceExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_column_alias_reference_expr(self, node: SqlColumnAliasReferenceExpression) -> VisitorOutputT:  # noqa: D
+    def visit_column_alias_reference_expr(  # noqa: D102
+        self, node: SqlColumnAliasReferenceExpression
+    ) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_comparison_expr(self, node: SqlComparisonExpression) -> VisitorOutputT:  # noqa: D
+    def visit_comparison_expr(self, node: SqlComparisonExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_function_expr(self, node: SqlAggregateFunctionExpression) -> VisitorOutputT:  # noqa: D
+    def visit_function_expr(self, node: SqlAggregateFunctionExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_percentile_expr(self, node: SqlPercentileExpression) -> VisitorOutputT:  # noqa: D
+    def visit_percentile_expr(self, node: SqlPercentileExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_null_expr(self, node: SqlNullExpression) -> VisitorOutputT:  # noqa: D
+    def visit_null_expr(self, node: SqlNullExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_logical_expr(self, node: SqlLogicalExpression) -> VisitorOutputT:  # noqa: D
+    def visit_logical_expr(self, node: SqlLogicalExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_string_literal_expr(self, node: SqlStringLiteralExpression) -> VisitorOutputT:  # noqa: D
+    def visit_string_literal_expr(self, node: SqlStringLiteralExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_is_null_expr(self, node: SqlIsNullExpression) -> VisitorOutputT:  # noqa: D
+    def visit_is_null_expr(self, node: SqlIsNullExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_cast_to_timestamp_expr(self, node: SqlCastToTimestampExpression) -> VisitorOutputT:  # noqa: D
+    def visit_cast_to_timestamp_expr(self, node: SqlCastToTimestampExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_date_trunc_expr(self, node: SqlDateTruncExpression) -> VisitorOutputT:  # noqa: D
+    def visit_date_trunc_expr(self, node: SqlDateTruncExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_extract_expr(self, node: SqlExtractExpression) -> VisitorOutputT:  # noqa: D
+    def visit_extract_expr(self, node: SqlExtractExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_time_delta_expr(self, node: SqlSubtractTimeIntervalExpression) -> VisitorOutputT:  # noqa: D
+    def visit_time_delta_expr(self, node: SqlSubtractTimeIntervalExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_ratio_computation_expr(self, node: SqlRatioComputationExpression) -> VisitorOutputT:  # noqa: D
+    def visit_ratio_computation_expr(self, node: SqlRatioComputationExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_between_expr(self, node: SqlBetweenExpression) -> VisitorOutputT:  # noqa: D
+    def visit_between_expr(self, node: SqlBetweenExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_window_function_expr(self, node: SqlWindowFunctionExpression) -> VisitorOutputT:  # noqa: D
+    def visit_window_function_expr(self, node: SqlWindowFunctionExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod
-    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> VisitorOutputT:  # noqa: D
+    def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> VisitorOutputT:  # noqa: D102
         pass
 
 
@@ -260,40 +262,40 @@ class SqlStringExpression(SqlExpressionNode):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_STRING_ID_PREFIX
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_string_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"String SQL Expression: {self._sql_expr}"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (DisplayedProperty("sql_expr", self._sql_expr),)
 
     @property
-    def sql_expr(self) -> str:  # noqa: D
+    def sql_expr(self) -> str:  # noqa: D102
         return self._sql_expr
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return self._requires_parenthesis
 
     @property
-    def bind_parameters(self) -> SqlBindParameters:  # noqa: D
+    def bind_parameters(self) -> SqlBindParameters:  # noqa: D102
         return self._bind_parameters
 
     @property
-    def used_columns(self) -> Optional[Tuple[str, ...]]:  # noqa: D
+    def used_columns(self) -> Optional[Tuple[str, ...]]:  # noqa: D102
         return self._used_columns
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(node_id={self.node_id} sql_expr={self.sql_expr})"
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -303,10 +305,10 @@ class SqlStringExpression(SqlExpressionNode):
         return self
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage(string_exprs=(self,))
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlStringExpression):
             return False
         return (
@@ -324,41 +326,41 @@ class SqlStringExpression(SqlExpressionNode):
 class SqlStringLiteralExpression(SqlExpressionNode):
     """A string literal like 'foo'. It shouldn't include delimiters as it should be added during rendering."""
 
-    def __init__(self, literal_value: str) -> None:  # noqa: D
+    def __init__(self, literal_value: str) -> None:  # noqa: D107
         self._literal_value = literal_value
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_STRING_LITERAL_PREFIX
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_string_literal_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"String Literal: {self._literal_value}"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (DisplayedProperty("value", self._literal_value),)
 
     @property
-    def literal_value(self) -> str:  # noqa: D
+    def literal_value(self) -> str:  # noqa: D102
         return self._literal_value
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
     @property
-    def bind_parameters(self) -> SqlBindParameters:  # noqa: D
+    def bind_parameters(self) -> SqlBindParameters:  # noqa: D102
         return SqlBindParameters()
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(node_id={self.node_id}, literal_value={self.literal_value})"
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -366,10 +368,10 @@ class SqlStringLiteralExpression(SqlExpressionNode):
         return self
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage(other_exprs=(self,))
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlStringLiteralExpression):
             return False
         return self.literal_value == other.literal_value
@@ -402,33 +404,33 @@ class SqlColumnReferenceExpression(SqlExpressionNode):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_COLUMN_REFERENCE_ID_PREFIX
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_column_reference_expr(self)
 
     @property
-    def col_ref(self) -> SqlColumnReference:  # noqa: D
+    def col_ref(self) -> SqlColumnReference:  # noqa: D102
         return self._col_ref
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"Column: {self.col_ref}"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (DisplayedProperty("col_ref", self.col_ref),)
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
     @property
-    def as_column_reference_expression(self) -> Optional[SqlColumnReferenceExpression]:  # noqa:
+    def as_column_reference_expression(self) -> Optional[SqlColumnReferenceExpression]:  # noqa: D102
         return self
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -463,14 +465,14 @@ class SqlColumnReferenceExpression(SqlExpressionNode):
         )
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage(column_reference_exprs=(self,))
 
     @property
-    def should_render_table_alias(self) -> bool:  # noqa: D
+    def should_render_table_alias(self) -> bool:  # noqa: D102
         return self._should_render_table_alias
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlColumnReferenceExpression):
             return False
         return self.col_ref == other.col_ref
@@ -485,38 +487,38 @@ class SqlColumnAliasReferenceExpression(SqlExpressionNode):
     ambiguities.
     """
 
-    def __init__(self, column_alias: str) -> None:  # noqa: D
+    def __init__(self, column_alias: str) -> None:  # noqa: D107
         self._column_alias = column_alias
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_COLUMN_REFERENCE_ID_PREFIX
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_column_alias_reference_expr(self)
 
     @property
-    def column_alias(self) -> str:  # noqa: D
+    def column_alias(self) -> str:  # noqa: D102
         return self._column_alias
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"Unqualified Column: {self._column_alias}"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (DisplayedProperty("column_alias", self.column_alias),)
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
     @property
-    def as_column_reference_expression(self) -> Optional[SqlColumnReferenceExpression]:  # noqa:
+    def as_column_reference_expression(self) -> Optional[SqlColumnReferenceExpression]:  # noqa: D102
         return None
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -526,16 +528,16 @@ class SqlColumnAliasReferenceExpression(SqlExpressionNode):
         return self
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage(column_alias_reference_exprs=(self,))
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlColumnAliasReferenceExpression):
             return False
         return self.column_alias == other.column_alias
 
 
-class SqlComparison(Enum):  # noqa: D
+class SqlComparison(Enum):  # noqa: D101
     LESS_THAN = "<"
     GREATER_THAN = ">"
     LESS_THAN_OR_EQUALS = "<="
@@ -563,26 +565,26 @@ class SqlComparisonExpression(SqlExpressionNode):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[self._left_expr, self._right_expr])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_COMPARISON_ID_PREFIX
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_comparison_expr(self)
 
     @property
-    def left_expr(self) -> SqlExpressionNode:  # noqa: D
+    def left_expr(self) -> SqlExpressionNode:  # noqa: D102
         return self._left_expr
 
     @property
-    def right_expr(self) -> SqlExpressionNode:  # noqa: D
+    def right_expr(self) -> SqlExpressionNode:  # noqa: D102
         return self._right_expr
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"{self._comparison.value} Expression"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (
             DisplayedProperty("left_expr", self.left_expr),
             DisplayedProperty("comparison", self.comparison.value),
@@ -590,14 +592,14 @@ class SqlComparisonExpression(SqlExpressionNode):
         )
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return True
 
     @property
-    def comparison(self) -> SqlComparison:  # noqa: D
+    def comparison(self) -> SqlComparison:  # noqa: D102
         return self._comparison
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -609,12 +611,12 @@ class SqlComparisonExpression(SqlExpressionNode):
         )
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(other_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlComparisonExpression):
             return False
         return self.comparison == other.comparison and self._parents_match(other)
@@ -755,22 +757,22 @@ class SqlAggregateFunctionExpression(SqlFunctionExpression):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=sql_function_args)
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_FUNCTION_ID_PREFIX
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_function_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"{self._sql_function.value} Expression"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return (
             tuple(super().displayed_properties)
             + (DisplayedProperty("function", self.sql_function),)
@@ -778,17 +780,17 @@ class SqlAggregateFunctionExpression(SqlFunctionExpression):
         )
 
     @property
-    def sql_function(self) -> SqlFunction:  # noqa: D
+    def sql_function(self) -> SqlFunction:  # noqa: D102
         return self._sql_function
 
     @property
-    def sql_function_args(self) -> List[SqlExpressionNode]:  # noqa: D
+    def sql_function_args(self) -> List[SqlExpressionNode]:  # noqa: D102
         return self._sql_function_args
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(node_id={self.node_id}, sql_function={self.sql_function.name})"
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -801,16 +803,16 @@ class SqlAggregateFunctionExpression(SqlFunctionExpression):
         )
 
     @property
-    def is_aggregate_function(self) -> bool:  # noqa: D
+    def is_aggregate_function(self) -> bool:  # noqa: D102
         return True
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(function_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlAggregateFunctionExpression):
             return False
         return self.sql_function == other.sql_function and self._parents_match(other)
@@ -878,40 +880,40 @@ class SqlPercentileExpression(SqlFunctionExpression):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[order_by_arg])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_PERCENTILE_ID_PREFIX
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
     @property
-    def order_by_arg(self) -> SqlExpressionNode:  # noqa: D
+    def order_by_arg(self) -> SqlExpressionNode:  # noqa: D102
         return self._order_by_arg
 
     @property
-    def percentile_args(self) -> SqlPercentileExpressionArgument:  # noqa: D
+    def percentile_args(self) -> SqlPercentileExpressionArgument:  # noqa: D102
         return self._percentile_args
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_percentile_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"{self._percentile_args.function_type.value} Percentile({self._percentile_args.percentile}) Expression"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return (
             tuple(super().displayed_properties)
             + (DisplayedProperty("argument", self._order_by_arg),)
             + (DisplayedProperty("percentile_args", self._percentile_args),)
         )
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(node_id={self.node_id}, percentile={self._percentile_args.percentile}, function_type={self._percentile_args.function_type.value})"
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -922,16 +924,16 @@ class SqlPercentileExpression(SqlFunctionExpression):
         )
 
     @property
-    def is_aggregate_function(self) -> bool:  # noqa: D
+    def is_aggregate_function(self) -> bool:  # noqa: D102
         return True
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(function_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlPercentileExpression):
             return False
         return self._percentile_args == other._percentile_args and self._parents_match(other)
@@ -1000,22 +1002,22 @@ class SqlWindowFunctionExpression(SqlFunctionExpression):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=parent_nodes)
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_WINDOW_FUNCTION_ID_PREFIX
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_window_function_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"{self._sql_function.value} Window Function Expression"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return (
             tuple(super().displayed_properties)
             + (DisplayedProperty("function", self.sql_function),)
@@ -1025,29 +1027,29 @@ class SqlWindowFunctionExpression(SqlFunctionExpression):
         )
 
     @property
-    def sql_function(self) -> SqlWindowFunction:  # noqa: D
+    def sql_function(self) -> SqlWindowFunction:  # noqa: D102
         return self._sql_function
 
     @property
-    def sql_function_args(self) -> Sequence[SqlExpressionNode]:  # noqa: D
+    def sql_function_args(self) -> Sequence[SqlExpressionNode]:  # noqa: D102
         return self._sql_function_args
 
     @property
-    def partition_by_args(self) -> Sequence[SqlExpressionNode]:  # noqa: D
+    def partition_by_args(self) -> Sequence[SqlExpressionNode]:  # noqa: D102
         return self._partition_by_args
 
     @property
-    def order_by_args(self) -> Sequence[SqlWindowOrderByArgument]:  # noqa: D
+    def order_by_args(self) -> Sequence[SqlWindowOrderByArgument]:  # noqa: D102
         return self._order_by_args
 
     @property
-    def is_aggregate_function(self) -> bool:  # noqa: D
+    def is_aggregate_function(self) -> bool:  # noqa: D102
         return False
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(node_id={self.node_id}, sql_function={self.sql_function.name})"
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1071,12 +1073,12 @@ class SqlWindowFunctionExpression(SqlFunctionExpression):
         )
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(function_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlWindowFunctionExpression):
             return False
         return (
@@ -1089,25 +1091,25 @@ class SqlWindowFunctionExpression(SqlFunctionExpression):
 class SqlNullExpression(SqlExpressionNode):
     """Represents NULL."""
 
-    def __init__(self) -> None:  # noqa: D
+    def __init__(self) -> None:  # noqa: D107
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_NULL_PREFIX
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_null_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "NULL Expression"
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1115,10 +1117,10 @@ class SqlNullExpression(SqlExpressionNode):
         return self
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage(other_exprs=(self,))
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         return isinstance(other, SqlNullExpression)
 
 
@@ -1135,34 +1137,34 @@ class SqlLogicalOperator(Enum):
 class SqlLogicalExpression(SqlExpressionNode):
     """A logical expression like "a AND b AND c"."""
 
-    def __init__(self, operator: SqlLogicalOperator, args: Tuple[SqlExpressionNode, ...]) -> None:  # noqa: D
+    def __init__(self, operator: SqlLogicalOperator, args: Tuple[SqlExpressionNode, ...]) -> None:  # noqa: D107
         self._operator = operator
         super().__init__(node_id=self.create_unique_id(), parent_nodes=list(args))
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_LOGICAL_OPERATOR_PREFIX
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return True
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_logical_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"Logical Operator {self._operator.value}"
 
     @property
-    def args(self) -> Sequence[SqlExpressionNode]:  # noqa: D
+    def args(self) -> Sequence[SqlExpressionNode]:  # noqa: D102
         return self.parent_nodes
 
     @property
-    def operator(self) -> SqlLogicalOperator:  # noqa: D
+    def operator(self) -> SqlLogicalOperator:  # noqa: D102
         return self._operator
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1173,12 +1175,12 @@ class SqlLogicalExpression(SqlExpressionNode):
         )
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(other_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlLogicalExpression):
             return False
         return self.operator == other.operator and self._parents_match(other)
@@ -1187,30 +1189,30 @@ class SqlLogicalExpression(SqlExpressionNode):
 class SqlIsNullExpression(SqlExpressionNode):
     """An IS NULL expression like "foo IS NULL"."""
 
-    def __init__(self, arg: SqlExpressionNode) -> None:  # noqa: D
+    def __init__(self, arg: SqlExpressionNode) -> None:  # noqa: D107
         self._arg = arg
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[arg])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_IS_NULL_PREFIX
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return True
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_is_null_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "IS NULL Expression"
 
     @property
-    def arg(self) -> SqlExpressionNode:  # noqa: D
+    def arg(self) -> SqlExpressionNode:  # noqa: D102
         return self._arg
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1218,10 +1220,10 @@ class SqlIsNullExpression(SqlExpressionNode):
         return SqlIsNullExpression(arg=self.arg.rewrite(column_replacements, should_render_table_alias))
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine([self.arg.lineage, SqlExpressionTreeLineage(other_exprs=(self,))])
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlIsNullExpression):
             return False
         return self._parents_match(other)
@@ -1236,7 +1238,7 @@ class SqlSubtractTimeIntervalExpression(SqlExpressionNode):
     value.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         arg: SqlExpressionNode,
         count: int,
@@ -1248,33 +1250,33 @@ class SqlSubtractTimeIntervalExpression(SqlExpressionNode):
         self._arg = arg
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_SUBTRACT_TIME_INTERVAL_PREFIX
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_time_delta_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Time delta"
 
     @property
-    def arg(self) -> SqlExpressionNode:  # noqa: D
+    def arg(self) -> SqlExpressionNode:  # noqa: D102
         return self._arg
 
     @property
-    def count(self) -> int:  # noqa: D
+    def count(self) -> int:  # noqa: D102
         return self._count
 
     @property
-    def granularity(self) -> TimeGranularity:  # noqa: D
+    def granularity(self) -> TimeGranularity:  # noqa: D102
         return self._time_granularity
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1286,12 +1288,12 @@ class SqlSubtractTimeIntervalExpression(SqlExpressionNode):
         )
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(other_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlSubtractTimeIntervalExpression):
             return False
         return self.count == other.count and self.granularity == other.granularity and self._parents_match(other)
@@ -1300,30 +1302,30 @@ class SqlSubtractTimeIntervalExpression(SqlExpressionNode):
 class SqlCastToTimestampExpression(SqlExpressionNode):
     """Cast to the timestamp type like CAST('2020-01-01' AS TIMESTAMP)."""
 
-    def __init__(self, arg: SqlExpressionNode) -> None:  # noqa: D
+    def __init__(self, arg: SqlExpressionNode) -> None:  # noqa: D107
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[arg])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_CAST_TO_TIMESTAMP_PREFIX
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_cast_to_timestamp_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Cast to Timestamp"
 
     @property
-    def arg(self) -> SqlExpressionNode:  # noqa: D
+    def arg(self) -> SqlExpressionNode:  # noqa: D102
         assert len(self.parent_nodes) == 1
         return self.parent_nodes[0]
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1331,12 +1333,12 @@ class SqlCastToTimestampExpression(SqlExpressionNode):
         return SqlCastToTimestampExpression(arg=self.arg.rewrite(column_replacements, should_render_table_alias))
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(other_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlCastToTimestampExpression):
             return False
         return self._parents_match(other)
@@ -1356,30 +1358,30 @@ class SqlDateTruncExpression(SqlExpressionNode):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[arg])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_DATE_TRUNC
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_date_trunc_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"DATE_TRUNC() to {self.time_granularity}"
 
     @property
-    def time_granularity(self) -> TimeGranularity:  # noqa: D
+    def time_granularity(self) -> TimeGranularity:  # noqa: D102
         return self._time_granularity
 
     @property
-    def arg(self) -> SqlExpressionNode:  # noqa: D
+    def arg(self) -> SqlExpressionNode:  # noqa: D102
         assert len(self.parent_nodes) == 1
         return self.parent_nodes[0]
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1389,12 +1391,12 @@ class SqlDateTruncExpression(SqlExpressionNode):
         )
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(other_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlDateTruncExpression):
             return False
         return self.time_granularity == other.time_granularity and self._parents_match(other)
@@ -1414,30 +1416,30 @@ class SqlExtractExpression(SqlExpressionNode):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[arg])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_EXTRACT
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_extract_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"Extract {self.date_part.name}"
 
     @property
-    def date_part(self) -> DatePart:  # noqa: D
+    def date_part(self) -> DatePart:  # noqa: D102
         return self._date_part
 
     @property
-    def arg(self) -> SqlExpressionNode:  # noqa: D
+    def arg(self) -> SqlExpressionNode:  # noqa: D102
         assert len(self.parent_nodes) == 1
         return self.parent_nodes[0]
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1447,12 +1449,12 @@ class SqlExtractExpression(SqlExpressionNode):
         )
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(other_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlExtractExpression):
             return False
         return self.date_part == other.date_part and self._parents_match(other)
@@ -1479,29 +1481,29 @@ class SqlRatioComputationExpression(SqlExpressionNode):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[numerator, denominator])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_RATIO_COMPUTATION
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_ratio_computation_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Divide numerator by denominator, with appropriate casting"
 
     @property
-    def numerator(self) -> SqlExpressionNode:  # noqa: D
+    def numerator(self) -> SqlExpressionNode:  # noqa: D102
         return self._numerator
 
     @property
-    def denominator(self) -> SqlExpressionNode:  # noqa: D
+    def denominator(self) -> SqlExpressionNode:  # noqa: D102
         return self._denominator
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1512,12 +1514,12 @@ class SqlRatioComputationExpression(SqlExpressionNode):
         )
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(other_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlRatioComputationExpression):
             return False
         return self._parents_match(other)
@@ -1526,7 +1528,7 @@ class SqlRatioComputationExpression(SqlExpressionNode):
 class SqlBetweenExpression(SqlExpressionNode):
     """A BETWEEN clause like `column BETWEEN val1 AND val2`."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self, column_arg: SqlExpressionNode, start_expr: SqlExpressionNode, end_expr: SqlExpressionNode
     ) -> None:
         self._column_arg = column_arg
@@ -1535,33 +1537,33 @@ class SqlBetweenExpression(SqlExpressionNode):
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[column_arg, start_expr, end_expr])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_BETWEEN_PREFIX
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_between_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "BETWEEN operator"
 
     @property
-    def column_arg(self) -> SqlExpressionNode:  # noqa: D
+    def column_arg(self) -> SqlExpressionNode:  # noqa: D102
         return self._column_arg
 
     @property
-    def start_expr(self) -> SqlExpressionNode:  # noqa: D
+    def start_expr(self) -> SqlExpressionNode:  # noqa: D102
         return self._start_expr
 
     @property
-    def end_expr(self) -> SqlExpressionNode:  # noqa: D
+    def end_expr(self) -> SqlExpressionNode:  # noqa: D102
         return self._end_expr
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1573,12 +1575,12 @@ class SqlBetweenExpression(SqlExpressionNode):
         )
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage.combine(
             tuple(x.lineage for x in self.parent_nodes) + (SqlExpressionTreeLineage(other_exprs=(self,)),)
         )
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         if not isinstance(other, SqlBetweenExpression):
             return False
         return self._parents_match(other)
@@ -1587,36 +1589,36 @@ class SqlBetweenExpression(SqlExpressionNode):
 class SqlGenerateUuidExpression(SqlExpressionNode):
     """Renders a sql to generate a random uuid, is non-deterministic.."""
 
-    def __init__(self) -> None:  # noqa: D
+    def __init__(self) -> None:  # noqa: D107
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_EXPR_GENERATE_UUID_PREFIX
 
-    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlExpressionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_generate_uuid_expr(self)
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Generate a universally unique identifier"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return super().displayed_properties
 
     @property
-    def requires_parenthesis(self) -> bool:  # noqa: D
+    def requires_parenthesis(self) -> bool:  # noqa: D102
         return False
 
     @property
-    def bind_parameters(self) -> SqlBindParameters:  # noqa: D
+    def bind_parameters(self) -> SqlBindParameters:  # noqa: D102
         return SqlBindParameters()
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}(node_id={self.node_id})"
 
-    def rewrite(  # noqa: D
+    def rewrite(  # noqa: D102
         self,
         column_replacements: Optional[SqlColumnReplacements] = None,
         should_render_table_alias: Optional[bool] = None,
@@ -1624,8 +1626,8 @@ class SqlGenerateUuidExpression(SqlExpressionNode):
         return self
 
     @property
-    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D
+    def lineage(self) -> SqlExpressionTreeLineage:  # noqa: D102
         return SqlExpressionTreeLineage(other_exprs=(self,))
 
-    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D
+    def matches(self, other: SqlExpressionNode) -> bool:  # noqa: D102
         return False

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -33,12 +33,12 @@ class SqlQueryPlanNode(DagNode, ABC):
     Is there an existing library that can do this?
     """
 
-    def __init__(self, node_id: NodeId, parent_nodes: Sequence[SqlQueryPlanNode]) -> None:  # noqa: D:
+    def __init__(self, node_id: NodeId, parent_nodes: Sequence[SqlQueryPlanNode]) -> None:  # noqa: D107
         self._parent_nodes = parent_nodes
         super().__init__(node_id=node_id)
 
     @property
-    def parent_nodes(self) -> List[SqlQueryPlanNode]:  # noqa: D
+    def parent_nodes(self) -> List[SqlQueryPlanNode]:  # noqa: D102
         return list(self._parent_nodes)
 
     @abstractmethod
@@ -66,19 +66,19 @@ class SqlQueryPlanNodeVisitor(Generic[VisitorOutputT], ABC):
     """
 
     @abstractmethod
-    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> VisitorOutputT:  # noqa: D
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> VisitorOutputT:  # noqa: D
+    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> VisitorOutputT:  # noqa: D
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod
-    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> VisitorOutputT:  # noqa: D
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> VisitorOutputT:  # noqa: D102
         raise NotImplementedError
 
 
@@ -102,7 +102,7 @@ class SqlJoinType(Enum):
     INNER = "INNER JOIN"
     CROSS_JOIN = "CROSS JOIN"
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}.{self.name}"
 
 
@@ -118,7 +118,7 @@ class SqlJoinDescription:
 
 
 @dataclass(frozen=True)
-class SqlOrderByDescription:  # noqa: D
+class SqlOrderByDescription:  # noqa: D101
     expr: SqlExpressionNode
     desc: bool
 
@@ -126,7 +126,7 @@ class SqlOrderByDescription:  # noqa: D
 class SqlSelectStatementNode(SqlQueryPlanNode):
     """Represents an SQL Select statement."""
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         description: str,
         select_columns: Tuple[SqlSelectColumn, ...],
@@ -161,15 +161,15 @@ class SqlSelectStatementNode(SqlQueryPlanNode):
         )
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_PLAN_SELECT_STATEMENT_ID_PREFIX
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return self._description
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return (
             tuple(super().displayed_properties)
             + tuple(DisplayedProperty(f"col{i}", column) for i, column in enumerate(self._select_columns))
@@ -182,123 +182,123 @@ class SqlSelectStatementNode(SqlQueryPlanNode):
         )
 
     @property
-    def select_columns(self) -> Tuple[SqlSelectColumn, ...]:  # noqa: D
+    def select_columns(self) -> Tuple[SqlSelectColumn, ...]:  # noqa: D102
         return self._select_columns
 
     @property
-    def from_source(self) -> SqlQueryPlanNode:  # noqa: D
+    def from_source(self) -> SqlQueryPlanNode:  # noqa: D102
         return self._from_source
 
     @property
-    def from_source_alias(self) -> str:  # noqa: D
+    def from_source_alias(self) -> str:  # noqa: D102
         return self._from_source_alias
 
     @property
-    def join_descs(self) -> Tuple[SqlJoinDescription, ...]:  # noqa: D
+    def join_descs(self) -> Tuple[SqlJoinDescription, ...]:  # noqa: D102
         return self._join_descs
 
     @property
-    def group_bys(self) -> Tuple[SqlSelectColumn, ...]:  # noqa: D
+    def group_bys(self) -> Tuple[SqlSelectColumn, ...]:  # noqa: D102
         return self._group_bys
 
     @property
-    def where(self) -> Optional[SqlExpressionNode]:  # noqa: D
+    def where(self) -> Optional[SqlExpressionNode]:  # noqa: D102
         return self._where
 
     @property
-    def order_bys(self) -> Tuple[SqlOrderByDescription, ...]:  # noqa: D
+    def order_bys(self) -> Tuple[SqlOrderByDescription, ...]:  # noqa: D102
         return self._order_bys
 
-    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_select_statement_node(self)
 
     @property
-    def is_table(self) -> bool:  # noqa: D
+    def is_table(self) -> bool:  # noqa: D102
         return False
 
     @property
-    def limit(self) -> Optional[int]:  # noqa: D
+    def limit(self) -> Optional[int]:  # noqa: D102
         return self._limit
 
     @property
-    def as_select_node(self) -> Optional[SqlSelectStatementNode]:  # noqa: D
+    def as_select_node(self) -> Optional[SqlSelectStatementNode]:  # noqa: D102
         return self
 
     @property
-    def distinct(self) -> bool:  # noqa: D
+    def distinct(self) -> bool:  # noqa: D102
         return self._distinct
 
 
 class SqlTableFromClauseNode(SqlQueryPlanNode):
     """An SQL table that can go in the FROM clause."""
 
-    def __init__(self, sql_table: SqlTable) -> None:  # noqa: D
+    def __init__(self, sql_table: SqlTable) -> None:  # noqa: D107
         self._sql_table = sql_table
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_PLAN_TABLE_FROM_CLAUSE_ID_PREFIX
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return f"Read from {self._sql_table.sql}"
 
     @property
-    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D
+    def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (DisplayedProperty("table_id", self._sql_table.sql),)
 
-    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_table_from_clause_node(self)
 
     @property
-    def sql_table(self) -> SqlTable:  # noqa: D
+    def sql_table(self) -> SqlTable:  # noqa: D102
         return self._sql_table
 
     @property
-    def is_table(self) -> bool:  # noqa: D
+    def is_table(self) -> bool:  # noqa: D102
         return True
 
     @property
-    def as_select_node(self) -> Optional[SqlSelectStatementNode]:  # noqa: D
+    def as_select_node(self) -> Optional[SqlSelectStatementNode]:  # noqa: D102
         return None
 
 
 class SqlSelectQueryFromClauseNode(SqlQueryPlanNode):
     """An SQL select query that can go in the FROM clause."""
 
-    def __init__(self, select_query: str) -> None:  # noqa: D
+    def __init__(self, select_query: str) -> None:  # noqa: D107
         self._select_query = select_query
         super().__init__(node_id=self.create_unique_id(), parent_nodes=[])
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.SQL_PLAN_QUERY_FROM_CLAUSE_ID_PREFIX
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Read From a Select Query"
 
-    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D
+    def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_query_from_clause_node(self)
 
     @property
-    def select_query(self) -> str:  # noqa: D
+    def select_query(self) -> str:  # noqa: D102
         return self._select_query
 
     @property
-    def is_table(self) -> bool:  # noqa: D
+    def is_table(self) -> bool:  # noqa: D102
         return False
 
     @property
-    def as_select_node(self) -> Optional[SqlSelectStatementNode]:  # noqa: D
+    def as_select_node(self) -> Optional[SqlSelectStatementNode]:  # noqa: D102
         return None
 
 
 class SqlCreateTableAsNode(SqlQueryPlanNode):
     """An SQL select query that can go in the FROM clause."""
 
-    def __init__(self, sql_table: SqlTable, parent_node: SqlQueryPlanNode) -> None:  # noqa: D
+    def __init__(self, sql_table: SqlTable, parent_node: SqlQueryPlanNode) -> None:  # noqa: D107
         self._sql_table = sql_table
         self._parent_node = parent_node
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(self._parent_node,))
@@ -333,11 +333,11 @@ class SqlCreateTableAsNode(SqlQueryPlanNode):
         return self._sql_table
 
     @property
-    def parent_node(self) -> SqlQueryPlanNode:  # noqa: D
+    def parent_node(self) -> SqlQueryPlanNode:  # noqa: D102
         return self._parent_node
 
 
-class SqlQueryPlan(MetricFlowDag[SqlQueryPlanNode]):  # noqa: D
+class SqlQueryPlan(MetricFlowDag[SqlQueryPlanNode]):
     """Model for an SQL Query as a DAG."""
 
     def __init__(self, render_node: SqlQueryPlanNode, plan_id: Optional[DagId] = None) -> None:
@@ -354,5 +354,5 @@ class SqlQueryPlan(MetricFlowDag[SqlQueryPlanNode]):  # noqa: D
         )
 
     @property
-    def render_node(self) -> SqlQueryPlanNode:  # noqa: D
+    def render_node(self) -> SqlQueryPlanNode:  # noqa: D102
         return self._render_node

--- a/metricflow/sql/sql_table.py
+++ b/metricflow/sql/sql_table.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Optional, Tuple, Union
 
 
-class SqlTableType(Enum):  # noqa: D
+class SqlTableType(Enum):  # noqa: D101
     TABLE = "table"
     VIEW = "view"
 
@@ -20,7 +20,7 @@ class SqlTable:
     table_type: SqlTableType = SqlTableType.TABLE
 
     @staticmethod
-    def from_string(sql_str: str) -> SqlTable:  # noqa: D
+    def from_string(sql_str: str) -> SqlTable:  # noqa: D102
         sql_str_split = sql_str.split(".")
         if len(sql_str_split) == 2:
             return SqlTable(schema_name=sql_str_split[0], table_name=sql_str_split[1])

--- a/metricflow/sql_request/sql_request_attributes.py
+++ b/metricflow/sql_request/sql_request_attributes.py
@@ -12,5 +12,5 @@ class SqlRequestId:
 
     id_str: str
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return self.id_str

--- a/metricflow/telemetry/handlers/handlers.py
+++ b/metricflow/telemetry/handlers/handlers.py
@@ -37,14 +37,14 @@ class TelemetryHandler(ABC):
 class ToMemoryTelemetryHandler(TelemetryHandler):
     """Records telemetry events to memory for testing purposes."""
 
-    def __init__(self) -> None:  # noqa: D
+    def __init__(self) -> None:  # noqa: D107
         self._payloads: List[TelemetryPayload] = []
 
-    def _write_log(self, client_id: str, payload: PayloadType) -> None:  # noqa: D
+    def _write_log(self, client_id: str, payload: PayloadType) -> None:
         pass
 
     @property
-    def payloads(self) -> Sequence[TelemetryPayload]:  # noqa: D
+    def payloads(self) -> Sequence[TelemetryPayload]:  # noqa: D102
         return self._payloads
 
     def log(

--- a/metricflow/telemetry/handlers/python_log.py
+++ b/metricflow/telemetry/handlers/python_log.py
@@ -12,10 +12,10 @@ logger = logging.getLogger(__name__)
 class PythonLoggerTelemetryHandler(TelemetryHandler):
     """A telemetry client that logs data to the Python logger for debugging during tests."""
 
-    def __init__(self, logger_level: int) -> None:  # noqa: D
+    def __init__(self, logger_level: int) -> None:  # noqa: D107
         self._logger_level = logger_level
 
-    def _write_log(self, client_id: str, payload: PayloadType) -> None:  # noqa: D
+    def _write_log(self, client_id: str, payload: PayloadType) -> None:
         logger.log(
             level=self._logger_level,
             msg=f"Logging telemetry payload:\n{textwrap.indent(mf_pformat(payload), prefix='    ')}",

--- a/metricflow/telemetry/models.py
+++ b/metricflow/telemetry/models.py
@@ -45,7 +45,7 @@ class FunctionStartEvent(TelemetryEvent, FrozenBaseModel):
     function_name: str
 
     @staticmethod
-    def create(  # noqa: D
+    def create(  # noqa: D102
         event_time: datetime.datetime,
         level_name: str,
         invocation_id: str,
@@ -73,7 +73,7 @@ class FunctionEndEvent(TelemetryEvent, FrozenBaseModel):
     exception_trace: Optional[str] = None
 
     @staticmethod
-    def create(  # noqa: D
+    def create(  # noqa: D102
         event_time: datetime.datetime,
         level_name: str,
         invocation_id: str,

--- a/metricflow/telemetry/reporter.py
+++ b/metricflow/telemetry/reporter.py
@@ -61,7 +61,7 @@ class TelemetryReporter:
         id_str = "_".join([sys.platform, platform.release(), str(uuid.getnode())])
         return sha256(id_str.encode("utf-8")).hexdigest()
 
-    def add_python_log_handler(self) -> None:  # noqa: D
+    def add_python_log_handler(self) -> None:  # noqa: D102
         self._handlers.append(PythonLoggerTelemetryHandler(logger_level=logging.INFO))
 
     def add_test_handler(self) -> None:
@@ -73,7 +73,7 @@ class TelemetryReporter:
         """Used for testing only to verify that the handlers are getting the right events."""
         return self._test_handler
 
-    def log_function_start(  # noqa: D
+    def log_function_start(
         self,
         invocation_id: str,
         module_name: str,
@@ -96,7 +96,7 @@ class TelemetryReporter:
                     ),
                 )
 
-    def log_function_end(  # noqa: D
+    def log_function_end(
         self, invocation_id: str, module_name: str, function_name: str, runtime: float, exception_trace: Optional[str]
     ) -> None:
         """Similar to log_function_end, except adding the duration of the call and exception trace on error."""

--- a/metricflow/test/cli/test_cli.py
+++ b/metricflow/test/cli/test_cli.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 # TODO: Use snapshots to compare CLI output for all tests here.
 
 
-def test_query(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
+def test_query(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D103
     resp = cli_runner.run(query, args=["--metrics", "bookings", "--group-by", "metric_time"])
     # case insensitive matches are needed for snowflake due to the capitalization thing
     engine_is_snowflake = cli_runner.cli_context.sql_client.sql_engine_type is SqlEngine.SNOWFLAKE
@@ -46,21 +46,21 @@ def test_query(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
     assert resp.exit_code == 0
 
 
-def test_list_dimensions(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
+def test_list_dimensions(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D103
     resp = cli_runner.run(dimensions, args=["--metrics", "bookings"])
 
     assert "ds" in resp.output
     assert resp.exit_code == 0
 
 
-def test_list_metrics(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
+def test_list_metrics(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D103
     resp = cli_runner.run(metrics)
 
     assert "bookings_per_listing: listing__capacity_latest" in resp.output
     assert resp.exit_code == 0
 
 
-def test_get_dimension_values(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
+def test_get_dimension_values(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D103
     resp = cli_runner.run(dimension_values, args=["--metrics", "bookings", "--dimension", "booking__is_instant"])
 
     actual_output_lines = sorted(resp.output.split("\n"))
@@ -132,7 +132,7 @@ def test_validate_configs(cli_context: CLIContext) -> None:
         dummy_project.unlink()
 
 
-def test_health_checks(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
+def test_health_checks(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D103
     resp = cli_runner.run(health_checks)
 
     assert "SELECT 1: Success!" in resp.output
@@ -155,7 +155,7 @@ def test_tutorial_message(cli_runner: MetricFlowCliRunner) -> None:
     assert "dbt seed" in resp.output
 
 
-def test_list_entities(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
+def test_list_entities(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D103
     # Disabling capsys to resolve error "ValueError: I/O operation on closed file". Better solution TBD.
     resp = cli_runner.run(entities, args=["--metrics", "bookings"])
 
@@ -164,7 +164,7 @@ def test_list_entities(cli_runner: MetricFlowCliRunner) -> None:  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_saved_query(  # noqa: D
+def test_saved_query(  # noqa: D103
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,
     mf_test_configuration: MetricFlowTestConfiguration,
@@ -188,7 +188,7 @@ def test_saved_query(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_saved_query_with_where(  # noqa: D
+def test_saved_query_with_where(  # noqa: D103
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,
     mf_test_configuration: MetricFlowTestConfiguration,
@@ -219,7 +219,7 @@ def test_saved_query_with_where(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_saved_query_with_limit(  # noqa: D
+def test_saved_query_with_limit(  # noqa: D103
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,
     mf_test_configuration: MetricFlowTestConfiguration,
@@ -249,7 +249,7 @@ def test_saved_query_with_limit(  # noqa: D
     )
 
 
-def test_saved_query_explain(  # noqa: D
+def test_saved_query_explain(  # noqa: D103
     capsys: pytest.CaptureFixture,
     mf_test_configuration: MetricFlowTestConfiguration,
     cli_runner: MetricFlowCliRunner,
@@ -264,7 +264,7 @@ def test_saved_query_explain(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_saved_query_with_cumulative_metric(  # noqa: D
+def test_saved_query_with_cumulative_metric(  # noqa: D103
     request: FixtureRequest,
     capsys: pytest.CaptureFixture,
     mf_test_configuration: MetricFlowTestConfiguration,

--- a/metricflow/test/collection_helpers/test_merger.py
+++ b/metricflow/test/collection_helpers/test_merger.py
@@ -9,7 +9,7 @@ from metricflow.collection_helpers.merger import Mergeable
 
 
 @dataclass(frozen=True)
-class NumberTuple(Mergeable):  # noqa: D
+class NumberTuple(Mergeable):  # noqa: D101
     numbers: Tuple[int, ...] = field(default_factory=tuple)
 
     @override
@@ -22,7 +22,7 @@ class NumberTuple(Mergeable):  # noqa: D
         return NumberTuple()
 
 
-def test_merger() -> None:  # noqa: D
+def test_merger() -> None:  # noqa: D103
     items_to_merge: List[NumberTuple] = [
         NumberTuple(()),
         NumberTuple((1,)),

--- a/metricflow/test/collection_helpers/test_pretty_print.py
+++ b/metricflow/test/collection_helpers/test_pretty_print.py
@@ -13,20 +13,20 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
 logger = logging.getLogger(__name__)
 
 
-def test_literals() -> None:  # noqa: D
+def test_literals() -> None:  # noqa: D103
     assert mf_pformat(1) == "1"
     assert mf_pformat(1.0) == "1.0"
     assert mf_pformat("foo") == "'foo'"
 
 
-def test_containers() -> None:  # noqa: D
+def test_containers() -> None:  # noqa: D103
     assert mf_pformat((1,)) == "(1,)"
     assert mf_pformat(((1, 2), 3)) == "((1, 2), 3)"
     assert mf_pformat([[1, 2], 3]) == "[[1, 2], 3]"
     assert mf_pformat({"a": ((1, 2), 3), (1, 2): 3}) == "{'a': ((1, 2), 3), (1, 2): 3}"
 
 
-def test_classes() -> None:  # noqa: D
+def test_classes() -> None:  # noqa: D103
     assert "TimeDimensionSpec('metric_time', DAY)" == mf_pformat(
         MTD_SPEC_DAY,
         include_object_field_names=False,
@@ -125,13 +125,13 @@ def test_multi_line_key_value_dict_short_value() -> None:
     )
 
 
-def test_pydantic_model() -> None:  # noqa: D
+def test_pydantic_model() -> None:  # noqa: D103
     assert "PydanticDimension(name='foo', type=CATEGORICAL, is_partition=False)" == mf_pformat(
         PydanticDimension(name="foo", type=DimensionType.CATEGORICAL)
     )
 
 
-def test_pformat_many() -> None:  # noqa: D
+def test_pformat_many() -> None:  # noqa: D103
     result = mf_pformat_many("Example description:", obj_dict={"object_0": (1, 2, 3), "object_1": {4: 5}})
 
     assert (
@@ -150,7 +150,7 @@ def test_pformat_many() -> None:  # noqa: D
     )
 
 
-def test_pformat_many_with_raw_strings() -> None:  # noqa: D
+def test_pformat_many_with_raw_strings() -> None:  # noqa: D103
     result = mf_pformat_many("Example description:", obj_dict={"object_0": "foo\nbar"}, preserve_raw_strings=True)
 
     assert (
@@ -167,7 +167,7 @@ def test_pformat_many_with_raw_strings() -> None:  # noqa: D
     )
 
 
-def test_pformat_many_with_strings() -> None:  # noqa: D
+def test_pformat_many_with_strings() -> None:  # noqa: D103
     result = mf_pformat_many("Example description:", obj_dict={"object_0": "foo\nbar"})
     assert (
         textwrap.dedent(

--- a/metricflow/test/dataflow/builder/test_cyclic_join.py
+++ b/metricflow/test/dataflow/builder/test_cyclic_join.py
@@ -23,13 +23,13 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def cyclic_join_manifest_dataflow_plan_builder(  # noqa: D
+def cyclic_join_manifest_dataflow_plan_builder(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> DataflowPlanBuilder:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.CYCLIC_JOIN_MANIFEST].dataflow_plan_builder
 
 
-def test_cyclic_join(  # noqa: D
+def test_cyclic_join(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     cyclic_join_manifest_dataflow_plan_builder: DataflowPlanBuilder,

--- a/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
+++ b/metricflow/test/dataflow/builder/test_dataflow_plan_builder.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_plan(  # noqa: D
+def test_simple_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -65,7 +65,7 @@ def test_simple_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_primary_entity_dimension(  # noqa: D
+def test_primary_entity_dimension(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -98,7 +98,7 @@ def test_primary_entity_dimension(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_joined_plan(  # noqa: D
+def test_joined_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -135,7 +135,7 @@ def test_joined_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_order_by_plan(  # noqa: D
+def test_order_by_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -173,7 +173,7 @@ def test_order_by_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_limit_rows_plan(  # noqa: D
+def test_limit_rows_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -202,7 +202,7 @@ def test_limit_rows_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_multiple_metrics_plan(  # noqa: D
+def test_multiple_metrics_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -304,7 +304,7 @@ def test_multi_semantic_model_ratio_metrics_plan(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_multihop_join_plan(  # noqa: D
+def test_multihop_join_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     multihop_dataflow_plan_builder: DataflowPlanBuilder,
@@ -340,7 +340,7 @@ def test_multihop_join_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_where_constrained_plan(  # noqa: D
+def test_where_constrained_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
@@ -370,7 +370,7 @@ def test_where_constrained_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_where_constrained_plan_time_dimension(  # noqa: D
+def test_where_constrained_plan_time_dimension(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -399,7 +399,7 @@ def test_where_constrained_plan_time_dimension(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_where_constrained_with_common_linkable_plan(  # noqa: D
+def test_where_constrained_with_common_linkable_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
@@ -429,7 +429,7 @@ def test_where_constrained_with_common_linkable_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_multihop_join_plan_ambiguous_dim(  # noqa: D
+def test_multihop_join_plan_ambiguous_dim(
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
 ) -> None:
@@ -452,7 +452,7 @@ def test_multihop_join_plan_ambiguous_dim(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_cumulative_metric_with_window(  # noqa: D
+def test_cumulative_metric_with_window(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -481,7 +481,7 @@ def test_cumulative_metric_with_window(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_cumulative_metric_no_window_or_grain_with_metric_time(  # noqa: D
+def test_cumulative_metric_no_window_or_grain_with_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -509,7 +509,7 @@ def test_cumulative_metric_no_window_or_grain_with_metric_time(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_cumulative_metric_no_window_or_grain_without_metric_time(  # noqa: D
+def test_cumulative_metric_no_window_or_grain_without_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -537,7 +537,7 @@ def test_cumulative_metric_no_window_or_grain_without_metric_time(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_distinct_values_plan(  # noqa: D
+def test_distinct_values_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -568,7 +568,7 @@ def test_distinct_values_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_distinct_values_plan_with_join(  # noqa: D
+def test_distinct_values_plan_with_join(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -654,7 +654,7 @@ def test_measure_constraint_with_reused_measure_plan(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_common_semantic_model(  # noqa: D
+def test_common_semantic_model(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -685,7 +685,7 @@ def test_common_semantic_model(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_offset_window(  # noqa: D
+def test_derived_metric_offset_window(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -713,7 +713,7 @@ def test_derived_metric_offset_window(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_offset_to_grain(  # noqa: D
+def test_derived_metric_offset_to_grain(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -741,7 +741,7 @@ def test_derived_metric_offset_to_grain(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_offset_with_granularity(  # noqa: D
+def test_derived_metric_offset_with_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -768,7 +768,7 @@ def test_derived_metric_offset_with_granularity(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_offset_cumulative_metric(  # noqa: D
+def test_derived_offset_cumulative_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -794,7 +794,7 @@ def test_derived_offset_cumulative_metric(  # noqa: D
     )
 
 
-def test_join_to_time_spine_with_metric_time(  # noqa: D
+def test_join_to_time_spine_with_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -820,7 +820,7 @@ def test_join_to_time_spine_with_metric_time(  # noqa: D
     )
 
 
-def test_join_to_time_spine_derived_metric(  # noqa: D
+def test_join_to_time_spine_derived_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -846,7 +846,7 @@ def test_join_to_time_spine_derived_metric(  # noqa: D
     )
 
 
-def test_join_to_time_spine_with_non_metric_time(  # noqa: D
+def test_join_to_time_spine_with_non_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -874,7 +874,7 @@ def test_join_to_time_spine_with_non_metric_time(  # noqa: D
     )
 
 
-def test_dont_join_to_time_spine_if_no_time_dimension_requested(  # noqa: D
+def test_dont_join_to_time_spine_if_no_time_dimension_requested(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -897,7 +897,7 @@ def test_dont_join_to_time_spine_if_no_time_dimension_requested(  # noqa: D
     )
 
 
-def test_nested_derived_metric_with_outer_offset(  # noqa: D
+def test_nested_derived_metric_with_outer_offset(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -981,7 +981,7 @@ def test_min_max_only_time(
     )
 
 
-def test_metric_time_only(  # noqa: D
+def test_metric_time_only(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -1004,7 +1004,7 @@ def test_metric_time_only(  # noqa: D
     )
 
 
-def test_metric_time_quarter(  # noqa: D
+def test_metric_time_quarter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -1027,7 +1027,7 @@ def test_metric_time_quarter(  # noqa: D
     )
 
 
-def test_metric_time_with_other_dimensions(  # noqa: D
+def test_metric_time_with_other_dimensions(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -1056,7 +1056,7 @@ def test_metric_time_with_other_dimensions(  # noqa: D
     )
 
 
-def test_dimensions_with_time_constraint(  # noqa: D
+def test_dimensions_with_time_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,

--- a/metricflow/test/dataflow/builder/test_measure_additiveness.py
+++ b/metricflow/test/dataflow/builder/test_measure_additiveness.py
@@ -6,7 +6,7 @@ from metricflow.dataflow.builder.measure_additiveness import group_measure_specs
 from metricflow.specs.specs import MeasureSpec, NonAdditiveDimensionSpec
 
 
-def test_bucket_measure_specs_by_additiveness() -> None:  # noqa: D
+def test_bucket_measure_specs_by_additiveness() -> None:  # noqa: D103
     # Semi-additive Bucket 1
     measure_1 = MeasureSpec(
         element_name="measure_1",

--- a/metricflow/test/dataflow/builder/test_node_data_set.py
+++ b/metricflow/test/dataflow/builder/test_node_data_set.py
@@ -89,7 +89,7 @@ def test_no_parent_node_data_set(
     assert resolver.get_output_data_set(node).instance_set == data_set.instance_set
 
 
-def test_joined_node_data_set(  # noqa: D
+def test_joined_node_data_set(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],

--- a/metricflow/test/dataflow/builder/test_node_evaluator.py
+++ b/metricflow/test/dataflow/builder/test_node_evaluator.py
@@ -59,7 +59,7 @@ def make_multihop_node_evaluator(
     source_node_set: SourceNodeSet,
     semantic_manifest_lookup_with_multihop_links: SemanticManifestLookup,
     desired_linkable_specs: Sequence[LinkableInstanceSpec],
-) -> NodeEvaluatorForLinkableInstances:  # noqa: D
+) -> NodeEvaluatorForLinkableInstances:
     """Return a node evaluator using the nodes in multihop_semantic_model_name_to_nodes."""
     node_data_set_resolver: DataflowPlanNodeOutputDataSetResolver = DataflowPlanNodeOutputDataSetResolver(
         column_association_resolver=DunderColumnAssociationResolver(semantic_manifest_lookup_with_multihop_links),
@@ -92,7 +92,7 @@ def make_multihop_node_evaluator(
     )
 
 
-def test_node_evaluator_with_no_linkable_specs(  # noqa: D
+def test_node_evaluator_with_no_linkable_specs(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     node_evaluator: NodeEvaluatorForLinkableInstances,
 ) -> None:
@@ -107,7 +107,7 @@ def test_node_evaluator_with_no_linkable_specs(  # noqa: D
     )
 
 
-def test_node_evaluator_with_unjoinable_specs(  # noqa: D
+def test_node_evaluator_with_unjoinable_specs(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     node_evaluator: NodeEvaluatorForLinkableInstances,
 ) -> None:
@@ -137,7 +137,7 @@ def test_node_evaluator_with_unjoinable_specs(  # noqa: D
     )
 
 
-def test_node_evaluator_with_local_spec(  # noqa: D
+def test_node_evaluator_with_local_spec(
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     node_evaluator: NodeEvaluatorForLinkableInstances,
 ) -> None:
@@ -158,7 +158,7 @@ def test_node_evaluator_with_local_spec(  # noqa: D
     )
 
 
-def test_node_evaluator_with_local_spec_using_primary_entity(  # noqa: D
+def test_node_evaluator_with_local_spec_using_primary_entity(
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     node_evaluator: NodeEvaluatorForLinkableInstances,
 ) -> None:
@@ -189,7 +189,7 @@ def test_node_evaluator_with_local_spec_using_primary_entity(  # noqa: D
     )
 
 
-def test_node_evaluator_with_joined_spec(  # noqa: D
+def test_node_evaluator_with_joined_spec(
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     node_evaluator: NodeEvaluatorForLinkableInstances,
 ) -> None:
@@ -250,7 +250,7 @@ def test_node_evaluator_with_joined_spec(  # noqa: D
     )
 
 
-def test_node_evaluator_with_joined_spec_on_unique_id(  # noqa: D
+def test_node_evaluator_with_joined_spec_on_unique_id(
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     node_evaluator: NodeEvaluatorForLinkableInstances,
 ) -> None:
@@ -298,7 +298,7 @@ def test_node_evaluator_with_joined_spec_on_unique_id(  # noqa: D
     )
 
 
-def test_node_evaluator_with_multiple_joined_specs(  # noqa: D
+def test_node_evaluator_with_multiple_joined_specs(
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     node_evaluator: NodeEvaluatorForLinkableInstances,
 ) -> None:
@@ -369,7 +369,7 @@ def test_node_evaluator_with_multiple_joined_specs(  # noqa: D
     )
 
 
-def test_node_evaluator_with_multihop_joined_spec(  # noqa: D
+def test_node_evaluator_with_multihop_joined_spec(
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     partitioned_multi_hop_join_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> None:
@@ -444,7 +444,7 @@ def test_node_evaluator_with_multihop_joined_spec(  # noqa: D
     )
 
 
-def test_node_evaluator_with_partition_joined_spec(  # noqa: D
+def test_node_evaluator_with_partition_joined_spec(
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     node_evaluator: NodeEvaluatorForLinkableInstances,
 ) -> None:

--- a/metricflow/test/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
@@ -24,7 +24,7 @@ from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_plan_snapshot_text_equal
 
 
-def make_dataflow_plan(node: BaseOutput) -> DataflowPlan:  # noqa: D
+def make_dataflow_plan(node: BaseOutput) -> DataflowPlan:  # noqa: D103
     return DataflowPlan(
         sink_output_nodes=[WriteToResultDataframeNode(node)],
         plan_id=DagId.from_id_prefix(StaticIdPrefix.OPTIMIZED_DATAFLOW_PLAN_PREFIX),
@@ -32,7 +32,7 @@ def make_dataflow_plan(node: BaseOutput) -> DataflowPlan:  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_read_sql_source_combination(  # noqa: D
+def test_read_sql_source_combination(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
@@ -61,7 +61,7 @@ def test_read_sql_source_combination(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_filter_combination(  # noqa: D
+def test_filter_combination(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],

--- a/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
+++ b/metricflow/test/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
@@ -54,65 +54,65 @@ class ReadSqlSourceNodeCounter(DataflowPlanNodeVisitor[int]):
     def _sum_parents(self, node: DataflowPlanNode) -> int:
         return sum(parent_node.accept(self) for parent_node in node.parent_nodes)
 
-    def visit_source_node(self, node: ReadSqlSourceNode) -> int:  # noqa: D
+    def visit_source_node(self, node: ReadSqlSourceNode) -> int:  # noqa: D102
         return 1
 
-    def visit_join_to_base_output_node(self, node: JoinToBaseOutputNode) -> int:  # noqa: D
+    def visit_join_to_base_output_node(self, node: JoinToBaseOutputNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_aggregate_measures_node(self, node: AggregateMeasuresNode) -> int:  # noqa: D
+    def visit_aggregate_measures_node(self, node: AggregateMeasuresNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_compute_metrics_node(self, node: ComputeMetricsNode) -> int:  # noqa: D
+    def visit_compute_metrics_node(self, node: ComputeMetricsNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> int:  # noqa: D
+    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_where_constraint_node(self, node: WhereConstraintNode) -> int:  # noqa: D
+    def visit_where_constraint_node(self, node: WhereConstraintNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> int:  # noqa: D
+    def visit_write_to_result_dataframe_node(self, node: WriteToResultDataframeNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> int:  # noqa: D
+    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_pass_elements_filter_node(self, node: FilterElementsNode) -> int:  # noqa: D
+    def visit_pass_elements_filter_node(self, node: FilterElementsNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_combine_aggregated_outputs_node(self, node: CombineAggregatedOutputsNode) -> int:  # noqa: D
+    def visit_combine_aggregated_outputs_node(self, node: CombineAggregatedOutputsNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_constrain_time_range_node(self, node: ConstrainTimeRangeNode) -> int:  # noqa: D
+    def visit_constrain_time_range_node(self, node: ConstrainTimeRangeNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_join_over_time_range_node(self, node: JoinOverTimeRangeNode) -> int:  # noqa: D
+    def visit_join_over_time_range_node(self, node: JoinOverTimeRangeNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_semi_additive_join_node(self, node: SemiAdditiveJoinNode) -> int:  # noqa: D
+    def visit_semi_additive_join_node(self, node: SemiAdditiveJoinNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_metric_time_dimension_transform_node(self, node: MetricTimeDimensionTransformNode) -> int:  # noqa: D
+    def visit_metric_time_dimension_transform_node(self, node: MetricTimeDimensionTransformNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> int:  # noqa: D
+    def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_min_max_node(self, node: MinMaxNode) -> int:  # noqa: D
+    def visit_min_max_node(self, node: MinMaxNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
     def visit_add_generated_uuid_column_node(self, node: AddGeneratedUuidColumnNode) -> int:  # noqa :D
         return self._sum_parents(node)
 
-    def visit_join_conversion_events_node(self, node: JoinConversionEventsNode) -> int:  # noqa: D
+    def visit_join_conversion_events_node(self, node: JoinConversionEventsNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def count_source_nodes(self, dataflow_plan: DataflowPlan) -> int:  # noqa: D
+    def count_source_nodes(self, dataflow_plan: DataflowPlan) -> int:  # noqa: D102
         return dataflow_plan.sink_output_node.accept(self)
 
 
-def check_optimization(  # noqa: D
+def check_optimization(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -157,7 +157,7 @@ def check_optimization(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_2_metrics_from_1_semantic_model(  # noqa: D
+def test_2_metrics_from_1_semantic_model(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -183,7 +183,7 @@ def test_2_metrics_from_1_semantic_model(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_2_metrics_from_2_semantic_models(  # noqa: D
+def test_2_metrics_from_2_semantic_models(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -203,7 +203,7 @@ def test_2_metrics_from_2_semantic_models(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_3_metrics_from_2_semantic_models(  # noqa: D
+def test_3_metrics_from_2_semantic_models(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -227,7 +227,7 @@ def test_3_metrics_from_2_semantic_models(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_constrained_metric_not_combined(  # noqa: D
+def test_constrained_metric_not_combined(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
@@ -254,7 +254,7 @@ def test_constrained_metric_not_combined(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric(  # noqa: D
+def test_derived_metric(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -277,7 +277,7 @@ def test_derived_metric(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_nested_derived_metric(  # noqa: D
+def test_nested_derived_metric(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -301,7 +301,7 @@ def test_nested_derived_metric(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_with_non_derived_metric(  # noqa: D
+def test_derived_metric_with_non_derived_metric(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -333,7 +333,7 @@ def test_derived_metric_with_non_derived_metric(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_2_ratio_metrics_from_1_semantic_model(  # noqa: D
+def test_2_ratio_metrics_from_1_semantic_model(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -356,7 +356,7 @@ def test_2_ratio_metrics_from_1_semantic_model(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_duplicate_measures(  # noqa: D
+def test_duplicate_measures(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,

--- a/metricflow/test/dataflow/test_sql_column.py
+++ b/metricflow/test/dataflow/test_sql_column.py
@@ -4,7 +4,7 @@ from metricflow.sql.sql_column import SqlColumn
 from metricflow.sql.sql_table import SqlTable
 
 
-def test_sql_column() -> None:  # noqa: D
+def test_sql_column() -> None:  # noqa: D103
     sql_column = SqlColumn(
         table=SqlTable(db_name="test_db", schema_name="test_schema", table_name="test_table"), column_name="test_column"
     )

--- a/metricflow/test/dataflow/test_sql_table.py
+++ b/metricflow/test/dataflow/test_sql_table.py
@@ -5,20 +5,20 @@ import pytest
 from metricflow.sql.sql_table import SqlTable
 
 
-def test_sql_table() -> None:  # noqa: D
+def test_sql_table() -> None:  # noqa: D103
     sql_table = SqlTable(schema_name="foo", table_name="bar")
 
     assert sql_table.sql == "foo.bar"
     assert SqlTable.from_string("foo.bar") == sql_table
 
 
-def test_sql_table_with_db() -> None:  # noqa: D
+def test_sql_table_with_db() -> None:  # noqa: D103
     sql_table = SqlTable(db_name="db", schema_name="foo", table_name="bar")
 
     assert sql_table.sql == "db.foo.bar"
     assert SqlTable.from_string("db.foo.bar") == sql_table
 
 
-def test_invalid_sql_table() -> None:  # noqa: D
+def test_invalid_sql_table() -> None:  # noqa: D103
     with pytest.raises(RuntimeError):
         SqlTable.from_string("foo")

--- a/metricflow/test/dataset/test_convert_semantic_model.py
+++ b/metricflow/test/dataset/test_convert_semantic_model.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.sql_engine_snapshot
-def test_convert_table_semantic_model_without_measures(  # noqa: D
+def test_convert_table_semantic_model_without_measures(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -45,7 +45,7 @@ def test_convert_table_semantic_model_without_measures(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_convert_table_semantic_model_with_measures(  # noqa: D
+def test_convert_table_semantic_model_with_measures(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -80,7 +80,7 @@ def test_convert_table_semantic_model_with_measures(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_convert_query_semantic_model(  # noqa: D
+def test_convert_query_semantic_model(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,

--- a/metricflow/test/execution/noop_task.py
+++ b/metricflow/test/execution/noop_task.py
@@ -21,7 +21,7 @@ class NoOpExecutionPlanTask(ExecutionPlanTask):
     # Error to return if should_error is set.
     EXAMPLE_ERROR = TaskExecutionError("Expected Error")
 
-    def __init__(self, parent_tasks: Sequence[ExecutionPlanTask] = (), should_error: bool = False) -> None:  # noqa: D
+    def __init__(self, parent_tasks: Sequence[ExecutionPlanTask] = (), should_error: bool = False) -> None:
         """Constructor.
 
         Args:
@@ -32,14 +32,14 @@ class NoOpExecutionPlanTask(ExecutionPlanTask):
         super().__init__(task_id=self.create_unique_id(), parent_nodes=list(parent_tasks))
 
     @property
-    def description(self) -> str:  # noqa: D
+    def description(self) -> str:  # noqa: D102
         return "Dummy No-Op"
 
     @classmethod
-    def id_prefix(cls) -> IdPrefix:  # noqa: D
+    def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.EXEC_NODE_NOOP
 
-    def execute(self) -> TaskExecutionResult:  # noqa: D
+    def execute(self) -> TaskExecutionResult:  # noqa: D102
         start_time = time.time()
         time.sleep(0.01)
         end_time = time.time()
@@ -48,5 +48,5 @@ class NoOpExecutionPlanTask(ExecutionPlanTask):
         )
 
     @property
-    def sql_query(self) -> Optional[SqlQuery]:  # noqa: D
+    def sql_query(self) -> Optional[SqlQuery]:  # noqa: D102
         return None

--- a/metricflow/test/execution/test_tasks.py
+++ b/metricflow/test/execution/test_tasks.py
@@ -17,7 +17,7 @@ from metricflow.test.compare_df import assert_dataframes_equal
 from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 
 
-def test_read_sql_task(sql_client: SqlClient) -> None:  # noqa: D
+def test_read_sql_task(sql_client: SqlClient) -> None:  # noqa: D103
     task = SelectSqlQueryToDataFrameTask(sql_client, "SELECT 1 AS foo", SqlBindParameters())
     execution_plan = ExecutionPlan(leaf_tasks=[task], dag_id=DagId.from_str("plan0"))
 
@@ -37,7 +37,9 @@ def test_read_sql_task(sql_client: SqlClient) -> None:  # noqa: D
     )
 
 
-def test_write_table_task(mf_test_configuration: MetricFlowTestConfiguration, sql_client: SqlClient) -> None:  # noqa: D
+def test_write_table_task(  # noqa: D103
+    mf_test_configuration: MetricFlowTestConfiguration, sql_client: SqlClient
+) -> None:  # noqa: D103
     output_table = SqlTable(schema_name=mf_test_configuration.mf_system_schema, table_name=f"test_table_{random_id()}")
     task = SelectSqlQueryToTableTask(
         sql_client=sql_client,

--- a/metricflow/test/fixtures/cli_fixtures.py
+++ b/metricflow/test/fixtures/cli_fixtures.py
@@ -76,7 +76,7 @@ class FakeCLIContext(CLIContext):
 
 
 @pytest.fixture
-def cli_context(  # noqa: D
+def cli_context(  # noqa: D103
     sql_client: SqlClient,
     simple_semantic_manifest: SemanticManifest,
     create_source_tables: bool,
@@ -101,12 +101,12 @@ def cli_context(  # noqa: D
 class MetricFlowCliRunner(CliRunner):
     """Custom CliRunner class to handle passing context."""
 
-    def __init__(self, cli_context: CLIContext, project_path: str) -> None:  # noqa: D
+    def __init__(self, cli_context: CLIContext, project_path: str) -> None:  # noqa: D107
         self.cli_context = cli_context
         self.project_path = project_path
         super().__init__()
 
-    def run(self, cli: click.BaseCommand, args: Optional[Sequence[str]] = None) -> Result:  # noqa: D
+    def run(self, cli: click.BaseCommand, args: Optional[Sequence[str]] = None) -> Result:  # noqa: D102
         current_dir = os.getcwd()
         os.chdir(self.project_path)
         result = super().invoke(cli, args, obj=self.cli_context)
@@ -115,5 +115,5 @@ class MetricFlowCliRunner(CliRunner):
 
 
 @pytest.fixture
-def cli_runner(cli_context: CLIContext) -> MetricFlowCliRunner:  # noqa: D
+def cli_runner(cli_context: CLIContext) -> MetricFlowCliRunner:  # noqa: D103
     return MetricFlowCliRunner(cli_context=cli_context, project_path=dbt_project_dir())

--- a/metricflow/test/fixtures/dataflow_fixtures.py
+++ b/metricflow/test/fixtures/dataflow_fixtures.py
@@ -21,14 +21,14 @@ Using 'session' scope can result in other 'session' scope fixtures causing ID co
 
 
 @pytest.fixture(scope="session")
-def column_association_resolver(  # noqa: D
+def column_association_resolver(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> ColumnAssociationResolver:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].column_association_resolver
 
 
 @pytest.fixture
-def dataflow_plan_builder(  # noqa: D
+def dataflow_plan_builder(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> DataflowPlanBuilder:
     # Scope needs to be function as the DataflowPlanBuilder contains state.
@@ -36,14 +36,14 @@ def dataflow_plan_builder(  # noqa: D
 
 
 @pytest.fixture(scope="session")
-def query_parser(  # noqa: D
+def query_parser(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> MetricFlowQueryParser:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].query_parser
 
 
 @pytest.fixture
-def extended_date_dataflow_plan_builder(  # noqa: D
+def extended_date_dataflow_plan_builder(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> DataflowPlanBuilder:
     # Scope needs to be function as the DataflowPlanBuilder contains state.
@@ -51,7 +51,7 @@ def extended_date_dataflow_plan_builder(  # noqa: D
 
 
 @pytest.fixture
-def multihop_dataflow_plan_builder(  # noqa: D
+def multihop_dataflow_plan_builder(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> DataflowPlanBuilder:
     # Scope needs to be function as the DataflowPlanBuilder contains state.
@@ -61,14 +61,14 @@ def multihop_dataflow_plan_builder(  # noqa: D
 
 
 @pytest.fixture(scope="session")
-def scd_column_association_resolver(  # noqa: D
+def scd_column_association_resolver(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> ColumnAssociationResolver:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].column_association_resolver
 
 
 @pytest.fixture
-def scd_dataflow_plan_builder(  # noqa: D
+def scd_dataflow_plan_builder(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> DataflowPlanBuilder:
     # Scope needs to be function as the DataflowPlanBuilder contains state.
@@ -76,14 +76,14 @@ def scd_dataflow_plan_builder(  # noqa: D
 
 
 @pytest.fixture(scope="session")
-def scd_query_parser(  # noqa: D
+def scd_query_parser(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> MetricFlowQueryParser:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].query_parser
 
 
 @pytest.fixture(scope="session")
-def time_spine_source(  # noqa: D
+def time_spine_source(  # noqa: D103
     sql_client: SqlClient, mf_test_configuration: MetricFlowTestConfiguration  # noqa: F811
 ) -> TimeSpineSource:
     return TimeSpineSource(schema_name=mf_test_configuration.mf_source_schema, table_name="mf_time_spine")

--- a/metricflow/test/fixtures/manifest_fixtures.py
+++ b/metricflow/test/fixtures/manifest_fixtures.py
@@ -89,11 +89,11 @@ class SemanticManifestSetup(Enum):
     )
 
     @property
-    def id_number_space(self) -> IdNumberSpace:  # noqa: D
+    def id_number_space(self) -> IdNumberSpace:  # noqa: D102
         return self.value.id_number_space
 
     @property
-    def semantic_manifest_name(self) -> str:  # noqa: D
+    def semantic_manifest_name(self) -> str:  # noqa: D102
         return self.value.semantic_manifest_name
 
 
@@ -114,7 +114,7 @@ class MetricFlowEngineTestFixture:
     _node_output_resolver: DataflowPlanNodeOutputDataSetResolver
 
     @staticmethod
-    def from_parameters(  # noqa: D
+    def from_parameters(  # noqa: D102
         sql_client: SqlClient, semantic_manifest: PydanticSemanticManifest
     ) -> MetricFlowEngineTestFixture:
         semantic_manifest_lookup = SemanticManifestLookup(semantic_manifest)
@@ -257,21 +257,21 @@ def template_mapping(mf_test_configuration: MetricFlowTestConfiguration) -> Dict
 
 
 @pytest.fixture(scope="session")
-def simple_semantic_manifest_lookup_non_ds(  # noqa: D
+def simple_semantic_manifest_lookup_non_ds(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> SemanticManifestLookup:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.NON_SM_MANIFEST].semantic_manifest_lookup
 
 
 @pytest.fixture(scope="session")
-def simple_semantic_manifest_lookup(  # noqa: D
+def simple_semantic_manifest_lookup(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> SemanticManifestLookup:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].semantic_manifest_lookup
 
 
 @pytest.fixture(scope="session")
-def partitioned_multi_hop_join_semantic_manifest_lookup(  # noqa: D
+def partitioned_multi_hop_join_semantic_manifest_lookup(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> SemanticManifestLookup:
     return mf_engine_test_fixture_mapping[
@@ -280,7 +280,7 @@ def partitioned_multi_hop_join_semantic_manifest_lookup(  # noqa: D
 
 
 @pytest.fixture(scope="session")
-def multi_hop_join_semantic_manifest_lookup(  # noqa: D
+def multi_hop_join_semantic_manifest_lookup(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> SemanticManifestLookup:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.MULTI_HOP_JOIN_MANIFEST].semantic_manifest_lookup
@@ -295,7 +295,7 @@ def simple_semantic_manifest(
 
 
 @pytest.fixture(scope="session")
-def extended_date_semantic_manifest_lookup(  # noqa: D
+def extended_date_semantic_manifest_lookup(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> SemanticManifestLookup:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.EXTENDED_DATE_MANIFEST].semantic_manifest_lookup
@@ -334,21 +334,21 @@ def ambiguous_resolution_manifest(
 
 
 @pytest.fixture(scope="session")
-def ambiguous_resolution_manifest_lookup(  # noqa: D
+def ambiguous_resolution_manifest_lookup(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> SemanticManifestLookup:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.AMBIGUOUS_RESOLUTION_MANIFEST].semantic_manifest_lookup
 
 
 @pytest.fixture(scope="session")
-def simple_multi_hop_join_manifest(  # noqa: D
+def simple_multi_hop_join_manifest(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> PydanticSemanticManifest:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MULTI_HOP_JOIN_MANIFEST].semantic_manifest
 
 
 @pytest.fixture(scope="session")
-def simple_multi_hop_join_manifest_lookup(  # noqa: D
+def simple_multi_hop_join_manifest_lookup(
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> SemanticManifestLookup:
     """Manifest used to test ambiguous resolution of group-by-items."""

--- a/metricflow/test/fixtures/setup_fixtures.py
+++ b/metricflow/test/fixtures/setup_fixtures.py
@@ -56,11 +56,11 @@ OVERWRITE_SNAPSHOTS_CLI_FLAG = "--overwrite-snapshots"
 USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG = "--use-persistent-source-schema"
 
 
-def add_display_snapshots_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D
+def add_display_snapshots_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D103
     parser.addoption(DISPLAY_SNAPSHOTS_CLI_FLAG, action="store_true", help="Displays snapshots in a browser if set")
 
 
-def add_overwrite_snapshots_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D
+def add_overwrite_snapshots_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D103
     parser.addoption(
         OVERWRITE_SNAPSHOTS_CLI_FLAG,
         action="store_true",
@@ -68,7 +68,7 @@ def add_overwrite_snapshots_cli_flag(parser: _pytest.config.argparsing.Parser) -
     )
 
 
-def add_display_graphs_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D
+def add_display_graphs_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D103
     parser.addoption(
         DISPLAY_GRAPHS_CLI_FLAG,
         action="store_true",
@@ -76,7 +76,7 @@ def add_display_graphs_cli_flag(parser: _pytest.config.argparsing.Parser) -> Non
     )
 
 
-def add_use_persistent_source_schema_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D
+def add_use_persistent_source_schema_cli_flag(parser: _pytest.config.argparsing.Parser) -> None:  # noqa: D103
     parser.addoption(
         USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG,
         action="store_true",
@@ -116,7 +116,7 @@ def check_sql_engine_snapshot_marker(request: FixtureRequest) -> None:
 
 
 @pytest.fixture(scope="session")
-def mf_test_configuration(  # noqa: D
+def mf_test_configuration(  # noqa: D103
     request: FixtureRequest,
     disable_sql_alchemy_deprecation_warning: None,
     source_table_snapshot_repository: SqlTableSnapshotRepository,
@@ -203,7 +203,7 @@ def dbt_project_dir() -> str:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def warn_user_about_slow_tests_without_parallelism(  # noqa: D
+def warn_user_about_slow_tests_without_parallelism(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:

--- a/metricflow/test/fixtures/sql_clients/base_sql_client_implementation.py
+++ b/metricflow/test/fixtures/sql_clients/base_sql_client_implementation.py
@@ -61,7 +61,7 @@ class BaseSqlClientImplementation(ABC, SqlClient):
         logger.info(f"Finished running the query in {stop - start:.2f}s with {df.shape[0]} row(s) returned")
         return df
 
-    def execute(  # noqa: D
+    def execute(  # noqa: D102
         self,
         stmt: str,
         sql_bind_parameters: SqlBindParameters = SqlBindParameters(),
@@ -123,7 +123,7 @@ class BaseSqlClientImplementation(ABC, SqlClient):
         pass
 
     @abstractmethod
-    def create_table_from_dataframe(  # noqa: D
+    def create_table_from_dataframe(  # noqa: D102
         self,
         sql_table: SqlTable,
         df: pd.DataFrame,
@@ -131,13 +131,13 @@ class BaseSqlClientImplementation(ABC, SqlClient):
     ) -> None:
         pass
 
-    def create_schema(self, schema_name: str) -> None:  # noqa: D
+    def create_schema(self, schema_name: str) -> None:  # noqa: D102
         self.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
 
-    def drop_schema(self, schema_name: str, cascade: bool = True) -> None:  # noqa: D
+    def drop_schema(self, schema_name: str, cascade: bool = True) -> None:  # noqa: D102
         self.execute(f"DROP SCHEMA IF EXISTS {schema_name}{' CASCADE' if cascade else ''}")
 
-    def close(self) -> None:  # noqa: D
+    def close(self) -> None:  # noqa: D102
         pass
 
     def render_bind_parameter_key(self, bind_parameter_key: str) -> str:

--- a/metricflow/test/fixtures/sql_clients/ddl_sql_client.py
+++ b/metricflow/test/fixtures/sql_clients/ddl_sql_client.py
@@ -42,6 +42,6 @@ class SqlClientWithDDLMethods(SqlClient, Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def drop_schema(self, schema_name: str, cascade: bool) -> None:  # noqa: D
+    def drop_schema(self, schema_name: str, cascade: bool) -> None:
         """Drop the given schema if it exists. If cascade is set, drop the tables in the schema first."""
         raise NotImplementedError

--- a/metricflow/test/fixtures/sql_clients/sqlalchemy_dialect.py
+++ b/metricflow/test/fixtures/sql_clients/sqlalchemy_dialect.py
@@ -19,12 +19,12 @@ logger = logging.getLogger(__name__)
 class SqlAlchemySqlClient(BaseSqlClientImplementation, ABC):
     """Base class for to create DBClients for engines supported by SQLAlchemy."""
 
-    def __init__(self, engine: sqlalchemy.engine.Engine) -> None:  # noqa: D
+    def __init__(self, engine: sqlalchemy.engine.Engine) -> None:  # noqa: D107
         self._engine = engine
         super().__init__()
 
     @staticmethod
-    def build_engine_url(  # noqa: D
+    def build_engine_url(  # noqa: D102
         dialect: str,
         database: str,
         username: str,
@@ -45,7 +45,7 @@ class SqlAlchemySqlClient(BaseSqlClientImplementation, ABC):
         )
 
     @staticmethod
-    def create_engine(  # noqa: D
+    def create_engine(  # noqa: D102
         dialect: str,
         port: int,
         database: str,
@@ -102,12 +102,12 @@ class SqlAlchemySqlClient(BaseSqlClientImplementation, ABC):
         with self._engine_connection(self._engine) as conn:
             conn.execute(sqlalchemy.text(stmt), bind_params.param_dict)
 
-    def _engine_specific_dry_run_implementation(self, stmt: str, bind_params: SqlBindParameters) -> None:  # noqa: D
+    def _engine_specific_dry_run_implementation(self, stmt: str, bind_params: SqlBindParameters) -> None:
         with self._engine_connection(self._engine) as conn:
             s = "EXPLAIN " + stmt
             conn.execute(sqlalchemy.text(s), bind_params.param_dict)
 
-    def create_table_from_dataframe(  # noqa: D
+    def create_table_from_dataframe(  # noqa: D102
         self, sql_table: SqlTable, df: pd.DataFrame, chunk_size: Optional[int] = None
     ) -> None:
         logger.info(f"Creating table '{sql_table.sql}' from a DataFrame with {df.shape[0]} row(s)")

--- a/metricflow/test/fixtures/sql_fixtures.py
+++ b/metricflow/test/fixtures/sql_fixtures.py
@@ -10,26 +10,26 @@ from metricflow.test.fixtures.manifest_fixtures import MetricFlowEngineTestFixtu
 
 
 @pytest.fixture
-def default_sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D
+def default_sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
     return DefaultSqlQueryPlanRenderer()
 
 
 @pytest.fixture(scope="session")
-def dataflow_to_sql_converter(  # noqa: D
+def dataflow_to_sql_converter(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> DataflowToSqlQueryPlanConverter:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].dataflow_to_sql_converter
 
 
 @pytest.fixture(scope="session")
-def extended_date_dataflow_to_sql_converter(  # noqa: D
+def extended_date_dataflow_to_sql_converter(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> DataflowToSqlQueryPlanConverter:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.EXTENDED_DATE_MANIFEST].dataflow_to_sql_converter
 
 
 @pytest.fixture(scope="session")
-def multihop_dataflow_to_sql_converter(  # noqa: D
+def multihop_dataflow_to_sql_converter(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> DataflowToSqlQueryPlanConverter:
     return mf_engine_test_fixture_mapping[
@@ -38,7 +38,7 @@ def multihop_dataflow_to_sql_converter(  # noqa: D
 
 
 @pytest.fixture(scope="session")
-def scd_dataflow_to_sql_converter(  # noqa: D
+def scd_dataflow_to_sql_converter(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture]
 ) -> DataflowToSqlQueryPlanConverter:
     return mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].dataflow_to_sql_converter

--- a/metricflow/test/fixtures/table_fixtures.py
+++ b/metricflow/test/fixtures/table_fixtures.py
@@ -25,7 +25,7 @@ CONFIGURED_SOURCE_TABLE_SNAPSHOT_REPOSITORY = SqlTableSnapshotRepository(
 
 
 @pytest.fixture(scope="session")
-def source_table_snapshot_repository() -> SqlTableSnapshotRepository:  # noqa: D
+def source_table_snapshot_repository() -> SqlTableSnapshotRepository:  # noqa: D103
     return CONFIGURED_SOURCE_TABLE_SNAPSHOT_REPOSITORY
 
 

--- a/metricflow/test/generate_snapshots.py
+++ b/metricflow/test/generate_snapshots.py
@@ -36,6 +36,7 @@ export MF_TEST_ENGINE_CREDENTIALS=$(cat <<EOF
 EOF
 )
 """
+
 from __future__ import annotations
 
 import logging
@@ -55,18 +56,18 @@ logger = logging.getLogger(__name__)
 TEST_DIRECTORY = "metricflow/test"
 
 
-class MetricFlowTestCredentialSet(FrozenBaseModel):  # noqa: D
+class MetricFlowTestCredentialSet(FrozenBaseModel):  # noqa: D101
     engine_url: Optional[str]
     engine_password: Optional[str]
 
 
 @dataclass(frozen=True)
-class MetricFlowTestConfiguration:  # noqa: D
+class MetricFlowTestConfiguration:  # noqa: D101
     engine: SqlEngine
     credential_set: MetricFlowTestCredentialSet
 
 
-class MetricFlowTestCredentialSetForAllEngines(FrozenBaseModel):  # noqa: D
+class MetricFlowTestCredentialSetForAllEngines(FrozenBaseModel):  # noqa: D101
     duck_db: MetricFlowTestCredentialSet
     redshift: MetricFlowTestCredentialSet
     snowflake: MetricFlowTestCredentialSet
@@ -76,7 +77,7 @@ class MetricFlowTestCredentialSetForAllEngines(FrozenBaseModel):  # noqa: D
     trino: MetricFlowTestCredentialSet
 
     @property
-    def as_configurations(self) -> Sequence[MetricFlowTestConfiguration]:  # noqa: D
+    def as_configurations(self) -> Sequence[MetricFlowTestConfiguration]:  # noqa: D102
         return (
             MetricFlowTestConfiguration(
                 engine=SqlEngine.DUCKDB,
@@ -109,7 +110,7 @@ class MetricFlowTestCredentialSetForAllEngines(FrozenBaseModel):  # noqa: D
         )
 
 
-def run_command(command: str) -> None:  # noqa: D
+def run_command(command: str) -> None:  # noqa: D103
     logger.info(f"Running command {command}")
     return_code = os.system(command)
     if return_code != 0:
@@ -134,7 +135,7 @@ def set_engine_env_variables(test_configuration: MetricFlowTestConfiguration) ->
         os.environ["MF_SQL_ENGINE_PASSWORD"] = test_configuration.credential_set.engine_password
 
 
-def run_tests(test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D
+def run_tests(test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D103
     set_engine_env_variables(test_configuration)
 
     if test_configuration.engine is SqlEngine.DUCKDB:
@@ -165,7 +166,7 @@ def run_tests(test_configuration: MetricFlowTestConfiguration) -> None:  # noqa:
         assert_values_exhausted(test_configuration.engine)
 
 
-def run_cli(function_to_run: Callable) -> None:  # noqa: D
+def run_cli(function_to_run: Callable) -> None:  # noqa: D103
     # Setup logging.
     dev_format = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d [%(threadName)s] - %(message)s"
     logging.basicConfig(level=logging.INFO, format=dev_format)

--- a/metricflow/test/inference/context/test_snowflake.py
+++ b/metricflow/test/inference/context/test_snowflake.py
@@ -16,7 +16,7 @@ from metricflow.sql.sql_column import SqlColumn
 from metricflow.sql.sql_table import SqlTable
 
 
-def test_column_type_conversion() -> None:  # noqa: D
+def test_column_type_conversion() -> None:  # noqa: D103
     ctx_provider = SnowflakeInferenceContextProvider(client=MagicMock(), tables=[])
 
     # known snowflake types

--- a/metricflow/test/inference/renderer/test_config_file.py
+++ b/metricflow/test/inference/renderer/test_config_file.py
@@ -1,4 +1,5 @@
 """These tests rely on the pytest tmp_path factory fixture."""
+
 from __future__ import annotations
 
 import os
@@ -14,12 +15,12 @@ from metricflow.sql.sql_column import SqlColumn
 yaml = YAML()
 
 
-def test_no_overwrite_with_existing_dir(tmpdir: Path) -> None:  # noqa: D
+def test_no_overwrite_with_existing_dir(tmpdir: Path) -> None:  # noqa: D103
     with pytest.raises(ValueError):
         ConfigFileRenderer(tmpdir, False)
 
 
-def test_dir_path_is_file(tmpdir: Path) -> None:  # noqa: D
+def test_dir_path_is_file(tmpdir: Path) -> None:  # noqa: D103
     file_path = os.path.join(tmpdir, "file.txt")
     with open(file_path, "w") as f:
         f.write("file contents!")
@@ -28,7 +29,7 @@ def test_dir_path_is_file(tmpdir: Path) -> None:  # noqa: D
         ConfigFileRenderer(file_path, False)
 
 
-def test_render_configs(tmpdir: Path) -> None:  # noqa: D
+def test_render_configs(tmpdir: Path) -> None:  # noqa: D103
     inference_results = [
         InferenceResult(
             column=SqlColumn.from_string("db.schema.test_table.id"),

--- a/metricflow/test/inference/rule/test_defaults.py
+++ b/metricflow/test/inference/rule/test_defaults.py
@@ -12,7 +12,7 @@ from metricflow.sql.sql_column import SqlColumn
 from metricflow.sql.sql_table import SqlTable
 
 
-def get_column_properties(column_str: str, type: InferenceColumnType, unique: bool) -> ColumnProperties:  # noqa: D
+def get_column_properties(column_str: str, type: InferenceColumnType, unique: bool) -> ColumnProperties:  # noqa: D103
     return ColumnProperties(
         column=SqlColumn.from_string(column_str),
         type=type,
@@ -25,7 +25,7 @@ def get_column_properties(column_str: str, type: InferenceColumnType, unique: bo
     )
 
 
-def test_any_entity_by_name_matcher() -> None:  # noqa: D
+def test_any_entity_by_name_matcher() -> None:  # noqa: D103
     assert defaults.AnyEntityByNameRule().match_column(
         get_column_properties("db.schema.table.id", InferenceColumnType.INTEGER, True)
     )
@@ -43,7 +43,7 @@ def test_any_entity_by_name_matcher() -> None:  # noqa: D
     )
 
 
-def test_primary_entity_by_name_matcher() -> None:  # noqa: D
+def test_primary_entity_by_name_matcher() -> None:  # noqa: D103
     assert defaults.PrimaryEntityByNameRule().match_column(
         get_column_properties("db.schema.table.id", InferenceColumnType.INTEGER, True)
     )
@@ -70,7 +70,7 @@ def test_primary_entity_by_name_matcher() -> None:  # noqa: D
     )
 
 
-def test_unique_entity_by_distinct_count_matcher() -> None:  # noqa: D
+def test_unique_entity_by_distinct_count_matcher() -> None:  # noqa: D103
     assert defaults.UniqueEntityByDistinctCountRule().match_column(
         get_column_properties("db.schema.table.unique_id", InferenceColumnType.INTEGER, True)
     )
@@ -79,7 +79,7 @@ def test_unique_entity_by_distinct_count_matcher() -> None:  # noqa: D
     )
 
 
-def test_time_dimension_by_time_type_matcher() -> None:  # noqa: D
+def test_time_dimension_by_time_type_matcher() -> None:  # noqa: D103
     assert defaults.TimeDimensionByTimeTypeRule().match_column(
         get_column_properties("db.schema.table.time", InferenceColumnType.DATETIME, True)
     )
@@ -101,7 +101,7 @@ def test_time_dimension_by_time_type_matcher() -> None:  # noqa: D
     )
 
 
-def test_primary_time_dimension_by_name_matcher() -> None:  # noqa: D
+def test_primary_time_dimension_by_name_matcher() -> None:  # noqa: D103
     assert defaults.PrimaryTimeDimensionByNameRule().match_column(
         get_column_properties("db.schema.table.ds", InferenceColumnType.DATETIME, True)
     )
@@ -116,7 +116,7 @@ def test_primary_time_dimension_by_name_matcher() -> None:  # noqa: D
     )
 
 
-def test_primary_time_dimension_if_only_time_rule() -> None:  # noqa: D
+def test_primary_time_dimension_if_only_time_rule() -> None:  # noqa: D103
     table = SqlTable.from_string("db.schema.table")
     single_time_col_warehouse = DataWarehouseInferenceContext(
         table_props=[
@@ -150,7 +150,7 @@ def test_primary_time_dimension_if_only_time_rule() -> None:  # noqa: D
     assert len(many_time_col_signals) == 0
 
 
-def test_categorical_dimension_by_boolean_type_matcher() -> None:  # noqa: D
+def test_categorical_dimension_by_boolean_type_matcher() -> None:  # noqa: D103
     assert defaults.CategoricalDimensionByBooleanTypeRule().match_column(
         get_column_properties("db.schema.table.dim", InferenceColumnType.BOOLEAN, True)
     )
@@ -159,7 +159,7 @@ def test_categorical_dimension_by_boolean_type_matcher() -> None:  # noqa: D
     )
 
 
-def test_categorical_dimension_by_string_type_matcher() -> None:  # noqa: D
+def test_categorical_dimension_by_string_type_matcher() -> None:  # noqa: D103
     assert defaults.CategoricalDimensionByStringTypeRule().match_column(
         get_column_properties("db.schema.table.dim", InferenceColumnType.STRING, True)
     )
@@ -168,7 +168,7 @@ def test_categorical_dimension_by_string_type_matcher() -> None:  # noqa: D
     )
 
 
-def test_categorical_dimension_by_string__and_cardinality_type_matcher() -> None:  # noqa: D
+def test_categorical_dimension_by_string__and_cardinality_type_matcher() -> None:
     """Tests the composite of string type and cardinality below supplied threshold.
 
     Since the helper cardinality ratio is always either 1 or 0.9, the cardinality thresholds are set to either above
@@ -187,7 +187,7 @@ def test_categorical_dimension_by_string__and_cardinality_type_matcher() -> None
     )
 
 
-def test_categorical_dimension_by_integer_type_matcher() -> None:  # noqa: D
+def test_categorical_dimension_by_integer_type_matcher() -> None:  # noqa: D103
     assert defaults.CategoricalDimensionByIntegerTypeRule().match_column(
         get_column_properties("db.schema.table.dim", InferenceColumnType.INTEGER, True)
     )
@@ -196,7 +196,7 @@ def test_categorical_dimension_by_integer_type_matcher() -> None:  # noqa: D
     )
 
 
-def test_measure_by_real_type_matcher() -> None:  # noqa: D
+def test_measure_by_real_type_matcher() -> None:  # noqa: D103
     assert defaults.MeasureByRealTypeRule().match_column(
         get_column_properties("db.schema.table.measure", InferenceColumnType.FLOAT, True)
     )
@@ -217,7 +217,7 @@ def test_measure_by_real_type_matcher() -> None:  # noqa: D
     )
 
 
-def test_measure_by_integer_type_matcher() -> None:  # noqa: D
+def test_measure_by_integer_type_matcher() -> None:  # noqa: D103
     assert defaults.MeasureByIntegerTypeRule().match_column(
         get_column_properties("db.schema.table.measure", InferenceColumnType.INTEGER, True)
     )

--- a/metricflow/test/inference/rule/test_rules.py
+++ b/metricflow/test/inference/rule/test_rules.py
@@ -35,13 +35,13 @@ def create_context_with_counts(rows: int, distinct: int, nulls: int) -> DataWare
     )
 
 
-class ExampleLowCardinalityRule(LowCardinalityRatioRule):  # noqa: D
+class ExampleLowCardinalityRule(LowCardinalityRatioRule):  # noqa: D101
     type_node = InferenceSignalType.DIMENSION.CATEGORICAL
     confidence = InferenceSignalConfidence.MEDIUM
     only_applies_to_parent_signal = False
 
 
-def test_column_matcher(warehouse_ctx: DataWarehouseInferenceContext) -> None:  # noqa: D
+def test_column_matcher(warehouse_ctx: DataWarehouseInferenceContext) -> None:  # noqa: D103
     class TestRule(ColumnMatcherRule):
         type_node = InferenceSignalType.DIMENSION.UNKNOWN
         confidence = InferenceSignalConfidence.MEDIUM
@@ -61,7 +61,7 @@ def test_column_matcher(warehouse_ctx: DataWarehouseInferenceContext) -> None:  
     assert not signals[0].only_applies_to_parent
 
 
-def test_low_cardinality_ratio_rule_high_cardinality_doesnt_match() -> None:  # noqa: D
+def test_low_cardinality_ratio_rule_high_cardinality_doesnt_match() -> None:  # noqa: D103
     rule = ExampleLowCardinalityRule(0.1)
     ctx = create_context_with_counts(100, 100, 0)
 
@@ -69,7 +69,7 @@ def test_low_cardinality_ratio_rule_high_cardinality_doesnt_match() -> None:  # 
     assert len(signals) == 0
 
 
-def test_low_cardinality_ratio_rule_low_cardinality_lots_of_nulls_doesnt_match() -> None:  # noqa: D
+def test_low_cardinality_ratio_rule_low_cardinality_lots_of_nulls_doesnt_match() -> None:  # noqa: D103
     rule = ExampleLowCardinalityRule(0.1)
     ctx = create_context_with_counts(100, 2, 99)
 
@@ -77,7 +77,7 @@ def test_low_cardinality_ratio_rule_low_cardinality_lots_of_nulls_doesnt_match()
     assert len(signals) == 0
 
 
-def test_low_cardinality_ratio_rule_low_cardinality_all_nulls_doesnt_match() -> None:  # noqa: D
+def test_low_cardinality_ratio_rule_low_cardinality_all_nulls_doesnt_match() -> None:  # noqa: D103
     rule = ExampleLowCardinalityRule(0.1)
     ctx = create_context_with_counts(100, 1, 100)
 
@@ -85,7 +85,7 @@ def test_low_cardinality_ratio_rule_low_cardinality_all_nulls_doesnt_match() -> 
     assert len(signals) == 0
 
 
-def test_low_cardinality_ratio_rule_low_cardinality_matches() -> None:  # noqa: D
+def test_low_cardinality_ratio_rule_low_cardinality_matches() -> None:  # noqa: D103
     rule = ExampleLowCardinalityRule(0.1)
     ctx = create_context_with_counts(100, 1, 0)
 

--- a/metricflow/test/inference/solver/test_weighted_tree.py
+++ b/metricflow/test/inference/solver/test_weighted_tree.py
@@ -8,7 +8,7 @@ column = SqlColumn.from_string("db.schema.table.col")
 solver = WeightedTypeTreeInferenceSolver()
 
 
-def test_empty_signals_return_unknown() -> None:  # noqa: D
+def test_empty_signals_return_unknown() -> None:  # noqa: D103
     result = solver.solve_column(column, [])
 
     assert result.type_node == InferenceSignalType.UNKNOWN

--- a/metricflow/test/integration/configured_test_case.py
+++ b/metricflow/test/integration/configured_test_case.py
@@ -33,7 +33,7 @@ class RequiredDwEngineFeatures(Enum):
     APPROXIMATE_CONTINUOUS_PERCENTILE_AGGREGATION = "APPROXIMATE_CONTINUOUS_PERCENTILE_AGGREGATION"
     APPROXIMATE_DISCRETE_PERCENTILE_AGGREGATION = "APPROXIMATE_DISCRETE_PERCENTILE_AGGREGATION"
 
-    def __repr__(self) -> str:  # noqa: D
+    def __repr__(self) -> str:  # noqa: D105
         return f"{self.__class__.__name__}.{self.name}"
 
 
@@ -41,7 +41,7 @@ class ConfiguredIntegrationTestCase(FrozenBaseModel):
     """Integration test case parsed from YAML files."""
 
     # Pydantic feature to throw errors on extra fields.
-    class Config:  # noqa: D
+    class Config:  # noqa: D106
         extra = "forbid"
 
     # Name of the test.
@@ -133,7 +133,7 @@ class ConfiguredIntegrationTestCaseRepository:
         return results
 
     @staticmethod
-    def _find_all_yaml_file_paths(directory: str) -> Sequence[str]:  # noqa: D
+    def _find_all_yaml_file_paths(directory: str) -> Sequence[str]:
         """Recursively search through the given directory for YAML files."""
         test_case_file_paths = []
 

--- a/metricflow/test/integration/conftest.py
+++ b/metricflow/test/integration/conftest.py
@@ -25,7 +25,7 @@ class IntegrationTestHelpers:
 
 
 @pytest.fixture
-def it_helpers(  # noqa: D
+def it_helpers(  # noqa: D103
     sql_client: SqlClient,
     create_source_tables: bool,
     simple_semantic_manifest_lookup: SemanticManifestLookup,

--- a/metricflow/test/integration/query_output/test_fill_nulls_with_0.py
+++ b/metricflow/test/integration/query_output/test_fill_nulls_with_0.py
@@ -13,7 +13,7 @@ from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_fill_nulls_with_0_metric_time(  # noqa: D
+def test_simple_fill_nulls_with_0_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -40,7 +40,7 @@ def test_simple_fill_nulls_with_0_metric_time(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_fill_nulls_with_0_month(  # noqa: D
+def test_simple_fill_nulls_with_0_month(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -67,7 +67,7 @@ def test_simple_fill_nulls_with_0_month(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_join_to_time_spine(  # noqa: D
+def test_simple_join_to_time_spine(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -94,7 +94,7 @@ def test_simple_join_to_time_spine(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_fill_nulls_with_0_multi_metric_query(  # noqa: D
+def test_fill_nulls_with_0_multi_metric_query(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -121,7 +121,7 @@ def test_fill_nulls_with_0_multi_metric_query(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_fill_nulls_with_0_multi_metric_query_with_categorical_dimension(  # noqa: D
+def test_fill_nulls_with_0_multi_metric_query_with_categorical_dimension(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,

--- a/metricflow/test/integration/query_output/test_offset_metrics.py
+++ b/metricflow/test/integration/query_output/test_offset_metrics.py
@@ -11,7 +11,7 @@ from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 
 
 @pytest.mark.sql_engine_snapshot
-def test_offset_to_grain_with_single_granularity(  # noqa: D
+def test_offset_to_grain_with_single_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -36,7 +36,7 @@ def test_offset_to_grain_with_single_granularity(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_offset_to_grain_with_multiple_granularities(  # noqa: D
+def test_offset_to_grain_with_multiple_granularities(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,

--- a/metricflow/test/integration/test_configured_cases.py
+++ b/metricflow/test/integration/test_configured_cases.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 class CheckQueryHelpers:
     """Functions that can be used to help render check queries in integration tests."""
 
-    def __init__(self, sql_client: SqlClient) -> None:  # noqa:D
+    def __init__(self, sql_client: SqlClient) -> None:  # noqa: D107
         self._sql_client = sql_client
 
     def render_time_constraint(
@@ -301,29 +301,31 @@ def test_case(
             limit=case.limit,
             time_constraint_start=parser.parse(case.time_constraint[0]) if case.time_constraint else None,
             time_constraint_end=parser.parse(case.time_constraint[1]) if case.time_constraint else None,
-            where_constraint=jinja2.Template(
-                case.where_filter,
-                undefined=jinja2.StrictUndefined,
-            ).render(
-                source_schema=mf_test_configuration.mf_source_schema,
-                render_time_constraint=check_query_helpers.render_time_constraint,
-                render_between_time_constraint=check_query_helpers.render_between_time_constraint,
-                TimeGranularity=TimeGranularity,
-                DatePart=DatePart,
-                render_date_sub=check_query_helpers.render_date_sub,
-                render_date_trunc=check_query_helpers.render_date_trunc,
-                render_extract=check_query_helpers.render_extract,
-                render_percentile_expr=check_query_helpers.render_percentile_expr,
-                mf_time_spine_source=semantic_manifest_lookup.time_spine_source.spine_table.sql,
-                double_data_type_name=check_query_helpers.double_data_type_name,
-                render_dimension_template=check_query_helpers.render_dimension_template,
-                render_entity_template=check_query_helpers.render_entity_template,
-                render_time_dimension_template=check_query_helpers.render_time_dimension_template,
-                generate_random_uuid=check_query_helpers.generate_random_uuid,
-                cast_to_ts=check_query_helpers.cast_to_ts,
-            )
-            if case.where_filter
-            else None,
+            where_constraint=(
+                jinja2.Template(
+                    case.where_filter,
+                    undefined=jinja2.StrictUndefined,
+                ).render(
+                    source_schema=mf_test_configuration.mf_source_schema,
+                    render_time_constraint=check_query_helpers.render_time_constraint,
+                    render_between_time_constraint=check_query_helpers.render_between_time_constraint,
+                    TimeGranularity=TimeGranularity,
+                    DatePart=DatePart,
+                    render_date_sub=check_query_helpers.render_date_sub,
+                    render_date_trunc=check_query_helpers.render_date_trunc,
+                    render_extract=check_query_helpers.render_extract,
+                    render_percentile_expr=check_query_helpers.render_percentile_expr,
+                    mf_time_spine_source=semantic_manifest_lookup.time_spine_source.spine_table.sql,
+                    double_data_type_name=check_query_helpers.double_data_type_name,
+                    render_dimension_template=check_query_helpers.render_dimension_template,
+                    render_entity_template=check_query_helpers.render_entity_template,
+                    render_time_dimension_template=check_query_helpers.render_time_dimension_template,
+                    generate_random_uuid=check_query_helpers.generate_random_uuid,
+                    cast_to_ts=check_query_helpers.cast_to_ts,
+                )
+                if case.where_filter
+                else None
+            ),
             order_by_names=case.order_bys,
             min_max_only=case.min_max_only,
         )

--- a/metricflow/test/integration/test_rendered_query.py
+++ b/metricflow/test/integration/test_rendered_query.py
@@ -18,7 +18,7 @@ from metricflow.test.time.configurable_time_source import ConfigurableTimeSource
 
 
 @pytest.mark.sql_engine_snapshot
-def test_render_query(  # noqa: D
+def test_render_query(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, it_helpers: IntegrationTestHelpers
 ) -> None:
     result = it_helpers.mf_engine.explain(
@@ -38,7 +38,7 @@ def test_render_query(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_render_write_to_table_query(  # noqa: D
+def test_render_write_to_table_query(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, it_helpers: IntegrationTestHelpers
 ) -> None:
     output_table = SqlTable(schema_name=it_helpers.mf_system_schema, table_name="test_table")
@@ -59,7 +59,7 @@ def test_render_write_to_table_query(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_id_enumeration(  # noqa: D
+def test_id_enumeration(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     simple_semantic_manifest_lookup: SemanticManifestLookup,

--- a/metricflow/test/integration/test_write_to_table.py
+++ b/metricflow/test/integration/test_write_to_table.py
@@ -10,7 +10,7 @@ from metricflow.test.compare_df import assert_dataframes_equal
 from metricflow.test.integration.conftest import IntegrationTestHelpers
 
 
-def test_write_to_table(it_helpers: IntegrationTestHelpers) -> None:  # noqa: D
+def test_write_to_table(it_helpers: IntegrationTestHelpers) -> None:  # noqa: D103
     output_table = SqlTable(schema_name=it_helpers.mf_system_schema, table_name=f"test_table_{random_id()}")
     try:
         it_helpers.mf_engine.query(

--- a/metricflow/test/mf_logging/test_dag_to_text.py
+++ b/metricflow/test/mf_logging/test_dag_to_text.py
@@ -43,7 +43,7 @@ def test_multithread_dag_to_text() -> None:
         ),
     )
 
-    def _run_mf_pformat() -> None:  # noqa: D
+    def _run_mf_pformat() -> None:
         current_thread = threading.current_thread()
         logger.debug(f"In {current_thread} - Starting .dag_to_text()")
         # Sleep a little bit so that all threads are likely to be running simultaneously.

--- a/metricflow/test/model/modify/modify_input_measure_filter.py
+++ b/metricflow/test/model/modify/modify_input_measure_filter.py
@@ -17,7 +17,7 @@ class ModifyInputMeasureFilterTransform(SemanticManifestTransformRule[PydanticSe
     This is useful for programmatically generating different manifests to create different test cases.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         metric_reference: MetricReference,
         where_filter_intersection: PydanticWhereFilterIntersection,

--- a/metricflow/test/model/modify/modify_input_metric_filter.py
+++ b/metricflow/test/model/modify/modify_input_metric_filter.py
@@ -17,7 +17,7 @@ class ModifyInputMetricFilterTransform(SemanticManifestTransformRule[PydanticSem
     This is useful for programmatically generating different manifests to create different test cases.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         metric_reference: MetricReference,
         where_filter_intersection: PydanticWhereFilterIntersection,

--- a/metricflow/test/model/modify/modify_metric_filter.py
+++ b/metricflow/test/model/modify/modify_metric_filter.py
@@ -13,7 +13,7 @@ class ModifyMetricFilterTransform(SemanticManifestTransformRule[PydanticSemantic
     This is useful for programmatically generating different manifests to create different test cases.
     """
 
-    def __init__(  # noqa: D
+    def __init__(  # noqa: D107
         self,
         metric_reference: MetricReference,
         where_filter_intersection: PydanticWhereFilterIntersection,

--- a/metricflow/test/model/semantics/test_linkable_spec_resolver.py
+++ b/metricflow/test/model/semantics/test_linkable_spec_resolver.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def simple_model_spec_resolver(  # noqa: D
+def simple_model_spec_resolver(  # noqa: D103
     simple_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> ValidLinkableSpecResolver:
     return ValidLinkableSpecResolver(
@@ -30,7 +30,7 @@ def simple_model_spec_resolver(  # noqa: D
 
 
 @pytest.fixture
-def cyclic_join_manifest_spec_resolver(  # noqa: D
+def cyclic_join_manifest_spec_resolver(  # noqa: D103
     cyclic_join_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> ValidLinkableSpecResolver:
     return ValidLinkableSpecResolver(
@@ -40,7 +40,7 @@ def cyclic_join_manifest_spec_resolver(  # noqa: D
     )
 
 
-def test_all_properties(  # noqa: D
+def test_all_properties(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     simple_model_spec_resolver: ValidLinkableSpecResolver,
@@ -57,7 +57,7 @@ def test_all_properties(  # noqa: D
     )
 
 
-def test_one_property(  # noqa: D
+def test_one_property(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     simple_model_spec_resolver: ValidLinkableSpecResolver,
@@ -74,7 +74,7 @@ def test_one_property(  # noqa: D
     )
 
 
-def test_metric_time_property_for_cumulative_metric(  # noqa: D
+def test_metric_time_property_for_cumulative_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     simple_model_spec_resolver: ValidLinkableSpecResolver,
@@ -91,7 +91,7 @@ def test_metric_time_property_for_cumulative_metric(  # noqa: D
     )
 
 
-def test_metric_time_property_for_derived_metrics(  # noqa: D
+def test_metric_time_property_for_derived_metrics(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     simple_model_spec_resolver: ValidLinkableSpecResolver,
@@ -108,7 +108,7 @@ def test_metric_time_property_for_derived_metrics(  # noqa: D
     )
 
 
-def test_cyclic_join_manifest(  # noqa: D
+def test_cyclic_join_manifest(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     cyclic_join_manifest_spec_resolver: ValidLinkableSpecResolver,

--- a/metricflow/test/model/semantics/test_semantic_model_join_evaluator.py
+++ b/metricflow/test/model/semantics/test_semantic_model_join_evaluator.py
@@ -325,7 +325,7 @@ def test_foreign_target_instance_set_join_validation(
     )
 
 
-def test_get_joinable_semantic_models_single_hop(  # noqa: D
+def test_get_joinable_semantic_models_single_hop(  # noqa: D103
     partitioned_multi_hop_join_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> None:
     semantic_model_reference = SemanticModelReference(semantic_model_name="account_month_txns")
@@ -352,7 +352,7 @@ def test_get_joinable_semantic_models_single_hop(  # noqa: D
     )
 
 
-def test_get_joinable_semantic_models_multi_hop(  # noqa: D
+def test_get_joinable_semantic_models_multi_hop(  # noqa: D103
     partitioned_multi_hop_join_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> None:
     semantic_model_reference = SemanticModelReference(semantic_model_name="account_month_txns")

--- a/metricflow/test/model/test_data_warehouse_tasks.py
+++ b/metricflow/test/model/test_data_warehouse_tasks.py
@@ -44,14 +44,14 @@ def dw_backed_warehouse_validation_model(
     return data_warehouse_validation_model
 
 
-def test_build_semantic_model_tasks(  # noqa:D
+def test_build_semantic_model_tasks(  # noqa: D103
     data_warehouse_validation_model: PydanticSemanticManifest,
 ) -> None:
     tasks = DataWarehouseTaskBuilder.gen_semantic_model_tasks(manifest=data_warehouse_validation_model)
     assert len(tasks) == len(data_warehouse_validation_model.semantic_models)
 
 
-def test_task_runner(sql_client: SqlClient, mf_test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D
+def test_task_runner(sql_client: SqlClient, mf_test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D103
     dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
 
     def good_query() -> Tuple[str, SqlBindParameters]:
@@ -77,7 +77,7 @@ def test_task_runner(sql_client: SqlClient, mf_test_configuration: MetricFlowTes
     assert err_msg_bad in issues.errors[0].message
 
 
-def test_validate_semantic_models(  # noqa: D
+def test_validate_semantic_models(  # noqa: D103
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
     mf_test_configuration: MetricFlowTestConfiguration,
@@ -102,7 +102,7 @@ def test_validate_semantic_models(  # noqa: D
     assert "Unable to access semantic model `test_semantic_model2`" in issues.all_issues[0].message
 
 
-def test_build_dimension_tasks(  # noqa: D
+def test_build_dimension_tasks(  # noqa: D103
     data_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
 ) -> None:
@@ -116,7 +116,7 @@ def test_build_dimension_tasks(  # noqa: D
     assert len(tasks[0].on_fail_subtasks) == 12
 
 
-def test_validate_dimensions(  # noqa: D
+def test_validate_dimensions(  # noqa: D103
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
     mf_test_configuration: MetricFlowTestConfiguration,
@@ -138,7 +138,7 @@ def test_validate_dimensions(  # noqa: D
     assert len(issues.all_issues) == 2
 
 
-def test_build_entities_tasks(  # noqa: D
+def test_build_entities_tasks(  # noqa: D103
     data_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
 ) -> None:
@@ -150,7 +150,7 @@ def test_build_entities_tasks(  # noqa: D
     assert len(tasks[0].on_fail_subtasks) == 1  # a sub task for each entity on the semantic model
 
 
-def test_validate_entities(  # noqa: D
+def test_validate_entities(  # noqa: D103
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
     mf_test_configuration: MetricFlowTestConfiguration,
@@ -172,7 +172,7 @@ def test_validate_entities(  # noqa: D
     assert len(issues.all_issues) == 2
 
 
-def test_build_measure_tasks(  # noqa: D
+def test_build_measure_tasks(  # noqa: D103
     data_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
 ) -> None:
@@ -184,7 +184,7 @@ def test_build_measure_tasks(  # noqa: D
     assert len(tasks[0].on_fail_subtasks) == 1  # a sub task for each measure on the semantic model
 
 
-def test_validate_measures(  # noqa: D
+def test_validate_measures(  # noqa: D103
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
     mf_test_configuration: MetricFlowTestConfiguration,
@@ -207,7 +207,7 @@ def test_validate_measures(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_build_metric_tasks(  # noqa: D
+def test_build_metric_tasks(  # noqa: D103
     request: FixtureRequest,
     data_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
@@ -229,7 +229,7 @@ def test_build_metric_tasks(  # noqa: D
     )
 
 
-def test_validate_metrics(  # noqa: D
+def test_validate_metrics(  # noqa: D103
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
     sql_client: SqlClient,
     mf_test_configuration: MetricFlowTestConfiguration,

--- a/metricflow/test/model/test_semantic_model_container.py
+++ b/metricflow/test/model/test_semantic_model_container.py
@@ -17,20 +17,20 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def semantic_model_lookup(simple_semantic_manifest: SemanticManifest) -> SemanticModelLookup:  # Noqa: D
+def semantic_model_lookup(simple_semantic_manifest: SemanticManifest) -> SemanticModelLookup:  # noqa: D103
     return SemanticModelLookup(
         model=simple_semantic_manifest,
     )
 
 
 @pytest.fixture
-def metric_lookup(  # Noqa: D
+def metric_lookup(  # noqa: D103
     simple_semantic_manifest: SemanticManifest, semantic_model_lookup: SemanticModelLookup
 ) -> MetricLookup:
     return MetricLookup(semantic_manifest=simple_semantic_manifest, semantic_model_lookup=semantic_model_lookup)
 
 
-def test_get_names(  # noqa: D
+def test_get_names(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     semantic_model_lookup: SemanticModelLookup,
@@ -47,7 +47,7 @@ def test_get_names(  # noqa: D
     )
 
 
-def test_get_elements(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D
+def test_get_elements(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D103
     for dimension_reference in semantic_model_lookup.get_dimension_references():
         assert (
             semantic_model_lookup.get_dimension(dimension_reference=dimension_reference).reference
@@ -58,7 +58,7 @@ def test_get_elements(semantic_model_lookup: SemanticModelLookup) -> None:  # no
         assert semantic_model_lookup.get_measure(measure_reference=measure_reference).reference == measure_reference
 
 
-def test_get_semantic_models_for_measure(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D
+def test_get_semantic_models_for_measure(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D103
     bookings_sources = semantic_model_lookup.get_semantic_models_for_measure(MeasureReference(element_name="bookings"))
     assert len(bookings_sources) == 1
     assert bookings_sources[0].name == "bookings_source"
@@ -72,7 +72,7 @@ def test_get_semantic_models_for_measure(semantic_model_lookup: SemanticModelLoo
     assert listings_sources[0].name == "listings_latest"
 
 
-def test_elements_for_metric(  # noqa: D
+def test_elements_for_metric(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, metric_lookup: MetricLookup
 ) -> None:
     assert_object_snapshot_equal(
@@ -94,7 +94,7 @@ def test_elements_for_metric(  # noqa: D
     )
 
 
-def test_local_linked_elements_for_metric(  # noqa: D
+def test_local_linked_elements_for_metric(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, metric_lookup: MetricLookup
 ) -> None:
     assert_object_snapshot_equal(
@@ -112,13 +112,13 @@ def test_local_linked_elements_for_metric(  # noqa: D
     )
 
 
-def test_get_semantic_models_for_entity(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D
+def test_get_semantic_models_for_entity(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D103
     entity_reference = EntityReference(element_name="user")
     linked_semantic_models = semantic_model_lookup.get_semantic_models_for_entity(entity_reference=entity_reference)
     assert len(linked_semantic_models) == 10
 
 
-def test_linkable_set(  # noqa: D
+def test_linkable_set(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, metric_lookup: MetricLookup
 ) -> None:
     assert_linkable_element_set_snapshot_equal(
@@ -159,7 +159,7 @@ def test_linkable_set_for_common_dimensions_in_different_models(
     )
 
 
-def test_get_valid_agg_time_dimensions_for_metric(  # noqa: D
+def test_get_valid_agg_time_dimensions_for_metric(  # noqa: D103
     metric_lookup: MetricLookup, semantic_model_lookup: SemanticModelLookup
 ) -> None:
     for metric_name in ["views", "listings", "bookings_per_view"]:
@@ -179,7 +179,7 @@ def test_get_valid_agg_time_dimensions_for_metric(  # noqa: D
             assert len(metric_agg_time_dims) == 0
 
 
-def test_get_agg_time_dimension_specs_for_measure(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D
+def test_get_agg_time_dimension_specs_for_measure(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D103
     for measure_name in ["bookings", "views", "listings"]:
         measure_reference = MeasureReference(measure_name)
         agg_time_dim_specs = semantic_model_lookup.get_agg_time_dimension_specs_for_measure(measure_reference)

--- a/metricflow/test/model/test_where_filter_spec.py
+++ b/metricflow/test/model/test_where_filter_spec.py
@@ -76,7 +76,7 @@ def create_where_filter_intersection(sql_template: str) -> WhereFilterIntersecti
     return PydanticWhereFilterIntersection(where_filters=[PydanticWhereFilter(where_sql_template=sql_template)])
 
 
-def test_dimension_in_filter(  # noqa: D
+def test_dimension_in_filter(  # noqa: D103
     column_association_resolver: ColumnAssociationResolver,
 ) -> None:
     where_filter_specs = WhereSpecFactory(
@@ -104,7 +104,7 @@ def test_dimension_in_filter(  # noqa: D
     )
 
 
-def test_dimension_in_filter_with_grain(  # noqa: D
+def test_dimension_in_filter_with_grain(  # noqa: D103
     column_association_resolver: ColumnAssociationResolver,
 ) -> None:
     where_filter_specs = WhereSpecFactory(
@@ -143,7 +143,7 @@ def test_dimension_in_filter_with_grain(  # noqa: D
     )
 
 
-def test_time_dimension_in_filter(  # noqa: D
+def test_time_dimension_in_filter(  # noqa: D103
     column_association_resolver: ColumnAssociationResolver,
 ) -> None:
     where_filter_specs = WhereSpecFactory(
@@ -182,7 +182,7 @@ def test_time_dimension_in_filter(  # noqa: D
     )
 
 
-def test_date_part_in_filter(  # noqa: D
+def test_date_part_in_filter(  # noqa: D103
     column_association_resolver: ColumnAssociationResolver,
 ) -> None:
     where_filter_specs = WhereSpecFactory(
@@ -265,7 +265,7 @@ def resolved_spec_lookup() -> FilterSpecResolutionLookUp:
         ("{{ Dimension('metric_time').grain('WEEK').date_part('year') }} = '2020'"),
     ),
 )
-def test_date_part_and_grain_in_filter(  # noqa: D
+def test_date_part_and_grain_in_filter(  # noqa: D103
     column_association_resolver: ColumnAssociationResolver,
     resolved_spec_lookup: FilterSpecResolutionLookUp,
     where_sql: str,
@@ -301,7 +301,7 @@ def test_date_part_and_grain_in_filter(  # noqa: D
         ("{{ Dimension('metric_time').grain('WEEK').date_part('day') }} = '2020'"),
     ),
 )
-def test_date_part_less_than_grain_in_filter(  # noqa: D
+def test_date_part_less_than_grain_in_filter(  # noqa: D103
     column_association_resolver: ColumnAssociationResolver,
     resolved_spec_lookup: FilterSpecResolutionLookUp,
     where_sql: str,
@@ -328,7 +328,7 @@ def test_date_part_less_than_grain_in_filter(  # noqa: D
     )
 
 
-def test_entity_in_filter(  # noqa: D
+def test_entity_in_filter(  # noqa: D103
     column_association_resolver: ColumnAssociationResolver,
     resolved_spec_lookup: FilterSpecResolutionLookUp,
 ) -> None:

--- a/metricflow/test/naming/conftest.py
+++ b/metricflow/test/naming/conftest.py
@@ -12,7 +12,7 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_MONTH, MTD_SPEC_
 
 
 @pytest.fixture(scope="session")
-def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D
+def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D103
     return (
         # Time dimensions
         MTD_SPEC_WEEK,

--- a/metricflow/test/naming/test_dunder_naming_scheme.py
+++ b/metricflow/test/naming/test_dunder_naming_scheme.py
@@ -13,11 +13,11 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_MONTH, MTD_SPEC_
 
 
 @pytest.fixture(scope="session")
-def dunder_naming_scheme() -> DunderNamingScheme:  # noqa: D
+def dunder_naming_scheme() -> DunderNamingScheme:  # noqa: D103
     return DunderNamingScheme()
 
 
-def test_input_str(dunder_naming_scheme: DunderNamingScheme) -> None:  # noqa: D
+def test_input_str(dunder_naming_scheme: DunderNamingScheme) -> None:  # noqa: D103
     assert (
         dunder_naming_scheme.input_str(
             DimensionSpec(
@@ -71,7 +71,7 @@ def test_input_str(dunder_naming_scheme: DunderNamingScheme) -> None:  # noqa: D
     )
 
 
-def test_input_follows_scheme(dunder_naming_scheme: DunderNamingScheme) -> None:  # noqa: D
+def test_input_follows_scheme(dunder_naming_scheme: DunderNamingScheme) -> None:  # noqa: D103
     assert dunder_naming_scheme.input_str_follows_scheme("listing__country")
     assert dunder_naming_scheme.input_str_follows_scheme("listing__creation_time__month")
     assert dunder_naming_scheme.input_str_follows_scheme("booking__listing")
@@ -80,9 +80,9 @@ def test_input_follows_scheme(dunder_naming_scheme: DunderNamingScheme) -> None:
     assert not dunder_naming_scheme.input_str_follows_scheme("TimeDimension('metric_time')")
 
 
-def test_spec_pattern(  # noqa: D
+def test_spec_pattern(  # noqa: D103
     dunder_naming_scheme: DunderNamingScheme, specs: Sequence[LinkableInstanceSpec]
-) -> None:
+) -> None:  # noqa: D103
     assert tuple(dunder_naming_scheme.spec_pattern("listing__user__country").match(specs)) == (
         DimensionSpec(
             element_name="country",

--- a/metricflow/test/naming/test_metric_name_scheme.py
+++ b/metricflow/test/naming/test_metric_name_scheme.py
@@ -9,19 +9,19 @@ from metricflow.specs.specs import DimensionSpec, InstanceSpec, MetricSpec
 
 
 @pytest.fixture(scope="session")
-def metric_naming_scheme() -> MetricNamingScheme:  # noqa: D
+def metric_naming_scheme() -> MetricNamingScheme:  # noqa: D103
     return MetricNamingScheme()
 
 
-def test_input_str(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D
+def test_input_str(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D103
     assert metric_naming_scheme.input_str(MetricSpec(element_name="example_metric")) == "example_metric"
 
 
-def test_input_follows_scheme(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D
+def test_input_follows_scheme(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D103
     assert metric_naming_scheme.input_str_follows_scheme("some_metric_name")
 
 
-def test_spec_pattern(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D
+def test_spec_pattern(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D103
     spec_pattern = metric_naming_scheme.spec_pattern("metric_0")
 
     specs: Sequence[InstanceSpec] = (

--- a/metricflow/test/naming/test_object_builder_naming_scheme.py
+++ b/metricflow/test/naming/test_object_builder_naming_scheme.py
@@ -13,11 +13,11 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_MONTH, MTD_SPEC_
 
 
 @pytest.fixture(scope="session")
-def object_builder_naming_scheme() -> ObjectBuilderNamingScheme:  # noqa: D
+def object_builder_naming_scheme() -> ObjectBuilderNamingScheme:  # noqa: D103
     return ObjectBuilderNamingScheme()
 
 
-def test_input_str(object_builder_naming_scheme: ObjectBuilderNamingScheme) -> None:  # noqa: D
+def test_input_str(object_builder_naming_scheme: ObjectBuilderNamingScheme) -> None:  # noqa: D103
     assert (
         object_builder_naming_scheme.input_str(
             DimensionSpec(
@@ -48,7 +48,7 @@ def test_input_str(object_builder_naming_scheme: ObjectBuilderNamingScheme) -> N
     )
 
 
-def test_input_follows_scheme(object_builder_naming_scheme: ObjectBuilderNamingScheme) -> None:  # noqa: D
+def test_input_follows_scheme(object_builder_naming_scheme: ObjectBuilderNamingScheme) -> None:  # noqa: D103
     assert object_builder_naming_scheme.input_str_follows_scheme(
         "Dimension('listing__country', entity_path=['booking'])"
     )
@@ -64,7 +64,7 @@ def test_input_follows_scheme(object_builder_naming_scheme: ObjectBuilderNamingS
     assert not object_builder_naming_scheme.input_str_follows_scheme("NotADimension('listing__country')")
 
 
-def test_spec_pattern(  # noqa: D
+def test_spec_pattern(  # noqa: D103
     object_builder_naming_scheme: ObjectBuilderNamingScheme, specs: Sequence[LinkableInstanceSpec]
 ) -> None:
     assert tuple(

--- a/metricflow/test/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
+++ b/metricflow/test/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
@@ -18,7 +18,7 @@ from metricflow.test.time.metric_time_dimension import MTD_SPEC_DAY
 
 
 @pytest.mark.sql_engine_snapshot
-def test_metric_time_dimension_transform_node_using_primary_time(  # noqa: D
+def test_metric_time_dimension_transform_node_using_primary_time(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -42,7 +42,7 @@ def test_metric_time_dimension_transform_node_using_primary_time(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_metric_time_dimension_transform_node_using_non_primary_time(  # noqa: D
+def test_metric_time_dimension_transform_node_using_non_primary_time(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,

--- a/metricflow/test/plan_conversion/test_dataflow_to_execution.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_execution.py
@@ -21,7 +21,7 @@ from metricflow.test.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from metricflow.test.snapshot_utils import assert_execution_plan_text_equal
 
 
-def make_execution_plan_converter(  # noqa: D
+def make_execution_plan_converter(  # noqa: D103
     semantic_manifest_lookup: SemanticManifestLookup,
     sql_client: SqlClient,
 ) -> DataflowToExecutionPlanConverter:
@@ -36,7 +36,7 @@ def make_execution_plan_converter(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_joined_plan(  # noqa: D
+def test_joined_plan(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -75,7 +75,7 @@ def test_joined_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_small_combined_metrics_plan(  # noqa: D
+def test_small_combined_metrics_plan(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -112,7 +112,7 @@ def test_small_combined_metrics_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_combined_metrics_plan(  # noqa: D
+def test_combined_metrics_plan(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -151,7 +151,7 @@ def test_combined_metrics_plan(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_multihop_joined_plan(  # noqa: D
+def test_multihop_joined_plan(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     multihop_dataflow_plan_builder: DataflowPlanBuilder,

--- a/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/metricflow/test/plan_conversion/test_dataflow_to_sql_plan.py
@@ -116,7 +116,7 @@ def convert_and_check(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_source_node(  # noqa: D
+def test_source_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -138,7 +138,7 @@ def test_source_node(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_filter_node(  # noqa: D
+def test_filter_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -166,7 +166,7 @@ def test_filter_node(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_filter_with_where_constraint_node(  # noqa: D
+def test_filter_with_where_constraint_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
@@ -214,7 +214,7 @@ def test_filter_with_where_constraint_node(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_measure_aggregation_node(  # noqa: D
+def test_measure_aggregation_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -262,7 +262,7 @@ def test_measure_aggregation_node(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_single_join_node(  # noqa: D
+def test_single_join_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -538,7 +538,7 @@ def test_compute_metrics_node_simple_expr(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_join_to_time_spine_node_without_offset(  # noqa: D
+def test_join_to_time_spine_node_without_offset(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -606,7 +606,7 @@ def test_join_to_time_spine_node_without_offset(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_join_to_time_spine_node_with_offset_window(  # noqa: D
+def test_join_to_time_spine_node_with_offset_window(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
@@ -1065,7 +1065,7 @@ def test_compute_metrics_node_ratio_from_multiple_semantic_models(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_combine_output_node(  # noqa: D
+def test_combine_output_node(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,

--- a/metricflow/test/plan_conversion/test_time_spine.py
+++ b/metricflow/test/plan_conversion/test_time_spine.py
@@ -8,7 +8,7 @@ from metricflow.protocols.sql_client import SqlClient
 from metricflow.time.time_constants import ISO8601_PYTHON_TS_FORMAT
 
 
-def test_date_spine_date_range(  # noqa: D
+def test_date_spine_date_range(  # noqa: D103
     sql_client: SqlClient,
     simple_semantic_manifest_lookup: SemanticManifestLookup,
     create_source_tables: None,

--- a/metricflow/test/populate_persistent_source_schemas.py
+++ b/metricflow/test/populate_persistent_source_schemas.py
@@ -18,7 +18,7 @@ from metricflow.test.generate_snapshots import (
 logger = logging.getLogger(__name__)
 
 
-def populate_schemas(test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D
+def populate_schemas(test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D103
     set_engine_env_variables(test_configuration)
 
     if test_configuration.engine is SqlEngine.DUCKDB or test_configuration.engine is SqlEngine.POSTGRES:

--- a/metricflow/test/query/group_by_item/conftest.py
+++ b/metricflow/test/query/group_by_item/conftest.py
@@ -99,5 +99,5 @@ def resolution_dags(
 
 
 @pytest.fixture(scope="session")
-def naming_scheme() -> QueryItemNamingScheme:  # noqa: D
+def naming_scheme() -> QueryItemNamingScheme:  # noqa: D103
     return ObjectBuilderNamingScheme()

--- a/metricflow/test/query/group_by_item/filter_spec_resolution/test_spec_lookup.py
+++ b/metricflow/test/query/group_by_item/filter_spec_resolution/test_spec_lookup.py
@@ -3,6 +3,7 @@
 This currently only tests filters in the query, but filters can be in other locations. Those will be tested later in
 more detail through the query parser.
 """
+
 from __future__ import annotations
 
 import logging
@@ -40,7 +41,7 @@ from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 logger = logging.getLogger(__name__)
 
 
-def assert_spec_lookup_snapshot_equal(  # noqa: D
+def assert_spec_lookup_snapshot_equal(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     spec_lookup: FilterSpecResolutionLookUp,
@@ -54,7 +55,7 @@ def assert_spec_lookup_snapshot_equal(  # noqa: D
 
 
 @pytest.mark.parametrize("dag_case_id", [case_id.value for case_id in AmbiguousResolutionQueryId])
-def test_filter_spec_resolution(  # noqa: D
+def test_filter_spec_resolution(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     naming_scheme: QueryItemNamingScheme,
@@ -78,7 +79,7 @@ def test_filter_spec_resolution(  # noqa: D
     )
 
 
-def check_resolution_with_filter(  # noqa: D
+def check_resolution_with_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     semantic_manifest: PydanticSemanticManifest,
@@ -120,7 +121,7 @@ def check_resolution_with_filter(  # noqa: D
     )
 
 
-def test_filter_resolution_for_valid_metric_filter(  # noqa: D
+def test_filter_resolution_for_valid_metric_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest: PydanticSemanticManifest,
@@ -147,7 +148,7 @@ def test_filter_resolution_for_valid_metric_filter(  # noqa: D
     )
 
 
-def test_filter_resolution_for_invalid_metric_filter(  # noqa: D
+def test_filter_resolution_for_invalid_metric_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest: PydanticSemanticManifest,
@@ -174,7 +175,7 @@ def test_filter_resolution_for_invalid_metric_filter(  # noqa: D
     )
 
 
-def test_filter_resolution_for_valid_metric_input_filter(  # noqa: D
+def test_filter_resolution_for_valid_metric_input_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest: PydanticSemanticManifest,
@@ -201,7 +202,7 @@ def test_filter_resolution_for_valid_metric_input_filter(  # noqa: D
     )
 
 
-def test_filter_resolution_for_invalid_metric_input_filter(  # noqa: D
+def test_filter_resolution_for_invalid_metric_input_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest: PydanticSemanticManifest,

--- a/metricflow/test/query/group_by_item/test_available_group_by_items.py
+++ b/metricflow/test/query/group_by_item/test_available_group_by_items.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("dag_case_id", [case_id.value for case_id in AmbiguousResolutionQueryId])
-def test_available_group_by_items(  # noqa: D
+def test_available_group_by_items(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,

--- a/metricflow/test/query/group_by_item/test_matching_item_for_filters.py
+++ b/metricflow/test/query/group_by_item/test_matching_item_for_filters.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("dag_case_id", [case_id.value for case_id in AmbiguousResolutionQueryId])
-def test_ambiguous_metric_time_in_query_filter(  # noqa: D
+def test_ambiguous_metric_time_in_query_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     naming_scheme: QueryItemNamingScheme,

--- a/metricflow/test/query/group_by_item/test_matching_item_for_querying.py
+++ b/metricflow/test/query/group_by_item/test_matching_item_for_querying.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("dag_case_id", [case_id.value for case_id in AmbiguousResolutionQueryId])
-def test_ambiguous_metric_time_in_query(  # noqa: D
+def test_ambiguous_metric_time_in_query(  # noqa: D103
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
     resolution_dags: Dict[AmbiguousResolutionQueryId, GroupByItemResolutionDag],
     dag_case_id: str,
@@ -63,7 +63,7 @@ def test_ambiguous_metric_time_in_query(  # noqa: D
         assert_values_exhausted(case_id)
 
 
-def test_unavailable_group_by_item_in_derived_metric_parent(  # noqa: D
+def test_unavailable_group_by_item_in_derived_metric_parent(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     naming_scheme: QueryItemNamingScheme,
@@ -91,7 +91,7 @@ def test_unavailable_group_by_item_in_derived_metric_parent(  # noqa: D
     )
 
 
-def test_invalid_group_by_item(  # noqa: D
+def test_invalid_group_by_item(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     naming_scheme: QueryItemNamingScheme,

--- a/metricflow/test/query/test_ambiguous_entity_path.py
+++ b/metricflow/test/query/test_ambiguous_entity_path.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def multi_hop_query_parser(  # noqa: D
+def multi_hop_query_parser(  # noqa: D103
     simple_multi_hop_join_manifest_lookup: SemanticManifestLookup,
 ) -> MetricFlowQueryParser:
     return MetricFlowQueryParser(
@@ -27,7 +27,7 @@ def multi_hop_query_parser(  # noqa: D
     )
 
 
-def test_resolvable_ambiguous_entity_path(  # noqa: D
+def test_resolvable_ambiguous_entity_path(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     multi_hop_query_parser: MetricFlowQueryParser,

--- a/metricflow/test/query/test_query_parser.py
+++ b/metricflow/test/query/test_query_parser.py
@@ -193,7 +193,7 @@ def revenue_query_parser() -> MetricFlowQueryParser:  # noqa
     return query_parser_from_yaml([EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, revenue_yaml_file])
 
 
-def test_query_parser(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
+def test_query_parser(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D103
     query_spec = bookings_query_parser.parse_and_validate_query(
         metric_names=["bookings"],
         group_by_names=["booking__is_instant", "listing", MTD],
@@ -220,7 +220,7 @@ def test_query_parser(bookings_query_parser: MetricFlowQueryParser) -> None:  # 
     )
 
 
-def test_query_parser_case_insensitivity(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
+def test_query_parser_case_insensitivity(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D103
     # String params
     query_spec = bookings_query_parser.parse_and_validate_query(
         metric_names=["BOOKINGS"],
@@ -279,12 +279,12 @@ def test_query_parser_case_insensitivity(bookings_query_parser: MetricFlowQueryP
     )
 
 
-def test_query_parser_invalid_group_by(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
+def test_query_parser_invalid_group_by(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D103
     with pytest.raises(InvalidQueryException):
         bookings_query_parser.parse_and_validate_query(group_by_names=["random_stuff"])
 
 
-def test_query_parser_with_object_params(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
+def test_query_parser_with_object_params(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D103
     metric = MetricParameter(name="bookings")
     group_by = (
         DimensionOrEntityParameter("booking__is_instant"),
@@ -342,7 +342,7 @@ def test_order_by_granularity_conversion() -> None:
     ) == query_spec.order_by_specs
 
 
-def test_order_by_granularity_no_conversion(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
+def test_order_by_granularity_no_conversion(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D103
     query_spec = bookings_query_parser.parse_and_validate_query(
         metric_names=["bookings"], group_by_names=[MTD], order_by_names=[MTD]
     )
@@ -601,7 +601,7 @@ def test_date_part_parsing() -> None:
     )
 
 
-def test_duplicate_metric_query(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
+def test_duplicate_metric_query(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D103
     with pytest.raises(InvalidQueryException, match="duplicate metrics"):
         bookings_query_parser.parse_and_validate_query(
             metric_names=["bookings", "bookings"],
@@ -609,12 +609,12 @@ def test_duplicate_metric_query(bookings_query_parser: MetricFlowQueryParser) ->
         )
 
 
-def test_no_metrics_or_group_by(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D
+def test_no_metrics_or_group_by(bookings_query_parser: MetricFlowQueryParser) -> None:  # noqa: D103
     with pytest.raises(InvalidQueryException, match="no metrics or group by items"):
         bookings_query_parser.parse_and_validate_query()
 
 
-def test_offset_metric_with_diff_agg_time_dims_error() -> None:  # noqa: D
+def test_offset_metric_with_diff_agg_time_dims_error() -> None:  # noqa: D103
     metrics_yaml_file = YamlConfigFile(filepath="inline_for_test_1", contents=METRICS_YAML)
     revenue_yaml_file = YamlConfigFile(filepath="inline_for_test_1", contents=REVENUE_YAML)
     query_parser = query_parser_from_yaml(

--- a/metricflow/test/query/test_suggestions.py
+++ b/metricflow/test/query/test_suggestions.py
@@ -24,7 +24,7 @@ from metricflow.test.snapshot_utils import assert_str_snapshot_equal
 logger = logging.getLogger(__name__)
 
 
-def test_suggestions_for_group_by_item(  # noqa: D
+def test_suggestions_for_group_by_item(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, query_parser: MetricFlowQueryParser
 ) -> None:
     with pytest.raises(InvalidQueryException) as e:
@@ -38,7 +38,7 @@ def test_suggestions_for_group_by_item(  # noqa: D
     )
 
 
-def test_suggestions_for_metric(  # noqa: D
+def test_suggestions_for_metric(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, query_parser: MetricFlowQueryParser
 ) -> None:
     with pytest.raises(InvalidQueryException) as e:
@@ -52,7 +52,7 @@ def test_suggestions_for_metric(  # noqa: D
     )
 
 
-def test_suggestions_for_multiple_metrics(  # noqa: D
+def test_suggestions_for_multiple_metrics(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, query_parser: MetricFlowQueryParser
 ) -> None:
     with pytest.raises(InvalidQueryException) as e:
@@ -66,7 +66,7 @@ def test_suggestions_for_multiple_metrics(  # noqa: D
     )
 
 
-def test_suggestions_for_defined_where_filter(  # noqa: D
+def test_suggestions_for_defined_where_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     simple_semantic_manifest: PydanticSemanticManifest,

--- a/metricflow/test/query_rendering/test_derived_metric_rendering.py
+++ b/metricflow/test/query_rendering/test_derived_metric_rendering.py
@@ -32,7 +32,7 @@ from metricflow.test.time.metric_time_dimension import (
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric(  # noqa: D
+def test_derived_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -56,7 +56,7 @@ def test_derived_metric(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_nested_derived_metric(  # noqa: D
+def test_nested_derived_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -80,7 +80,7 @@ def test_nested_derived_metric(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_with_offset_window(  # noqa: D
+def test_derived_metric_with_offset_window(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -104,7 +104,7 @@ def test_derived_metric_with_offset_window(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D
+def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     column_association_resolver: ColumnAssociationResolver,
@@ -135,7 +135,7 @@ def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_with_offset_to_grain(  # noqa: D
+def test_derived_metric_with_offset_to_grain(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -159,7 +159,7 @@ def test_derived_metric_with_offset_to_grain(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D
+def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -183,7 +183,7 @@ def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_offset_metric_with_one_input_metric(  # noqa: D
+def test_derived_offset_metric_with_one_input_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -207,7 +207,7 @@ def test_derived_offset_metric_with_one_input_metric(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_with_offset_window_and_granularity(  # noqa: D
+def test_derived_metric_with_offset_window_and_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -231,7 +231,7 @@ def test_derived_metric_with_offset_window_and_granularity(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_with_month_dimension_and_offset_window(  # noqa: D
+def test_derived_metric_with_month_dimension_and_offset_window(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     extended_date_dataflow_plan_builder: DataflowPlanBuilder,
@@ -255,7 +255,7 @@ def test_derived_metric_with_month_dimension_and_offset_window(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_with_offset_to_grain_and_granularity(  # noqa: D
+def test_derived_metric_with_offset_to_grain_and_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -279,7 +279,7 @@ def test_derived_metric_with_offset_to_grain_and_granularity(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity(  # noqa: D
+def test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -303,7 +303,7 @@ def test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity( 
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_offset_cumulative_metric(  # noqa: D
+def test_derived_offset_cumulative_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -327,7 +327,7 @@ def test_derived_offset_cumulative_metric(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_nested_offsets(  # noqa: D
+def test_nested_offsets(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -352,7 +352,7 @@ def test_nested_offsets(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_nested_derived_metric_with_offset_multiple_input_metrics(  # noqa: D
+def test_nested_derived_metric_with_offset_multiple_input_metrics(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -377,7 +377,7 @@ def test_nested_derived_metric_with_offset_multiple_input_metrics(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_nested_offsets_with_where_constraint(  # noqa: D
+def test_nested_offsets_with_where_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
@@ -409,7 +409,7 @@ def test_nested_offsets_with_where_constraint(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_nested_offsets_with_time_constraint(  # noqa: D
+def test_nested_offsets_with_time_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -437,7 +437,7 @@ def test_nested_offsets_with_time_constraint(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_time_offset_metric_with_time_constraint(  # noqa: D
+def test_time_offset_metric_with_time_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -487,7 +487,7 @@ def test_nested_filters(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_cumulative_time_offset_metric_with_time_constraint(  # noqa: D
+def test_cumulative_time_offset_metric_with_time_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -515,7 +515,7 @@ def test_cumulative_time_offset_metric_with_time_constraint(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(  # noqa: D
+def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
@@ -545,7 +545,7 @@ def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_offset_window_with_agg_time_dim(  # noqa: D
+def test_offset_window_with_agg_time_dim(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
@@ -571,7 +571,7 @@ def test_offset_window_with_agg_time_dim(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_offset_to_grain_with_agg_time_dim(  # noqa: D
+def test_offset_to_grain_with_agg_time_dim(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
@@ -597,7 +597,7 @@ def test_offset_to_grain_with_agg_time_dim(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_offset_metric_with_agg_time_dim(  # noqa: D
+def test_derived_offset_metric_with_agg_time_dim(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
@@ -623,7 +623,7 @@ def test_derived_offset_metric_with_agg_time_dim(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_multi_metric_fill_null(  # noqa: D
+def test_multi_metric_fill_null(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -651,7 +651,7 @@ def test_multi_metric_fill_null(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_nested_fill_nulls_without_time_spine(  # noqa: D
+def test_nested_fill_nulls_without_time_spine(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -676,7 +676,7 @@ def test_nested_fill_nulls_without_time_spine(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_nested_fill_nulls_without_time_spine_multi_metric(  # noqa: D
+def test_nested_fill_nulls_without_time_spine_multi_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,

--- a/metricflow/test/query_rendering/test_fill_nulls_with_rendering.py
+++ b/metricflow/test/query_rendering/test_fill_nulls_with_rendering.py
@@ -28,7 +28,7 @@ from metricflow.test.query_rendering.compare_rendered_query import convert_and_c
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_fill_nulls_with_0_metric_time(  # noqa: D
+def test_simple_fill_nulls_with_0_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -52,7 +52,7 @@ def test_simple_fill_nulls_with_0_metric_time(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_fill_nulls_with_0_month(  # noqa: D
+def test_simple_fill_nulls_with_0_month(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -76,7 +76,7 @@ def test_simple_fill_nulls_with_0_month(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_fill_nulls_with_0_with_non_metric_time(  # noqa: D
+def test_simple_fill_nulls_with_0_with_non_metric_time(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -102,7 +102,7 @@ def test_simple_fill_nulls_with_0_with_non_metric_time(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_fill_nulls_with_0_with_categorical_dimension(  # noqa: D
+def test_simple_fill_nulls_with_0_with_categorical_dimension(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -126,7 +126,7 @@ def test_simple_fill_nulls_with_0_with_categorical_dimension(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_fill_nulls_without_time_spine(  # noqa: D
+def test_simple_fill_nulls_without_time_spine(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -150,7 +150,7 @@ def test_simple_fill_nulls_without_time_spine(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_cumulative_fill_nulls(  # noqa: D
+def test_cumulative_fill_nulls(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -174,7 +174,7 @@ def test_cumulative_fill_nulls(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_derived_fill_nulls_for_one_input_metric(  # noqa: D
+def test_derived_fill_nulls_for_one_input_metric(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -198,7 +198,7 @@ def test_derived_fill_nulls_for_one_input_metric(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_join_to_time_spine_with_filters(  # noqa: D
+def test_join_to_time_spine_with_filters(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,

--- a/metricflow/test/query_rendering/test_granularity_date_part_rendering.py
+++ b/metricflow/test/query_rendering/test_granularity_date_part_rendering.py
@@ -24,7 +24,7 @@ from metricflow.test.query_rendering.compare_rendered_query import convert_and_c
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_query_with_date_part(  # noqa: D
+def test_simple_query_with_date_part(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -50,7 +50,7 @@ def test_simple_query_with_date_part(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_query_with_multiple_date_parts(  # noqa: D
+def test_simple_query_with_multiple_date_parts(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -81,7 +81,7 @@ def test_simple_query_with_multiple_date_parts(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_offset_window_with_date_part(  # noqa: D
+def test_offset_window_with_date_part(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,

--- a/metricflow/test/query_rendering/test_metric_time_without_metrics.py
+++ b/metricflow/test/query_rendering/test_metric_time_without_metrics.py
@@ -42,7 +42,7 @@ def test_metric_time_only(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_metric_time_quarter_alone(  # noqa:D
+def test_metric_time_quarter_alone(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -69,7 +69,7 @@ def test_metric_time_quarter_alone(  # noqa:D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_metric_time_with_other_dimensions(  # noqa:D
+def test_metric_time_with_other_dimensions(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -96,7 +96,7 @@ def test_metric_time_with_other_dimensions(  # noqa:D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_dimensions_with_time_constraint(  # noqa:D
+def test_dimensions_with_time_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,

--- a/metricflow/test/query_rendering/test_query_rendering.py
+++ b/metricflow/test/query_rendering/test_query_rendering.py
@@ -126,7 +126,7 @@ def test_partitioned_join(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_limit_rows(  # noqa: D
+def test_limit_rows(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -157,7 +157,7 @@ def test_limit_rows(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_distinct_values(  # noqa: D
+def test_distinct_values(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
@@ -187,7 +187,7 @@ def test_distinct_values(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_local_dimension_using_local_entity(  # noqa: D
+def test_local_dimension_using_local_entity(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -216,7 +216,7 @@ def test_local_dimension_using_local_entity(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_measure_constraint(  # noqa: D
+def test_measure_constraint(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
@@ -240,7 +240,7 @@ def test_measure_constraint(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_measure_constraint_with_reused_measure(  # noqa: D
+def test_measure_constraint_with_reused_measure(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
@@ -264,7 +264,7 @@ def test_measure_constraint_with_reused_measure(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_measure_constraint_with_single_expr_and_alias(  # noqa: D
+def test_measure_constraint_with_single_expr_and_alias(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     query_parser: MetricFlowQueryParser,
@@ -370,7 +370,7 @@ def test_multi_hop_to_scd_dimension(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_multiple_metrics_no_dimensions(  # noqa: D
+def test_multiple_metrics_no_dimensions(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -396,7 +396,7 @@ def test_multiple_metrics_no_dimensions(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_metric_with_measures_from_multiple_sources_no_dimensions(  # noqa: D
+def test_metric_with_measures_from_multiple_sources_no_dimensions(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
@@ -419,7 +419,7 @@ def test_metric_with_measures_from_multiple_sources_no_dimensions(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_common_semantic_model(  # noqa: D
+def test_common_semantic_model(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,

--- a/metricflow/test/query_rendering/test_time_spine_join_rendering.py
+++ b/metricflow/test/query_rendering/test_time_spine_join_rendering.py
@@ -25,7 +25,7 @@ from metricflow.test.query_rendering.compare_rendered_query import convert_and_c
 
 
 @pytest.mark.sql_engine_snapshot
-def test_simple_join_to_time_spine(  # noqa: D
+def test_simple_join_to_time_spine(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,

--- a/metricflow/test/snapshot_utils.py
+++ b/metricflow/test/snapshot_utils.py
@@ -35,7 +35,7 @@ def make_schema_replacement_function(system_schema: str, source_schema: str) -> 
     """Generates a function to replace schema names in test outputs."""
 
     # The schema of the warehouse used in tests changes from run to run, so don't compare those.
-    def replacement_function(text: str) -> str:  # noqa: D
+    def replacement_function(text: str) -> str:
         # Replace with a string of the same length so that indents are preserved.
         text = text.replace(source_schema, PLACEHOLDER_CHAR_FOR_INCOMPARABLE_STRINGS * len(source_schema))
         # Same with the MetricFlow system schema.
@@ -227,7 +227,7 @@ def assert_snapshot_text_equal(
             assert False, f"Snapshot from {file_path} does not match. Diff from expected to actual:\n" + "\n".join(diff)
 
 
-def assert_execution_plan_text_equal(  # noqa: D
+def assert_execution_plan_text_equal(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -246,7 +246,7 @@ def assert_execution_plan_text_equal(  # noqa: D
     )
 
 
-def assert_dataflow_plan_text_equal(  # noqa: D
+def assert_dataflow_plan_text_equal(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan: DataflowPlan,
@@ -332,7 +332,7 @@ def assert_str_snapshot_equal(  # type: ignore[misc]
     )
 
 
-def assert_linkable_element_set_snapshot_equal(  # noqa: D
+def assert_linkable_element_set_snapshot_equal(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     set_id: str,
@@ -345,9 +345,11 @@ def assert_linkable_element_set_snapshot_equal(  # noqa: D
             rows.append(
                 (
                     # Checking a limited set of fields as the result is large due to the paths in the object.
-                    linkable_dimension.semantic_model_origin.semantic_model_name
-                    if linkable_dimension.semantic_model_origin
-                    else None,
+                    (
+                        linkable_dimension.semantic_model_origin.semantic_model_name
+                        if linkable_dimension.semantic_model_origin
+                        else None
+                    ),
                     tuple(entity_link.element_name for entity_link in linkable_dimension.entity_links),
                     linkable_dimension.element_name,
                     linkable_dimension.time_granularity.name if linkable_dimension.time_granularity is not None else "",
@@ -379,7 +381,7 @@ def assert_linkable_element_set_snapshot_equal(  # noqa: D
     )
 
 
-def assert_spec_set_snapshot_equal(  # noqa: D
+def assert_spec_set_snapshot_equal(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, set_id: str, spec_set: InstanceSpecSet
 ) -> None:
     assert_object_snapshot_equal(
@@ -390,7 +392,7 @@ def assert_spec_set_snapshot_equal(  # noqa: D
     )
 
 
-def assert_linkable_spec_set_snapshot_equal(  # noqa: D
+def assert_linkable_spec_set_snapshot_equal(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, set_id: str, spec_set: LinkableSpecSet
 ) -> None:
     # TODO: This will be used in a later PR and this message will be removed.

--- a/metricflow/test/specs/patterns/test_entity_link_pattern.py
+++ b/metricflow/test/specs/patterns/test_entity_link_pattern.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
-def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D
+def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D103
     return (
         # Time dimensions
         MTD_SPEC_WEEK,
@@ -69,7 +69,7 @@ def test_valid_parameter_fields() -> None:
         assert spec_field.value in parameter_set_dict, f"{spec_field} is not a valid field for {parameter_set}"
 
 
-def test_dimension_match(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D
+def test_dimension_match(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D103
     pattern = EntityLinkPattern(
         EntityLinkPatternParameterSet.from_parameters(
             element_name="is_instant",
@@ -88,7 +88,7 @@ def test_dimension_match(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa
     )
 
 
-def test_entity_match(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D
+def test_entity_match(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D103
     pattern = EntityLinkPattern(
         EntityLinkPatternParameterSet.from_parameters(
             element_name="listing",
@@ -107,7 +107,7 @@ def test_entity_match(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D
     )
 
 
-def test_time_dimension_match(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D
+def test_time_dimension_match(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D103
     pattern = EntityLinkPattern(
         EntityLinkPatternParameterSet.from_parameters(
             element_name=METRIC_TIME_ELEMENT_NAME,
@@ -125,7 +125,7 @@ def test_time_dimension_match(specs: Sequence[LinkableInstanceSpec]) -> None:  #
     assert tuple(pattern.match(specs)) == (MTD_SPEC_WEEK,)
 
 
-def test_time_dimension_match_without_grain_specified(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D
+def test_time_dimension_match_without_grain_specified(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D103
     pattern = EntityLinkPattern(
         EntityLinkPatternParameterSet.from_parameters(
             element_name=METRIC_TIME_ELEMENT_NAME,

--- a/metricflow/test/specs/patterns/test_typed_patterns.py
+++ b/metricflow/test/specs/patterns/test_typed_patterns.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
-def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D
+def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D103
     return (
         # Time dimensions
         TimeDimensionSpec(
@@ -48,7 +48,7 @@ def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D
     )
 
 
-def test_dimension_pattern(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D
+def test_dimension_pattern(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D103
     pattern = DimensionPattern.from_call_parameter_set(
         DimensionCallParameterSet(
             entity_path=(EntityReference("booking"), EntityReference("listing")),
@@ -76,7 +76,7 @@ def test_dimension_pattern(specs: Sequence[LinkableInstanceSpec]) -> None:  # no
     )
 
 
-def test_time_dimension_pattern(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D
+def test_time_dimension_pattern(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D103
     pattern = TimeDimensionPattern.from_call_parameter_set(
         TimeDimensionCallParameterSet(
             entity_path=(EntityReference("booking"), EntityReference("listing")),
@@ -94,7 +94,7 @@ def test_time_dimension_pattern(specs: Sequence[LinkableInstanceSpec]) -> None: 
     )
 
 
-def test_time_dimension_pattern_with_date_part(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D
+def test_time_dimension_pattern_with_date_part(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D103
     pattern = TimeDimensionPattern.from_call_parameter_set(
         TimeDimensionCallParameterSet(
             entity_path=(EntityReference("booking"), EntityReference("listing")),
@@ -113,7 +113,7 @@ def test_time_dimension_pattern_with_date_part(specs: Sequence[LinkableInstanceS
     )
 
 
-def test_entity_pattern(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D
+def test_entity_pattern(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D103
     pattern = EntityPattern.from_call_parameter_set(
         EntityCallParameterSet(
             entity_path=(EntityReference("booking"), EntityReference("listing")),

--- a/metricflow/test/specs/test_time_dimension_spec.py
+++ b/metricflow/test/specs/test_time_dimension_spec.py
@@ -10,7 +10,7 @@ from metricflow.specs.specs import TimeDimensionSpec, TimeDimensionSpecField
 logger = logging.getLogger(__name__)
 
 
-def test_comparison_key_excluding_time_grain() -> None:  # noqa: D
+def test_comparison_key_excluding_time_grain() -> None:  # noqa: D103
     spec0 = TimeDimensionSpec(
         element_name="element0",
         entity_links=(EntityReference("entity0"),),

--- a/metricflow/test/sql/compare_sql_plan.py
+++ b/metricflow/test/sql/compare_sql_plan.py
@@ -13,7 +13,7 @@ from metricflow.test.snapshot_utils import (
 )
 
 
-def assert_default_rendered_sql_equal(  # noqa: D
+def assert_default_rendered_sql_equal(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     plan_id: str,
@@ -33,7 +33,7 @@ def assert_default_rendered_sql_equal(  # noqa: D
     )
 
 
-def assert_rendered_sql_equal(  # noqa: D
+def assert_rendered_sql_equal(
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     plan_id: str,
@@ -75,7 +75,7 @@ def assert_rendered_sql_from_plan_equal(
     )
 
 
-def assert_sql_plan_text_equal(  # noqa: D
+def assert_sql_plan_text_equal(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_query_plan: SqlQueryPlan,

--- a/metricflow/test/sql/optimizer/test_column_pruner.py
+++ b/metricflow/test/sql/optimizer/test_column_pruner.py
@@ -27,12 +27,12 @@ from metricflow.test.sql.compare_sql_plan import assert_default_rendered_sql_equ
 
 
 @pytest.fixture
-def column_pruner() -> SqlColumnPrunerOptimizer:  # noqa: D
+def column_pruner() -> SqlColumnPrunerOptimizer:  # noqa: D103
     return SqlColumnPrunerOptimizer()
 
 
 @pytest.fixture
-def sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D
+def sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
     return DefaultSqlQueryPlanRenderer()
 
 

--- a/metricflow/test/sql/optimizer/test_table_alias_simplifier.py
+++ b/metricflow/test/sql/optimizer/test_table_alias_simplifier.py
@@ -24,7 +24,7 @@ from metricflow.test.sql.compare_sql_plan import assert_default_rendered_sql_equ
 
 
 @pytest.fixture
-def sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D
+def sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
     return DefaultSqlQueryPlanRenderer()
 
 

--- a/metricflow/test/sql/test_bind_parameter_serialization.py
+++ b/metricflow/test/sql/test_bind_parameter_serialization.py
@@ -7,16 +7,16 @@ from metricflow.sql.sql_bind_parameters import SqlBindParameter, SqlBindParamete
 
 
 @pytest.fixture
-def serializer() -> DataclassSerializer:  # noqa: D
+def serializer() -> DataclassSerializer:  # noqa: D103
     return DataclassSerializer()
 
 
 @pytest.fixture
-def deserializer() -> DataClassDeserializer:  # noqa: D
+def deserializer() -> DataClassDeserializer:  # noqa: D103
     return DataClassDeserializer()
 
 
-def test_serialization(  # noqa: D
+def test_serialization(  # noqa: D103
     serializer: DataclassSerializer,
     deserializer: DataClassDeserializer,
 ) -> None:

--- a/metricflow/test/sql/test_sql_expr_render.py
+++ b/metricflow/test/sql/test_sql_expr_render.py
@@ -40,17 +40,17 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def default_expr_renderer() -> DefaultSqlExpressionRenderer:  # noqa: D
+def default_expr_renderer() -> DefaultSqlExpressionRenderer:  # noqa: D103
     return DefaultSqlExpressionRenderer()
 
 
-def test_str_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_str_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(SqlStringExpression("a + b")).sql
     expected = "a + b"
     assert actual == expected
 
 
-def test_col_ref_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_col_ref_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlColumnReferenceExpression(SqlColumnReference("my_table", "my_col"))
     ).sql
@@ -58,7 +58,7 @@ def test_col_ref_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> No
     assert actual == expected
 
 
-def test_comparison_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_comparison_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlComparisonExpression(
             left_expr=SqlColumnReferenceExpression(SqlColumnReference("my_table", "my_col")),
@@ -69,7 +69,7 @@ def test_comparison_expr(default_expr_renderer: DefaultSqlExpressionRenderer) ->
     assert actual == "my_table.my_col = (a + b)"
 
 
-def test_require_parenthesis(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_require_parenthesis(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlComparisonExpression(
             left_expr=SqlColumnReferenceExpression(SqlColumnReference("a", "booking_value")),
@@ -81,7 +81,7 @@ def test_require_parenthesis(default_expr_renderer: DefaultSqlExpressionRenderer
     assert actual == "a.booking_value > 100"
 
 
-def test_function_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_function_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlAggregateFunctionExpression(
             sql_function=SqlFunction.SUM,
@@ -109,7 +109,7 @@ def test_distinct_agg_expr(default_expr_renderer: DefaultSqlExpressionRenderer) 
     assert actual == "COUNT(DISTINCT my_table.a, my_table.b)"
 
 
-def test_nested_function_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_nested_function_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlAggregateFunctionExpression(
             sql_function=SqlFunction.CONCAT,
@@ -128,12 +128,12 @@ def test_nested_function_expr(default_expr_renderer: DefaultSqlExpressionRendere
     assert actual == "CONCAT(my_table.a, CONCAT(my_table.b, my_table.c))"
 
 
-def test_null_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_null_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(SqlNullExpression()).sql
     assert actual == "NULL"
 
 
-def test_and_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_and_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlLogicalExpression(
             operator=SqlLogicalOperator.AND,
@@ -153,7 +153,7 @@ def test_and_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None: 
     )
 
 
-def test_long_and_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_long_and_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlLogicalExpression(
             operator=SqlLogicalOperator.AND,
@@ -180,33 +180,33 @@ def test_long_and_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> N
     )
 
 
-def test_string_literal_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_string_literal_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(SqlStringLiteralExpression("foo")).sql
     assert actual == "'foo'"
 
 
-def test_is_null_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_is_null_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlIsNullExpression(SqlStringExpression("foo", requires_parenthesis=False))
     ).sql
     assert actual == "foo IS NULL"
 
 
-def test_date_trunc_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_date_trunc_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlDateTruncExpression(time_granularity=TimeGranularity.MONTH, arg=SqlStringExpression("ds"))
     ).sql
     assert actual == "DATE_TRUNC('month', ds)"
 
 
-def test_extract_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_extract_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlExtractExpression(date_part=DatePart.DOY, arg=SqlStringExpression("ds"))
     ).sql
     assert actual == "EXTRACT(doy FROM ds)"
 
 
-def test_ratio_computation_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_ratio_computation_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlRatioComputationExpression(
             numerator=SqlAggregateFunctionExpression(
@@ -218,7 +218,7 @@ def test_ratio_computation_expr(default_expr_renderer: DefaultSqlExpressionRende
     assert actual == "CAST(SUM(1) AS DOUBLE) / CAST(NULLIF(a.divide_by_me, 0) AS DOUBLE)"
 
 
-def test_expr_rewrite(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_expr_rewrite(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     expr = SqlLogicalExpression(
         operator=SqlLogicalOperator.AND,
         args=(
@@ -237,7 +237,7 @@ def test_expr_rewrite(default_expr_renderer: DefaultSqlExpressionRenderer) -> No
     assert default_expr_renderer.render_sql_expr(expr_rewritten).sql == "foo AND bar"
 
 
-def test_between_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D
+def test_between_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
         SqlBetweenExpression(
             column_arg=SqlColumnReferenceExpression(SqlColumnReference("a", "col0")),
@@ -256,7 +256,7 @@ def test_between_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> No
     assert actual == "a.col0 BETWEEN CAST('2020-01-01' AS TIMESTAMP) AND CAST('2020-01-10' AS TIMESTAMP)"
 
 
-def test_window_function_expr(  # noqa: D
+def test_window_function_expr(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     default_expr_renderer: DefaultSqlExpressionRenderer,

--- a/metricflow/test/sql/test_sql_plan_render.py
+++ b/metricflow/test/sql/test_sql_plan_render.py
@@ -220,7 +220,7 @@ def test_component_rendering(
 
 
 @pytest.mark.sql_engine_snapshot
-def test_render_where(  # noqa: D
+def test_render_where(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -261,7 +261,7 @@ def test_render_where(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_render_order_by(  # noqa: D
+def test_render_order_by(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -311,7 +311,7 @@ def test_render_order_by(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_render_limit(  # noqa: D
+def test_render_limit(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
@@ -343,7 +343,7 @@ def test_render_limit(  # noqa: D
 
 
 @pytest.mark.sql_engine_snapshot
-def test_render_create_table_as(  # noqa: D
+def test_render_create_table_as(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,

--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -21,7 +21,7 @@ def _random_table() -> str:
     return f"test_table_{random_id()}"
 
 
-def _select_x_as_y(x: int = 1, y: str = "y") -> str:  # noqa: D
+def _select_x_as_y(x: int = 1, y: str = "y") -> str:
     return f"SELECT {x} AS {y}"
 
 
@@ -38,18 +38,18 @@ def _check_1col(df: pd.DataFrame, col: str = "y", vals: Set[Union[int, str]] = {
     assert set(df[col]) == vals
 
 
-def test_query(sql_client: SqlClient) -> None:  # noqa: D
+def test_query(sql_client: SqlClient) -> None:  # noqa: D103
     df = sql_client.query(_select_x_as_y())
     _check_1col(df)
 
 
-def test_select_one_query(sql_client: SqlClient) -> None:  # noqa: D
+def test_select_one_query(sql_client: SqlClient) -> None:  # noqa: D103
     sql_client.query("SELECT 1")
     with pytest.raises(Exception):
         sql_client.query("this is garbage")
 
 
-def test_create_table_from_dataframe(  # noqa: D
+def test_create_table_from_dataframe(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration, ddl_sql_client: SqlClientWithDDLMethods
 ) -> None:
     expected_df = pd.DataFrame(
@@ -93,7 +93,7 @@ def example_df() -> pd.DataFrame:
     )
 
 
-def test_dry_run(mf_test_configuration: MetricFlowTestConfiguration, sql_client: SqlClient) -> None:  # noqa: D
+def test_dry_run(mf_test_configuration: MetricFlowTestConfiguration, sql_client: SqlClient) -> None:  # noqa: D103
     test_table = SqlTable(schema_name=mf_test_configuration.mf_system_schema, table_name=_random_table())
 
     stmt = f"CREATE TABLE {test_table.sql} AS SELECT 1 AS foo"
@@ -112,7 +112,7 @@ def test_dry_run(mf_test_configuration: MetricFlowTestConfiguration, sql_client:
     ), f"Expected an exception about table {match} not found, but got `{exception_message}`"
 
 
-def test_dry_run_of_bad_query_raises_exception(sql_client: SqlClient) -> None:  # noqa: D
+def test_dry_run_of_bad_query_raises_exception(sql_client: SqlClient) -> None:  # noqa: D103
     bad_stmt = "SELECT bad_col"
     # Tests that a bad query raises an exception. Different engines may raise different exceptions e.g.
     # ProgrammingError, OperationalError, google.api_core.exceptions.BadRequest, etc.
@@ -120,14 +120,14 @@ def test_dry_run_of_bad_query_raises_exception(sql_client: SqlClient) -> None:  
         sql_client.dry_run(bad_stmt)
 
 
-def test_update_params_with_same_item() -> None:  # noqa: D
+def test_update_params_with_same_item() -> None:  # noqa: D103
     bind_params0 = SqlBindParameters.create_from_dict({"key": "value"})
     bind_params1 = SqlBindParameters.create_from_dict({"key": "value"})
 
     bind_params0.combine(bind_params1)
 
 
-def test_update_params_with_same_key_different_values() -> None:  # noqa: D
+def test_update_params_with_same_key_different_values() -> None:  # noqa: D103
     bind_params0 = SqlBindParameters.create_from_dict(({"key": "value0"}))
     bind_params1 = SqlBindParameters.create_from_dict(({"key": "value1"}))
 

--- a/metricflow/test/table_snapshot/table_snapshots.py
+++ b/metricflow/test/table_snapshot/table_snapshots.py
@@ -29,11 +29,11 @@ class SqlTableSnapshotHash:
     str_value: str
 
     @staticmethod
-    def create_from_hashes(hashes: Sequence[SqlTableSnapshotHash]) -> SqlTableSnapshotHash:  # noqa: D
+    def create_from_hashes(hashes: Sequence[SqlTableSnapshotHash]) -> SqlTableSnapshotHash:  # noqa: D102
         return SqlTableSnapshotHash(hash_items(tuple(one_hash.str_value for one_hash in hashes)))
 
 
-class SqlTableColumnType(Enum):  # noqa: D
+class SqlTableColumnType(Enum):  # noqa: D101
     STRING = "STRING"
     TIME = "TIME"
     FLOAT = "FLOAT"
@@ -45,14 +45,14 @@ class SqlTableColumnDefinition(FrozenBaseModel):
     """Pydantic class to help parse column definitions in a table snapshots that are defined in YAML."""
 
     # Pydantic feature to throw errors on extra fields.
-    class Config:  # noqa: D
+    class Config:  # noqa: D106
         extra = "forbid"
 
     name: str
     type: SqlTableColumnType
 
 
-class SqlTableSnapshotTypeException(Exception):  # noqa: D
+class SqlTableSnapshotTypeException(Exception):  # noqa: D101
     pass
 
 
@@ -60,7 +60,7 @@ class SqlTableSnapshot(FrozenBaseModel):
     """Pydantic class to help parse table snapshots that are defined in YAML."""
 
     # Pydantic feature to throw errors on extra fields.
-    class Config:  # noqa: D
+    class Config:  # noqa: D106
         extra = "forbid"
 
     table_name: str
@@ -81,7 +81,7 @@ class SqlTableSnapshot(FrozenBaseModel):
         )
 
     @staticmethod
-    def _parse_bool_str(bool_str: str) -> bool:  # noqa: D
+    def _parse_bool_str(bool_str: str) -> bool:
         if bool_str.lower() == "false":
             return False
         elif bool_str.lower() == "true":
@@ -90,7 +90,7 @@ class SqlTableSnapshot(FrozenBaseModel):
             raise RuntimeError(f"Invalid string representation of a boolean: {bool_str}")
 
     @property
-    def as_df(self) -> pd.DataFrame:  # noqa: D
+    def as_df(self) -> pd.DataFrame:
         """Return this snapshot as represented by an equivalent dataframe."""
         # In the YAML files, all values are strings, but they need to be converted to defined type so that it can be
         # properly represented in a dataframe
@@ -125,11 +125,11 @@ class SqlTableSnapshot(FrozenBaseModel):
 class SqlTableSnapshotLoader:
     """Loads a snapshot of a table into the SQL engine."""
 
-    def __init__(self, ddl_sql_client: SqlClientWithDDLMethods, schema_name: str) -> None:  # noqa: D
+    def __init__(self, ddl_sql_client: SqlClientWithDDLMethods, schema_name: str) -> None:  # noqa: D107
         self._ddl_sql_client = ddl_sql_client
         self._schema_name = schema_name
 
-    def load(self, table_snapshot: SqlTableSnapshot) -> None:  # noqa: D
+    def load(self, table_snapshot: SqlTableSnapshot) -> None:  # noqa: D102
         sql_table = SqlTable(schema_name=self._schema_name, table_name=table_snapshot.table_name)
 
         self._ddl_sql_client.create_table_from_dataframe(
@@ -140,11 +140,11 @@ class SqlTableSnapshotLoader:
         )
 
 
-class TableSnapshotException(Exception):  # noqa: D
+class TableSnapshotException(Exception):  # noqa: D101
     pass
 
 
-class TableSnapshotParseException(TableSnapshotException):  # noqa: D
+class TableSnapshotParseException(TableSnapshotException):  # noqa: D101
     pass
 
 
@@ -214,7 +214,7 @@ class SqlTableSnapshotRepository:
         return results
 
     @staticmethod
-    def _find_all_yaml_file_paths(directory: Path) -> Sequence[Path]:  # noqa: D
+    def _find_all_yaml_file_paths(directory: Path) -> Sequence[Path]:
         """Recursively search through the given directory for YAML files."""
         yaml_file_paths = []
 
@@ -226,7 +226,7 @@ class SqlTableSnapshotRepository:
         return sorted(yaml_file_paths)
 
     @property
-    def table_snapshots(self) -> Sequence[SqlTableSnapshot]:  # noqa: D
+    def table_snapshots(self) -> Sequence[SqlTableSnapshot]:  # noqa: D102
         # tuple(self._table_snapshots.values()) shows a type warning
         return sorted(
             tuple(table_snapshot for table_snapshot in self._table_snapshots.values()),

--- a/metricflow/test/table_snapshot/test_table_snapshots.py
+++ b/metricflow/test/table_snapshot/test_table_snapshots.py
@@ -22,7 +22,7 @@ from metricflow.test.table_snapshot.table_snapshots import (
 
 
 @pytest.fixture
-def table_snapshot() -> SqlTableSnapshot:  # noqa: D
+def table_snapshot() -> SqlTableSnapshot:  # noqa: D103
     rows = (
         ("true", "1", "1.0", "2020-01-02", "hi"),
         ("false", "-1", "-1.0", "2020-03-04 05:06:07", "bye"),

--- a/metricflow/test/telemetry/test_telemetry.py
+++ b/metricflow/test/telemetry/test_telemetry.py
@@ -11,14 +11,14 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def telemetry_reporter() -> TelemetryReporter:  # noqa: D
+def telemetry_reporter() -> TelemetryReporter:  # noqa: D103
     reporter = TelemetryReporter(report_levels_higher_or_equal_to=TelemetryLevel.USAGE)
     reporter.add_python_log_handler()
     reporter.add_test_handler()
     return reporter
 
 
-def test_function_call(telemetry_reporter: TelemetryReporter) -> None:  # noqa: D
+def test_function_call(telemetry_reporter: TelemetryReporter) -> None:  # noqa: D103
     @log_call(telemetry_reporter=telemetry_reporter, module_name=__name__)
     def test_function() -> str:
         return "foo"
@@ -36,7 +36,7 @@ def test_function_call(telemetry_reporter: TelemetryReporter) -> None:  # noqa: 
     assert end_event.runtime > 0
 
 
-def test_function_exception(telemetry_reporter: TelemetryReporter) -> None:  # noqa: D
+def test_function_exception(telemetry_reporter: TelemetryReporter) -> None:  # noqa: D103
     with pytest.raises(ValueError):
 
         @log_call(telemetry_reporter=telemetry_reporter, module_name=__name__)
@@ -58,7 +58,7 @@ def test_function_exception(telemetry_reporter: TelemetryReporter) -> None:  # n
     assert end_event.runtime > 0
 
 
-def test_telemetry_off() -> None:  # noqa: D
+def test_telemetry_off() -> None:  # noqa: D103
     reporter = TelemetryReporter(report_levels_higher_or_equal_to=TelemetryLevel.OFF)
     reporter.add_python_log_handler()
     reporter.add_test_handler()

--- a/metricflow/test/test_instance_serialization.py
+++ b/metricflow/test/test_instance_serialization.py
@@ -13,16 +13,16 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def serializer() -> DataclassSerializer:  # noqa: D
+def serializer() -> DataclassSerializer:  # noqa: D103
     return DataclassSerializer()
 
 
 @pytest.fixture
-def deserializer() -> DataClassDeserializer:  # noqa: D
+def deserializer() -> DataClassDeserializer:  # noqa: D103
     return DataClassDeserializer()
 
 
-def test_serialization(  # noqa: D
+def test_serialization(  # noqa: D103
     mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
     serializer: DataclassSerializer,
     deserializer: DataClassDeserializer,

--- a/metricflow/test/test_specs.py
+++ b/metricflow/test/test_specs.py
@@ -20,7 +20,7 @@ from metricflow.specs.specs import (
 
 
 @pytest.fixture
-def dimension_spec() -> DimensionSpec:  # noqa: D
+def dimension_spec() -> DimensionSpec:  # noqa: D103
     return DimensionSpec(
         element_name="platform",
         entity_links=(
@@ -31,7 +31,7 @@ def dimension_spec() -> DimensionSpec:  # noqa: D
 
 
 @pytest.fixture
-def time_dimension_spec() -> TimeDimensionSpec:  # noqa: D
+def time_dimension_spec() -> TimeDimensionSpec:  # noqa: D103
     return TimeDimensionSpec(
         element_name="signup_ts",
         entity_links=(EntityReference(element_name="user_id"),),
@@ -40,7 +40,7 @@ def time_dimension_spec() -> TimeDimensionSpec:  # noqa: D
 
 
 @pytest.fixture
-def entity_spec() -> EntitySpec:  # noqa: D
+def entity_spec() -> EntitySpec:  # noqa: D103
     return EntitySpec(
         element_name="user_id",
         entity_links=(EntityReference(element_name="listing_id"),),
@@ -52,17 +52,17 @@ def test_merge_specs(dimension_spec: DimensionSpec, entity_spec: EntitySpec) -> 
     assert InstanceSpec.merge([dimension_spec], [entity_spec]) == [dimension_spec, entity_spec]
 
 
-def test_dimension_without_first_entity_link(dimension_spec: DimensionSpec) -> None:  # noqa: D
+def test_dimension_without_first_entity_link(dimension_spec: DimensionSpec) -> None:  # noqa: D103
     assert dimension_spec.without_first_entity_link == DimensionSpec(
         element_name="platform", entity_links=(EntityReference(element_name="device_id"),)
     )
 
 
-def test_dimension_without_entity_links(dimension_spec: DimensionSpec) -> None:  # noqa: D
+def test_dimension_without_entity_links(dimension_spec: DimensionSpec) -> None:  # noqa: D103
     assert dimension_spec.without_entity_links == DimensionSpec(element_name="platform", entity_links=())
 
 
-def test_time_dimension_without_first_entity_link(time_dimension_spec: TimeDimensionSpec) -> None:  # noqa: D
+def test_time_dimension_without_first_entity_link(time_dimension_spec: TimeDimensionSpec) -> None:  # noqa: D103
     assert time_dimension_spec.without_first_entity_link == TimeDimensionSpec(
         element_name="signup_ts",
         entity_links=(),
@@ -70,7 +70,7 @@ def test_time_dimension_without_first_entity_link(time_dimension_spec: TimeDimen
     )
 
 
-def test_time_dimension_without_entity_links(time_dimension_spec: TimeDimensionSpec) -> None:  # noqa: D
+def test_time_dimension_without_entity_links(time_dimension_spec: TimeDimensionSpec) -> None:  # noqa: D103
     assert time_dimension_spec.without_entity_links == TimeDimensionSpec(
         element_name="signup_ts",
         entity_links=(),
@@ -78,34 +78,34 @@ def test_time_dimension_without_entity_links(time_dimension_spec: TimeDimensionS
     )
 
 
-def test_entity_without_first_entity_link(entity_spec: EntitySpec) -> None:  # noqa: D
+def test_entity_without_first_entity_link(entity_spec: EntitySpec) -> None:  # noqa: D103
     assert entity_spec.without_first_entity_link == EntitySpec(
         element_name="user_id",
         entity_links=(),
     )
 
 
-def test_entity_without_entity_links(entity_spec: EntitySpec) -> None:  # noqa: D
+def test_entity_without_entity_links(entity_spec: EntitySpec) -> None:  # noqa: D103
     assert entity_spec.without_entity_links == EntitySpec(
         element_name="user_id",
         entity_links=(),
     )
 
 
-def test_merge_linkable_specs(dimension_spec: DimensionSpec, entity_spec: EntitySpec) -> None:  # noqa: D
+def test_merge_linkable_specs(dimension_spec: DimensionSpec, entity_spec: EntitySpec) -> None:  # noqa: D103
     linkable_specs: Sequence[LinkableInstanceSpec] = [dimension_spec, entity_spec]
 
     assert LinkableInstanceSpec.merge_linkable_specs([dimension_spec], [entity_spec]) == linkable_specs
 
 
-def test_qualified_name() -> None:  # noqa: D
+def test_qualified_name() -> None:  # noqa: D103
     assert (
         DimensionSpec(element_name="country", entity_links=(EntityReference("listing_id"),)).qualified_name
         == "listing_id__country"
     )
 
 
-def test_merge_spec_set() -> None:  # noqa: D
+def test_merge_spec_set() -> None:  # noqa: D103
     spec_set1 = InstanceSpecSet(metric_specs=(MetricSpec(element_name="bookings"),))
     spec_set2 = InstanceSpecSet(
         dimension_specs=(DimensionSpec(element_name="is_instant", entity_links=(EntityReference("booking"),)),)
@@ -118,7 +118,7 @@ def test_merge_spec_set() -> None:  # noqa: D
 
 
 @pytest.fixture
-def spec_set() -> InstanceSpecSet:  # noqa: D
+def spec_set() -> InstanceSpecSet:  # noqa: D103
     return InstanceSpecSet(
         metric_specs=(MetricSpec(element_name="bookings"),),
         measure_specs=(
@@ -143,7 +143,7 @@ def spec_set() -> InstanceSpecSet:  # noqa: D
     )
 
 
-def test_spec_set_linkable_specs(spec_set: InstanceSpecSet) -> None:  # noqa: D
+def test_spec_set_linkable_specs(spec_set: InstanceSpecSet) -> None:  # noqa: D103
     assert set(spec_set.linkable_specs) == {
         DimensionSpec(element_name="is_instant", entity_links=(EntityReference("booking"),)),
         TimeDimensionSpec(
@@ -158,7 +158,7 @@ def test_spec_set_linkable_specs(spec_set: InstanceSpecSet) -> None:  # noqa: D
     }
 
 
-def test_spec_set_all_specs(spec_set: InstanceSpecSet) -> None:  # noqa: D
+def test_spec_set_all_specs(spec_set: InstanceSpecSet) -> None:  # noqa: D103
     assert set(spec_set.all_specs) == {
         MetricSpec(element_name="bookings"),
         MeasureSpec(
@@ -177,7 +177,7 @@ def test_spec_set_all_specs(spec_set: InstanceSpecSet) -> None:  # noqa: D
     }
 
 
-def test_linkless_entity() -> None:  # noqa: D
+def test_linkless_entity() -> None:
     """Check that equals and hash works as expected for the LinklessEntitySpec / EntitySpec."""
     entity_spec = EntitySpec(element_name="user_id", entity_links=())
     linkless_entity_spec = LinklessEntitySpec.from_element_name("user_id")

--- a/metricflow/test/time/configurable_time_source.py
+++ b/metricflow/test/time/configurable_time_source.py
@@ -8,12 +8,12 @@ from metricflow.time.time_source import TimeSource
 class ConfigurableTimeSource(TimeSource):
     """A time source that can be configured so that scheduled operations can be simulated in testing."""
 
-    def __init__(self, configured_time: datetime.datetime) -> None:  # noqa: D
+    def __init__(self, configured_time: datetime.datetime) -> None:  # noqa: D107
         self._configured_time = configured_time
 
-    def get_time(self) -> datetime.datetime:  # noqa: D
+    def get_time(self) -> datetime.datetime:  # noqa: D102
         return self._configured_time
 
-    def set_time(self, new_time: datetime.datetime) -> datetime.datetime:  # noqa: D
+    def set_time(self, new_time: datetime.datetime) -> datetime.datetime:  # noqa: D102
         self._configured_time = new_time
         return new_time

--- a/metricflow/time/time_granularity.py
+++ b/metricflow/time/time_granularity.py
@@ -30,7 +30,7 @@ def format_with_first_or_last(time_granularity: TimeGranularity) -> bool:
     return time_granularity in [TimeGranularity.MONTH, TimeGranularity.QUARTER, TimeGranularity.YEAR]
 
 
-def is_period_start(time_granularity: TimeGranularity, date: Union[pd.Timestamp, date]) -> bool:  # noqa: D
+def is_period_start(time_granularity: TimeGranularity, date: Union[pd.Timestamp, date]) -> bool:  # noqa: D103
     pd_date = pd.Timestamp(date)
 
     if time_granularity is TimeGranularity.DAY:
@@ -47,7 +47,7 @@ def is_period_start(time_granularity: TimeGranularity, date: Union[pd.Timestamp,
         assert_values_exhausted(time_granularity)
 
 
-def is_period_end(time_granularity: TimeGranularity, date: Union[pd.Timestamp, date]) -> bool:  # noqa: D
+def is_period_end(time_granularity: TimeGranularity, date: Union[pd.Timestamp, date]) -> bool:  # noqa: D103
     pd_date = pd.Timestamp(date)
 
     if time_granularity is TimeGranularity.DAY:
@@ -64,7 +64,7 @@ def is_period_end(time_granularity: TimeGranularity, date: Union[pd.Timestamp, d
         assert_values_exhausted(time_granularity)
 
 
-def period_begin_offset(  # noqa: D
+def period_begin_offset(  # noqa: D103
     time_granularity: TimeGranularity,
 ) -> Union[pd.offsets.MonthBegin, pd.offsets.QuarterBegin, pd.offsets.Week, pd.offsets.YearBegin]:
     if time_granularity is TimeGranularity.DAY:
@@ -81,7 +81,7 @@ def period_begin_offset(  # noqa: D
         assert_values_exhausted(time_granularity)
 
 
-def period_end_offset(  # noqa: D
+def period_end_offset(  # noqa: D103
     time_granularity: TimeGranularity,
 ) -> Union[pd.offsets.MonthEnd, pd.offsets.QuarterEnd, pd.offsets.Week, pd.offsets.YearEnd]:
     if time_granularity is TimeGranularity.DAY:
@@ -164,6 +164,6 @@ class ISOWeekDay(ExtendedEnum):
         return self.value - 1
 
 
-def string_to_time_granularity(s: str) -> TimeGranularity:  # noqa: D
+def string_to_time_granularity(s: str) -> TimeGranularity:  # noqa: D103
     values = {item.value: item for item in TimeGranularity}
     return values[s]

--- a/metricflow/time/time_source.py
+++ b/metricflow/time/time_source.py
@@ -11,5 +11,5 @@ class TimeSource(ABC):
     """
 
     @abstractmethod
-    def get_time(self) -> datetime:  # noqa: D
+    def get_time(self) -> datetime:  # noqa: D102
         pass

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = [
+lint.select = [
     # Pyflakes
     "F",
     # Pycodestyle
@@ -10,7 +10,7 @@ select = [
     # isort
     "I",
 ]
-ignore = [
+lint.ignore = [
     # TODO: Fix these.
     # Lines longer than line-length. This is generally handled by Black.
     "E501",
@@ -32,12 +32,12 @@ ignore = [
 ]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = [
+lint.fixable = [
     "A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM",
     "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF",
     "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"
 ]
-unfixable = []
+lint.unfixable = []
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -67,17 +67,17 @@ exclude = [
 line-length = 120
 
 # Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 # Assume Python 3.8, the lowest version that MF supports.
 target-version = "py38"
 
-[mccabe]
+[lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 
-[pydocstyle]
+[lint.pydocstyle]
 convention = "google"
 
-[isort]
+[lint.isort]
 required-imports = ["from __future__ import annotations"]


### PR DESCRIPTION
The version of Ruff pinned in MetricFlow is positively ancient.
This has been a nuisance for some time, forcing VSCode users to
remain on the 2024.14 (or earlier) version of the Ruff extension,
and generally missing out on various improvements.

Now, with test package reshuffling, Ruff's older version's lack of
support for certain isort configuration operations may become even
more relevant.

This change pushes us to the latest version of Ruff. The core of the
change is in .pre-commit-config.yaml, which simply bumps the Ruff
version to current latest (v0.3.3). That version change triggered
two classes of changes:

1. The ruff.toml file must now have a `lint` prefix ahead of certain
keywords.
2. noqa directives must all have specific error overrides.

The second of these represents most changes in this commit - we had
a ton of `# noqa: D` variants in our codebase for docstring lint
error overrides.

These were all fixed by removing any noqa directives causing
problems and replacing them via ruff's `--add-noqa` flag.