### PR TITLE
Allow metrics in filters

### DIFF
--- a/metricflow/query/group_by_item/filter_spec_resolution/filter_pattern_factory.py
+++ b/metricflow/query/group_by_item/filter_spec_resolution/filter_pattern_factory.py
@@ -5,12 +5,18 @@ from abc import ABC, abstractmethod
 from dbt_semantic_interfaces.call_parameter_sets import (
     DimensionCallParameterSet,
     EntityCallParameterSet,
+    MetricCallParameterSet,
     TimeDimensionCallParameterSet,
 )
 from typing_extensions import override
 
 from metricflow.specs.patterns.spec_pattern import SpecPattern
-from metricflow.specs.patterns.typed_patterns import DimensionPattern, EntityPattern, TimeDimensionPattern
+from metricflow.specs.patterns.typed_patterns import (
+    DimensionPattern,
+    EntityPattern,
+    GroupByMetricPattern,
+    TimeDimensionPattern,
+)
 
 
 class WhereFilterPatternFactory(ABC):
@@ -34,6 +40,12 @@ class WhereFilterPatternFactory(ABC):
     ) -> SpecPattern:  # noqa: D102
         raise NotImplementedError
 
+    @abstractmethod
+    def create_for_metric_call_parameter_set(  # noqa: D102
+        self, metric_call_parameter_set: MetricCallParameterSet
+    ) -> SpecPattern:
+        raise NotImplementedError
+
 
 class DefaultWhereFilterPatternFactory(WhereFilterPatternFactory):
     """Default implementation using patterns derived from EntityLinkPattern."""
@@ -53,3 +65,7 @@ class DefaultWhereFilterPatternFactory(WhereFilterPatternFactory):
     @override
     def create_for_entity_call_parameter_set(self, entity_call_parameter_set: EntityCallParameterSet) -> SpecPattern:
         return EntityPattern.from_call_parameter_set(entity_call_parameter_set)
+
+    @override
+    def create_for_metric_call_parameter_set(self, metric_call_parameter_set: MetricCallParameterSet) -> SpecPattern:
+        return GroupByMetricPattern.from_call_parameter_set(metric_call_parameter_set)

--- a/metricflow/query/group_by_item/filter_spec_resolution/filter_spec_lookup.py
+++ b/metricflow/query/group_by_item/filter_spec_resolution/filter_spec_lookup.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional, Sequence, Tuple, Union
 from dbt_semantic_interfaces.call_parameter_sets import (
     DimensionCallParameterSet,
     EntityCallParameterSet,
+    MetricCallParameterSet,
     TimeDimensionCallParameterSet,
 )
 from dbt_semantic_interfaces.protocols import WhereFilterIntersection
@@ -177,7 +178,9 @@ class FilterSpecResolution:
     object_builder_str: str
 
 
-CallParameterSet = Union[DimensionCallParameterSet, TimeDimensionCallParameterSet, EntityCallParameterSet]
+CallParameterSet = Union[
+    DimensionCallParameterSet, TimeDimensionCallParameterSet, EntityCallParameterSet, MetricCallParameterSet
+]
 
 
 @dataclass(frozen=True)

--- a/metricflow/specs/where_filter_metric.py
+++ b/metricflow/specs/where_filter_metric.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from dbt_semantic_interfaces.call_parameter_sets import (
+    MetricCallParameterSet,
+)
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
+from dbt_semantic_interfaces.protocols.query_interface import QueryInterfaceMetric, QueryInterfaceMetricFactory
+from dbt_semantic_interfaces.references import EntityReference, LinkableElementReference, MetricReference
+from typing_extensions import override
+
+from metricflow.errors.errors import InvalidQuerySyntax
+from metricflow.query.group_by_item.filter_spec_resolution.filter_location import WhereFilterLocation
+from metricflow.query.group_by_item.filter_spec_resolution.filter_spec_lookup import (
+    FilterSpecResolutionLookUp,
+    ResolvedSpecLookUpKey,
+)
+from metricflow.specs.column_assoc import ColumnAssociationResolver
+from metricflow.specs.rendered_spec_tracker import RenderedSpecTracker
+
+
+class WhereFilterMetric(ProtocolHint[QueryInterfaceMetric]):
+    """A metric that is passed in through the where filter parameter."""
+
+    @override
+    def _implements_protocol(self) -> QueryInterfaceMetric:
+        return self
+
+    def __init__(  # noqa
+        self,
+        column_association_resolver: ColumnAssociationResolver,
+        resolved_spec_lookup: FilterSpecResolutionLookUp,
+        where_filter_location: WhereFilterLocation,
+        rendered_spec_tracker: RenderedSpecTracker,
+        element_name: str,
+        group_by: Sequence[LinkableElementReference],
+    ) -> None:
+        self._column_association_resolver = column_association_resolver
+        self._resolved_spec_lookup = resolved_spec_lookup
+        self._where_filter_location = where_filter_location
+        self._rendered_spec_tracker = rendered_spec_tracker
+        self._element_name = element_name
+        self._group_by = tuple(group_by)
+
+    def descending(self, _is_descending: bool) -> QueryInterfaceMetric:
+        """Set the sort order for order-by."""
+        raise InvalidQuerySyntax(
+            "Can't set descending in the where clause. Try setting descending in the order_by clause instead"
+        )
+
+    def __str__(self) -> str:
+        """Returns the column name.
+
+        Important in the Jinja sandbox.
+        """
+        call_parameter_set = MetricCallParameterSet(
+            group_by=tuple(EntityReference(element_name=group_by_ref.element_name) for group_by_ref in self._group_by),
+            metric_reference=MetricReference(self._element_name),
+        )
+        resolved_spec = self._resolved_spec_lookup.checked_resolved_spec(
+            ResolvedSpecLookUpKey(
+                filter_location=self._where_filter_location,
+                call_parameter_set=call_parameter_set,
+            )
+        )
+        self._rendered_spec_tracker.record_rendered_spec(resolved_spec)
+        column_association = self._column_association_resolver.resolve_spec(resolved_spec)
+
+        return column_association.column_name
+
+
+class WhereFilterMetricFactory(ProtocolHint[QueryInterfaceMetricFactory]):
+    """Creates a WhereFilterMetric.
+
+    Each call to `create` adds a MetricSpec to metric_specs.
+    """
+
+    @override
+    def _implements_protocol(self) -> QueryInterfaceMetricFactory:
+        return self
+
+    def __init__(  # noqa
+        self,
+        column_association_resolver: ColumnAssociationResolver,
+        spec_resolution_lookup: FilterSpecResolutionLookUp,
+        where_filter_location: WhereFilterLocation,
+        rendered_spec_tracker: RenderedSpecTracker,
+    ):
+        self._column_association_resolver = column_association_resolver
+        self._resolved_spec_lookup = spec_resolution_lookup
+        self._where_filter_location = where_filter_location
+        self._rendered_spec_tracker = rendered_spec_tracker
+
+    def create(self, metric_name: str, group_by: Sequence[str] = ()) -> WhereFilterMetric:
+        """Create a WhereFilterMetric."""
+        return WhereFilterMetric(
+            column_association_resolver=self._column_association_resolver,
+            resolved_spec_lookup=self._resolved_spec_lookup,
+            where_filter_location=self._where_filter_location,
+            rendered_spec_tracker=self._rendered_spec_tracker,
+            element_name=metric_name,
+            group_by=tuple(LinkableElementReference(group_by_name.lower()) for group_by_name in group_by),
+        )

--- a/metricflow/specs/where_filter_transform.py
+++ b/metricflow/specs/where_filter_transform.py
@@ -14,6 +14,7 @@ from metricflow.specs.rendered_spec_tracker import RenderedSpecTracker
 from metricflow.specs.specs import LinkableSpecSet, WhereFilterSpec
 from metricflow.specs.where_filter_dimension import WhereFilterDimensionFactory
 from metricflow.specs.where_filter_entity import WhereFilterEntityFactory
+from metricflow.specs.where_filter_metric import WhereFilterMetricFactory
 from metricflow.specs.where_filter_time_dimension import WhereFilterTimeDimensionFactory
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 
@@ -75,6 +76,12 @@ class WhereSpecFactory:
                 where_filter_location=filter_location,
                 rendered_spec_tracker=rendered_spec_tracker,
             )
+            metric_factory = WhereFilterMetricFactory(
+                column_association_resolver=self._column_association_resolver,
+                spec_resolution_lookup=self._spec_resolution_lookup,
+                where_filter_location=filter_location,
+                rendered_spec_tracker=rendered_spec_tracker,
+            )
             try:
                 # If there was an error with the template, it should have been caught while resolving the specs for
                 # the filters during query resolution.
@@ -83,6 +90,7 @@ class WhereSpecFactory:
                         "Dimension": dimension_factory.create,
                         "TimeDimension": time_dimension_factory.create,
                         "Entity": entity_factory.create,
+                        "Metric": metric_factory.create,
                     }
                 )
             except (jinja2.exceptions.UndefinedError, jinja2.exceptions.TemplateSyntaxError) as e:

--- a/tests/naming/conftest.py
+++ b/tests/naming/conftest.py
@@ -7,7 +7,7 @@ from dbt_semantic_interfaces.references import EntityReference
 from dbt_semantic_interfaces.type_enums import TimeGranularity
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 
-from metricflow.specs.specs import DimensionSpec, EntitySpec, LinkableInstanceSpec, TimeDimensionSpec
+from metricflow.specs.specs import DimensionSpec, EntitySpec, GroupByMetricSpec, LinkableInstanceSpec, TimeDimensionSpec
 from tests.time.metric_time_dimension import MTD_SPEC_MONTH, MTD_SPEC_WEEK, MTD_SPEC_YEAR
 
 
@@ -49,4 +49,6 @@ def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D103
             element_name="user",
             entity_links=(EntityReference(element_name="booking"), EntityReference(element_name="listing")),
         ),
+        # GroupByMetrics
+        GroupByMetricSpec(element_name="bookings", entity_links=(EntityReference(element_name="listing"),)),
     )

--- a/tests/naming/test_object_builder_naming_scheme.py
+++ b/tests/naming/test_object_builder_naming_scheme.py
@@ -8,7 +8,7 @@ from dbt_semantic_interfaces.type_enums import TimeGranularity
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 
 from metricflow.naming.object_builder_scheme import ObjectBuilderNamingScheme
-from metricflow.specs.specs import DimensionSpec, EntitySpec, LinkableInstanceSpec, TimeDimensionSpec
+from metricflow.specs.specs import DimensionSpec, EntitySpec, GroupByMetricSpec, LinkableInstanceSpec, TimeDimensionSpec
 from tests.time.metric_time_dimension import MTD_SPEC_MONTH, MTD_SPEC_WEEK, MTD_SPEC_YEAR
 
 
@@ -45,6 +45,16 @@ def test_input_str(object_builder_naming_scheme: ObjectBuilderNamingScheme) -> N
             )
         )
         == "Entity('listing__user', entity_path=['booking'])"
+    )
+
+    assert (
+        object_builder_naming_scheme.input_str(
+            GroupByMetricSpec(
+                element_name="bookings",
+                entity_links=(EntityReference(element_name="listing"),),
+            )
+        )
+        == "Metric('bookings', group_by=['listing'])"
     )
 
 
@@ -106,4 +116,10 @@ def test_spec_pattern(  # noqa: D103
             element_name="user",
             entity_links=(EntityReference(element_name="booking"), EntityReference(element_name="listing")),
         ),
+    )
+
+    assert tuple(
+        object_builder_naming_scheme.spec_pattern("Metric('bookings', group_by=['listing'])").match(specs)
+    ) == (
+        GroupByMetricSpec(element_name="bookings", entity_links=(EntityReference(element_name="listing"),)),
     )

--- a/tests/specs/patterns/test_entity_link_pattern.py
+++ b/tests/specs/patterns/test_entity_link_pattern.py
@@ -15,7 +15,7 @@ from metricflow.specs.patterns.entity_link_pattern import (
     EntityLinkPatternParameterSet,
     ParameterSetField,
 )
-from metricflow.specs.specs import DimensionSpec, EntitySpec, LinkableInstanceSpec, TimeDimensionSpec
+from metricflow.specs.specs import DimensionSpec, EntitySpec, GroupByMetricSpec, LinkableInstanceSpec, TimeDimensionSpec
 from tests.time.metric_time_dimension import MTD_SPEC_MONTH, MTD_SPEC_WEEK, MTD_SPEC_YEAR
 
 logger = logging.getLogger(__name__)
@@ -51,6 +51,11 @@ def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D103
         EntitySpec(
             element_name="host",
             entity_links=(EntityReference(element_name="booking"),),
+        ),
+        # Group by metrics
+        GroupByMetricSpec(
+            element_name="bookings",
+            entity_links=(EntityReference(element_name="listing"),),
         ),
     )
 
@@ -104,6 +109,25 @@ def test_entity_match(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D
 
     assert tuple(pattern.match(specs)) == (
         EntitySpec(element_name="listing", entity_links=(EntityReference(element_name="booking"),)),
+    )
+
+
+def test_group_by_metric_match(specs: Sequence[LinkableInstanceSpec]) -> None:  # noqa: D103
+    pattern = EntityLinkPattern(
+        EntityLinkPatternParameterSet.from_parameters(
+            element_name="bookings",
+            entity_links=(EntityReference(element_name="listing"),),
+            time_granularity=None,
+            date_part=None,
+            fields_to_compare=(
+                ParameterSetField.ELEMENT_NAME,
+                ParameterSetField.ENTITY_LINKS,
+            ),
+        )
+    )
+
+    assert tuple(pattern.match(specs)) == (
+        GroupByMetricSpec(element_name="bookings", entity_links=(EntityReference(element_name="listing"),)),
     )
 
 


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Allow metrics in filters. This builds off of the changes to allow metric filters in DSI. Changes include:
- Handle group by metrics in object builder scheme
- Create new `SpecPattern` for group by metrics
- Write MF implementation of `WhereFilterMetric`
- Tests for each of the above changes

This is still not complete since the DataflowPlanBuilder does not know how to build a plan to execute a query with a metric filter, so that's coming next.

<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
