### PR TITLE
Bug fix: filter by metrics in same semantic model as queried metrics

### DIFF
--- a/.changes/unreleased/Fixes-20240408-123954.yaml
+++ b/.changes/unreleased/Fixes-20240408-123954.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Enable filtering by metrics in the same semantic model as queried metrics.
+time: 2024-04-08T12:39:54.142472-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1115"

--- a/metricflow/model/semantics/linkable_element_properties.py
+++ b/metricflow/model/semantics/linkable_element_properties.py
@@ -38,5 +38,6 @@ class LinkableElementProperties(Enum):
                 LinkableElementProperties.MULTI_HOP,
                 LinkableElementProperties.DERIVED_TIME_GRANULARITY,
                 LinkableElementProperties.METRIC_TIME,
+                LinkableElementProperties.METRIC,
             }
         )

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,0 +1,457 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_17.bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    COUNT(DISTINCT subq_16.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers',]
+    SELECT
+      subq_15.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_14.guest__booking_value
+        , subq_14.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'guest__booking_value']
+        SELECT
+          subq_13.guest__booking_value
+          , subq_13.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_6.guest AS guest
+            , subq_12.booking_value AS guest__booking_value
+            , subq_6.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'guest']
+            SELECT
+              subq_5.guest
+              , subq_5.bookers
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.ds_partitioned__day
+                , subq_4.ds_partitioned__week
+                , subq_4.ds_partitioned__month
+                , subq_4.ds_partitioned__quarter
+                , subq_4.ds_partitioned__year
+                , subq_4.ds_partitioned__extract_year
+                , subq_4.ds_partitioned__extract_quarter
+                , subq_4.ds_partitioned__extract_month
+                , subq_4.ds_partitioned__extract_day
+                , subq_4.ds_partitioned__extract_dow
+                , subq_4.ds_partitioned__extract_doy
+                , subq_4.paid_at__day
+                , subq_4.paid_at__week
+                , subq_4.paid_at__month
+                , subq_4.paid_at__quarter
+                , subq_4.paid_at__year
+                , subq_4.paid_at__extract_year
+                , subq_4.paid_at__extract_quarter
+                , subq_4.paid_at__extract_month
+                , subq_4.paid_at__extract_day
+                , subq_4.paid_at__extract_dow
+                , subq_4.paid_at__extract_doy
+                , subq_4.booking__ds__day
+                , subq_4.booking__ds__week
+                , subq_4.booking__ds__month
+                , subq_4.booking__ds__quarter
+                , subq_4.booking__ds__year
+                , subq_4.booking__ds__extract_year
+                , subq_4.booking__ds__extract_quarter
+                , subq_4.booking__ds__extract_month
+                , subq_4.booking__ds__extract_day
+                , subq_4.booking__ds__extract_dow
+                , subq_4.booking__ds__extract_doy
+                , subq_4.booking__ds_partitioned__day
+                , subq_4.booking__ds_partitioned__week
+                , subq_4.booking__ds_partitioned__month
+                , subq_4.booking__ds_partitioned__quarter
+                , subq_4.booking__ds_partitioned__year
+                , subq_4.booking__ds_partitioned__extract_year
+                , subq_4.booking__ds_partitioned__extract_quarter
+                , subq_4.booking__ds_partitioned__extract_month
+                , subq_4.booking__ds_partitioned__extract_day
+                , subq_4.booking__ds_partitioned__extract_dow
+                , subq_4.booking__ds_partitioned__extract_doy
+                , subq_4.booking__paid_at__day
+                , subq_4.booking__paid_at__week
+                , subq_4.booking__paid_at__month
+                , subq_4.booking__paid_at__quarter
+                , subq_4.booking__paid_at__year
+                , subq_4.booking__paid_at__extract_year
+                , subq_4.booking__paid_at__extract_quarter
+                , subq_4.booking__paid_at__extract_month
+                , subq_4.booking__paid_at__extract_day
+                , subq_4.booking__paid_at__extract_dow
+                , subq_4.booking__paid_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.guest
+                , subq_4.host
+                , subq_4.booking__listing
+                , subq_4.booking__guest
+                , subq_4.booking__host
+                , subq_4.is_instant
+                , subq_4.booking__is_instant
+                , subq_4.bookings
+                , subq_4.instant_bookings
+                , subq_4.booking_value
+                , subq_4.max_booking_value
+                , subq_4.min_booking_value
+                , subq_4.bookers
+                , subq_4.average_booking_value
+                , subq_4.referred_bookings
+                , subq_4.median_booking_value
+                , subq_4.booking_value_p99
+                , subq_4.discrete_booking_value_p99
+                , subq_4.approximate_continuous_booking_value_p99
+                , subq_4.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                  , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                  , DATE_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                  , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                  , DATE_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                  , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                  , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                  , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                  , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                  , DATE_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                  , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                  , DATE_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                  , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                  , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                  , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_4
+            ) subq_5
+          ) subq_6
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['guest', 'booking_value']
+            SELECT
+              subq_11.guest
+              , subq_11.booking_value
+            FROM (
+              -- Compute Metrics via Expressions
+              SELECT
+                subq_10.guest
+                , subq_10.booking_value
+              FROM (
+                -- Aggregate Measures
+                SELECT
+                  subq_9.guest
+                  , SUM(subq_9.booking_value) AS booking_value
+                FROM (
+                  -- Pass Only Elements: ['booking_value', 'guest']
+                  SELECT
+                    subq_8.guest
+                    , subq_8.booking_value
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_7.ds__day
+                      , subq_7.ds__week
+                      , subq_7.ds__month
+                      , subq_7.ds__quarter
+                      , subq_7.ds__year
+                      , subq_7.ds__extract_year
+                      , subq_7.ds__extract_quarter
+                      , subq_7.ds__extract_month
+                      , subq_7.ds__extract_day
+                      , subq_7.ds__extract_dow
+                      , subq_7.ds__extract_doy
+                      , subq_7.ds_partitioned__day
+                      , subq_7.ds_partitioned__week
+                      , subq_7.ds_partitioned__month
+                      , subq_7.ds_partitioned__quarter
+                      , subq_7.ds_partitioned__year
+                      , subq_7.ds_partitioned__extract_year
+                      , subq_7.ds_partitioned__extract_quarter
+                      , subq_7.ds_partitioned__extract_month
+                      , subq_7.ds_partitioned__extract_day
+                      , subq_7.ds_partitioned__extract_dow
+                      , subq_7.ds_partitioned__extract_doy
+                      , subq_7.paid_at__day
+                      , subq_7.paid_at__week
+                      , subq_7.paid_at__month
+                      , subq_7.paid_at__quarter
+                      , subq_7.paid_at__year
+                      , subq_7.paid_at__extract_year
+                      , subq_7.paid_at__extract_quarter
+                      , subq_7.paid_at__extract_month
+                      , subq_7.paid_at__extract_day
+                      , subq_7.paid_at__extract_dow
+                      , subq_7.paid_at__extract_doy
+                      , subq_7.booking__ds__day
+                      , subq_7.booking__ds__week
+                      , subq_7.booking__ds__month
+                      , subq_7.booking__ds__quarter
+                      , subq_7.booking__ds__year
+                      , subq_7.booking__ds__extract_year
+                      , subq_7.booking__ds__extract_quarter
+                      , subq_7.booking__ds__extract_month
+                      , subq_7.booking__ds__extract_day
+                      , subq_7.booking__ds__extract_dow
+                      , subq_7.booking__ds__extract_doy
+                      , subq_7.booking__ds_partitioned__day
+                      , subq_7.booking__ds_partitioned__week
+                      , subq_7.booking__ds_partitioned__month
+                      , subq_7.booking__ds_partitioned__quarter
+                      , subq_7.booking__ds_partitioned__year
+                      , subq_7.booking__ds_partitioned__extract_year
+                      , subq_7.booking__ds_partitioned__extract_quarter
+                      , subq_7.booking__ds_partitioned__extract_month
+                      , subq_7.booking__ds_partitioned__extract_day
+                      , subq_7.booking__ds_partitioned__extract_dow
+                      , subq_7.booking__ds_partitioned__extract_doy
+                      , subq_7.booking__paid_at__day
+                      , subq_7.booking__paid_at__week
+                      , subq_7.booking__paid_at__month
+                      , subq_7.booking__paid_at__quarter
+                      , subq_7.booking__paid_at__year
+                      , subq_7.booking__paid_at__extract_year
+                      , subq_7.booking__paid_at__extract_quarter
+                      , subq_7.booking__paid_at__extract_month
+                      , subq_7.booking__paid_at__extract_day
+                      , subq_7.booking__paid_at__extract_dow
+                      , subq_7.booking__paid_at__extract_doy
+                      , subq_7.ds__day AS metric_time__day
+                      , subq_7.ds__week AS metric_time__week
+                      , subq_7.ds__month AS metric_time__month
+                      , subq_7.ds__quarter AS metric_time__quarter
+                      , subq_7.ds__year AS metric_time__year
+                      , subq_7.ds__extract_year AS metric_time__extract_year
+                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_7.ds__extract_month AS metric_time__extract_month
+                      , subq_7.ds__extract_day AS metric_time__extract_day
+                      , subq_7.ds__extract_dow AS metric_time__extract_dow
+                      , subq_7.ds__extract_doy AS metric_time__extract_doy
+                      , subq_7.listing
+                      , subq_7.guest
+                      , subq_7.host
+                      , subq_7.booking__listing
+                      , subq_7.booking__guest
+                      , subq_7.booking__host
+                      , subq_7.is_instant
+                      , subq_7.booking__is_instant
+                      , subq_7.bookings
+                      , subq_7.instant_bookings
+                      , subq_7.booking_value
+                      , subq_7.max_booking_value
+                      , subq_7.min_booking_value
+                      , subq_7.bookers
+                      , subq_7.average_booking_value
+                      , subq_7.referred_bookings
+                      , subq_7.median_booking_value
+                      , subq_7.booking_value_p99
+                      , subq_7.discrete_booking_value_p99
+                      , subq_7.approximate_continuous_booking_value_p99
+                      , subq_7.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                        , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                        , DATE_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                        , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                        , DATE_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                        , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                        , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                        , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                        , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                        , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                        , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                        , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                        , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                        , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                        , DATE_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                        , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                        , DATE_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                        , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                        , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                        , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                        , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                        , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                        , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                        , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_7
+                  ) subq_8
+                ) subq_9
+                GROUP BY
+                  guest
+              ) subq_10
+            ) subq_11
+          ) subq_12
+          ON
+            subq_6.guest = subq_12.guest
+        ) subq_13
+      ) subq_14
+      WHERE guest__booking_value > 1.00
+    ) subq_15
+  ) subq_16
+) subq_17

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookers',]
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  COUNT(DISTINCT bookers) AS bookers
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'guest__booking_value']
+  SELECT
+    subq_26.booking_value AS guest__booking_value
+    , subq_20.bookers AS bookers
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'guest']
+    SELECT
+      guest_id AS guest
+      , guest_id AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_20
+  LEFT OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['booking_value', 'guest']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    -- Pass Only Elements: ['guest', 'booking_value']
+    SELECT
+      guest_id AS guest
+      , SUM(booking_value) AS booking_value
+    FROM ***************************.fct_bookings bookings_source_src_28000
+    GROUP BY
+      guest
+  ) subq_26
+  ON
+    subq_20.guest = subq_26.guest
+) subq_28
+WHERE guest__booking_value > 1.00

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,0 +1,457 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_17.bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    COUNT(DISTINCT subq_16.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers',]
+    SELECT
+      subq_15.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_14.guest__booking_value
+        , subq_14.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'guest__booking_value']
+        SELECT
+          subq_13.guest__booking_value
+          , subq_13.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_6.guest AS guest
+            , subq_12.booking_value AS guest__booking_value
+            , subq_6.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'guest']
+            SELECT
+              subq_5.guest
+              , subq_5.bookers
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.ds_partitioned__day
+                , subq_4.ds_partitioned__week
+                , subq_4.ds_partitioned__month
+                , subq_4.ds_partitioned__quarter
+                , subq_4.ds_partitioned__year
+                , subq_4.ds_partitioned__extract_year
+                , subq_4.ds_partitioned__extract_quarter
+                , subq_4.ds_partitioned__extract_month
+                , subq_4.ds_partitioned__extract_day
+                , subq_4.ds_partitioned__extract_dow
+                , subq_4.ds_partitioned__extract_doy
+                , subq_4.paid_at__day
+                , subq_4.paid_at__week
+                , subq_4.paid_at__month
+                , subq_4.paid_at__quarter
+                , subq_4.paid_at__year
+                , subq_4.paid_at__extract_year
+                , subq_4.paid_at__extract_quarter
+                , subq_4.paid_at__extract_month
+                , subq_4.paid_at__extract_day
+                , subq_4.paid_at__extract_dow
+                , subq_4.paid_at__extract_doy
+                , subq_4.booking__ds__day
+                , subq_4.booking__ds__week
+                , subq_4.booking__ds__month
+                , subq_4.booking__ds__quarter
+                , subq_4.booking__ds__year
+                , subq_4.booking__ds__extract_year
+                , subq_4.booking__ds__extract_quarter
+                , subq_4.booking__ds__extract_month
+                , subq_4.booking__ds__extract_day
+                , subq_4.booking__ds__extract_dow
+                , subq_4.booking__ds__extract_doy
+                , subq_4.booking__ds_partitioned__day
+                , subq_4.booking__ds_partitioned__week
+                , subq_4.booking__ds_partitioned__month
+                , subq_4.booking__ds_partitioned__quarter
+                , subq_4.booking__ds_partitioned__year
+                , subq_4.booking__ds_partitioned__extract_year
+                , subq_4.booking__ds_partitioned__extract_quarter
+                , subq_4.booking__ds_partitioned__extract_month
+                , subq_4.booking__ds_partitioned__extract_day
+                , subq_4.booking__ds_partitioned__extract_dow
+                , subq_4.booking__ds_partitioned__extract_doy
+                , subq_4.booking__paid_at__day
+                , subq_4.booking__paid_at__week
+                , subq_4.booking__paid_at__month
+                , subq_4.booking__paid_at__quarter
+                , subq_4.booking__paid_at__year
+                , subq_4.booking__paid_at__extract_year
+                , subq_4.booking__paid_at__extract_quarter
+                , subq_4.booking__paid_at__extract_month
+                , subq_4.booking__paid_at__extract_day
+                , subq_4.booking__paid_at__extract_dow
+                , subq_4.booking__paid_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.guest
+                , subq_4.host
+                , subq_4.booking__listing
+                , subq_4.booking__guest
+                , subq_4.booking__host
+                , subq_4.is_instant
+                , subq_4.booking__is_instant
+                , subq_4.bookings
+                , subq_4.instant_bookings
+                , subq_4.booking_value
+                , subq_4.max_booking_value
+                , subq_4.min_booking_value
+                , subq_4.bookers
+                , subq_4.average_booking_value
+                , subq_4.referred_bookings
+                , subq_4.median_booking_value
+                , subq_4.booking_value_p99
+                , subq_4.discrete_booking_value_p99
+                , subq_4.approximate_continuous_booking_value_p99
+                , subq_4.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_4
+            ) subq_5
+          ) subq_6
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['guest', 'booking_value']
+            SELECT
+              subq_11.guest
+              , subq_11.booking_value
+            FROM (
+              -- Compute Metrics via Expressions
+              SELECT
+                subq_10.guest
+                , subq_10.booking_value
+              FROM (
+                -- Aggregate Measures
+                SELECT
+                  subq_9.guest
+                  , SUM(subq_9.booking_value) AS booking_value
+                FROM (
+                  -- Pass Only Elements: ['booking_value', 'guest']
+                  SELECT
+                    subq_8.guest
+                    , subq_8.booking_value
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_7.ds__day
+                      , subq_7.ds__week
+                      , subq_7.ds__month
+                      , subq_7.ds__quarter
+                      , subq_7.ds__year
+                      , subq_7.ds__extract_year
+                      , subq_7.ds__extract_quarter
+                      , subq_7.ds__extract_month
+                      , subq_7.ds__extract_day
+                      , subq_7.ds__extract_dow
+                      , subq_7.ds__extract_doy
+                      , subq_7.ds_partitioned__day
+                      , subq_7.ds_partitioned__week
+                      , subq_7.ds_partitioned__month
+                      , subq_7.ds_partitioned__quarter
+                      , subq_7.ds_partitioned__year
+                      , subq_7.ds_partitioned__extract_year
+                      , subq_7.ds_partitioned__extract_quarter
+                      , subq_7.ds_partitioned__extract_month
+                      , subq_7.ds_partitioned__extract_day
+                      , subq_7.ds_partitioned__extract_dow
+                      , subq_7.ds_partitioned__extract_doy
+                      , subq_7.paid_at__day
+                      , subq_7.paid_at__week
+                      , subq_7.paid_at__month
+                      , subq_7.paid_at__quarter
+                      , subq_7.paid_at__year
+                      , subq_7.paid_at__extract_year
+                      , subq_7.paid_at__extract_quarter
+                      , subq_7.paid_at__extract_month
+                      , subq_7.paid_at__extract_day
+                      , subq_7.paid_at__extract_dow
+                      , subq_7.paid_at__extract_doy
+                      , subq_7.booking__ds__day
+                      , subq_7.booking__ds__week
+                      , subq_7.booking__ds__month
+                      , subq_7.booking__ds__quarter
+                      , subq_7.booking__ds__year
+                      , subq_7.booking__ds__extract_year
+                      , subq_7.booking__ds__extract_quarter
+                      , subq_7.booking__ds__extract_month
+                      , subq_7.booking__ds__extract_day
+                      , subq_7.booking__ds__extract_dow
+                      , subq_7.booking__ds__extract_doy
+                      , subq_7.booking__ds_partitioned__day
+                      , subq_7.booking__ds_partitioned__week
+                      , subq_7.booking__ds_partitioned__month
+                      , subq_7.booking__ds_partitioned__quarter
+                      , subq_7.booking__ds_partitioned__year
+                      , subq_7.booking__ds_partitioned__extract_year
+                      , subq_7.booking__ds_partitioned__extract_quarter
+                      , subq_7.booking__ds_partitioned__extract_month
+                      , subq_7.booking__ds_partitioned__extract_day
+                      , subq_7.booking__ds_partitioned__extract_dow
+                      , subq_7.booking__ds_partitioned__extract_doy
+                      , subq_7.booking__paid_at__day
+                      , subq_7.booking__paid_at__week
+                      , subq_7.booking__paid_at__month
+                      , subq_7.booking__paid_at__quarter
+                      , subq_7.booking__paid_at__year
+                      , subq_7.booking__paid_at__extract_year
+                      , subq_7.booking__paid_at__extract_quarter
+                      , subq_7.booking__paid_at__extract_month
+                      , subq_7.booking__paid_at__extract_day
+                      , subq_7.booking__paid_at__extract_dow
+                      , subq_7.booking__paid_at__extract_doy
+                      , subq_7.ds__day AS metric_time__day
+                      , subq_7.ds__week AS metric_time__week
+                      , subq_7.ds__month AS metric_time__month
+                      , subq_7.ds__quarter AS metric_time__quarter
+                      , subq_7.ds__year AS metric_time__year
+                      , subq_7.ds__extract_year AS metric_time__extract_year
+                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_7.ds__extract_month AS metric_time__extract_month
+                      , subq_7.ds__extract_day AS metric_time__extract_day
+                      , subq_7.ds__extract_dow AS metric_time__extract_dow
+                      , subq_7.ds__extract_doy AS metric_time__extract_doy
+                      , subq_7.listing
+                      , subq_7.guest
+                      , subq_7.host
+                      , subq_7.booking__listing
+                      , subq_7.booking__guest
+                      , subq_7.booking__host
+                      , subq_7.is_instant
+                      , subq_7.booking__is_instant
+                      , subq_7.bookings
+                      , subq_7.instant_bookings
+                      , subq_7.booking_value
+                      , subq_7.max_booking_value
+                      , subq_7.min_booking_value
+                      , subq_7.bookers
+                      , subq_7.average_booking_value
+                      , subq_7.referred_bookings
+                      , subq_7.median_booking_value
+                      , subq_7.booking_value_p99
+                      , subq_7.discrete_booking_value_p99
+                      , subq_7.approximate_continuous_booking_value_p99
+                      , subq_7.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_7
+                  ) subq_8
+                ) subq_9
+                GROUP BY
+                  subq_9.guest
+              ) subq_10
+            ) subq_11
+          ) subq_12
+          ON
+            subq_6.guest = subq_12.guest
+        ) subq_13
+      ) subq_14
+      WHERE guest__booking_value > 1.00
+    ) subq_15
+  ) subq_16
+) subq_17

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookers',]
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  COUNT(DISTINCT bookers) AS bookers
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'guest__booking_value']
+  SELECT
+    subq_26.booking_value AS guest__booking_value
+    , subq_20.bookers AS bookers
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'guest']
+    SELECT
+      guest_id AS guest
+      , guest_id AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_20
+  LEFT OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['booking_value', 'guest']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    -- Pass Only Elements: ['guest', 'booking_value']
+    SELECT
+      guest_id AS guest
+      , SUM(booking_value) AS booking_value
+    FROM ***************************.fct_bookings bookings_source_src_28000
+    GROUP BY
+      guest_id
+  ) subq_26
+  ON
+    subq_20.guest = subq_26.guest
+) subq_28
+WHERE guest__booking_value > 1.00

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,0 +1,457 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_17.bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    COUNT(DISTINCT subq_16.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers',]
+    SELECT
+      subq_15.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_14.guest__booking_value
+        , subq_14.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'guest__booking_value']
+        SELECT
+          subq_13.guest__booking_value
+          , subq_13.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_6.guest AS guest
+            , subq_12.booking_value AS guest__booking_value
+            , subq_6.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'guest']
+            SELECT
+              subq_5.guest
+              , subq_5.bookers
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.ds_partitioned__day
+                , subq_4.ds_partitioned__week
+                , subq_4.ds_partitioned__month
+                , subq_4.ds_partitioned__quarter
+                , subq_4.ds_partitioned__year
+                , subq_4.ds_partitioned__extract_year
+                , subq_4.ds_partitioned__extract_quarter
+                , subq_4.ds_partitioned__extract_month
+                , subq_4.ds_partitioned__extract_day
+                , subq_4.ds_partitioned__extract_dow
+                , subq_4.ds_partitioned__extract_doy
+                , subq_4.paid_at__day
+                , subq_4.paid_at__week
+                , subq_4.paid_at__month
+                , subq_4.paid_at__quarter
+                , subq_4.paid_at__year
+                , subq_4.paid_at__extract_year
+                , subq_4.paid_at__extract_quarter
+                , subq_4.paid_at__extract_month
+                , subq_4.paid_at__extract_day
+                , subq_4.paid_at__extract_dow
+                , subq_4.paid_at__extract_doy
+                , subq_4.booking__ds__day
+                , subq_4.booking__ds__week
+                , subq_4.booking__ds__month
+                , subq_4.booking__ds__quarter
+                , subq_4.booking__ds__year
+                , subq_4.booking__ds__extract_year
+                , subq_4.booking__ds__extract_quarter
+                , subq_4.booking__ds__extract_month
+                , subq_4.booking__ds__extract_day
+                , subq_4.booking__ds__extract_dow
+                , subq_4.booking__ds__extract_doy
+                , subq_4.booking__ds_partitioned__day
+                , subq_4.booking__ds_partitioned__week
+                , subq_4.booking__ds_partitioned__month
+                , subq_4.booking__ds_partitioned__quarter
+                , subq_4.booking__ds_partitioned__year
+                , subq_4.booking__ds_partitioned__extract_year
+                , subq_4.booking__ds_partitioned__extract_quarter
+                , subq_4.booking__ds_partitioned__extract_month
+                , subq_4.booking__ds_partitioned__extract_day
+                , subq_4.booking__ds_partitioned__extract_dow
+                , subq_4.booking__ds_partitioned__extract_doy
+                , subq_4.booking__paid_at__day
+                , subq_4.booking__paid_at__week
+                , subq_4.booking__paid_at__month
+                , subq_4.booking__paid_at__quarter
+                , subq_4.booking__paid_at__year
+                , subq_4.booking__paid_at__extract_year
+                , subq_4.booking__paid_at__extract_quarter
+                , subq_4.booking__paid_at__extract_month
+                , subq_4.booking__paid_at__extract_day
+                , subq_4.booking__paid_at__extract_dow
+                , subq_4.booking__paid_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.guest
+                , subq_4.host
+                , subq_4.booking__listing
+                , subq_4.booking__guest
+                , subq_4.booking__host
+                , subq_4.is_instant
+                , subq_4.booking__is_instant
+                , subq_4.bookings
+                , subq_4.instant_bookings
+                , subq_4.booking_value
+                , subq_4.max_booking_value
+                , subq_4.min_booking_value
+                , subq_4.bookers
+                , subq_4.average_booking_value
+                , subq_4.referred_bookings
+                , subq_4.median_booking_value
+                , subq_4.booking_value_p99
+                , subq_4.discrete_booking_value_p99
+                , subq_4.approximate_continuous_booking_value_p99
+                , subq_4.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_4
+            ) subq_5
+          ) subq_6
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['guest', 'booking_value']
+            SELECT
+              subq_11.guest
+              , subq_11.booking_value
+            FROM (
+              -- Compute Metrics via Expressions
+              SELECT
+                subq_10.guest
+                , subq_10.booking_value
+              FROM (
+                -- Aggregate Measures
+                SELECT
+                  subq_9.guest
+                  , SUM(subq_9.booking_value) AS booking_value
+                FROM (
+                  -- Pass Only Elements: ['booking_value', 'guest']
+                  SELECT
+                    subq_8.guest
+                    , subq_8.booking_value
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_7.ds__day
+                      , subq_7.ds__week
+                      , subq_7.ds__month
+                      , subq_7.ds__quarter
+                      , subq_7.ds__year
+                      , subq_7.ds__extract_year
+                      , subq_7.ds__extract_quarter
+                      , subq_7.ds__extract_month
+                      , subq_7.ds__extract_day
+                      , subq_7.ds__extract_dow
+                      , subq_7.ds__extract_doy
+                      , subq_7.ds_partitioned__day
+                      , subq_7.ds_partitioned__week
+                      , subq_7.ds_partitioned__month
+                      , subq_7.ds_partitioned__quarter
+                      , subq_7.ds_partitioned__year
+                      , subq_7.ds_partitioned__extract_year
+                      , subq_7.ds_partitioned__extract_quarter
+                      , subq_7.ds_partitioned__extract_month
+                      , subq_7.ds_partitioned__extract_day
+                      , subq_7.ds_partitioned__extract_dow
+                      , subq_7.ds_partitioned__extract_doy
+                      , subq_7.paid_at__day
+                      , subq_7.paid_at__week
+                      , subq_7.paid_at__month
+                      , subq_7.paid_at__quarter
+                      , subq_7.paid_at__year
+                      , subq_7.paid_at__extract_year
+                      , subq_7.paid_at__extract_quarter
+                      , subq_7.paid_at__extract_month
+                      , subq_7.paid_at__extract_day
+                      , subq_7.paid_at__extract_dow
+                      , subq_7.paid_at__extract_doy
+                      , subq_7.booking__ds__day
+                      , subq_7.booking__ds__week
+                      , subq_7.booking__ds__month
+                      , subq_7.booking__ds__quarter
+                      , subq_7.booking__ds__year
+                      , subq_7.booking__ds__extract_year
+                      , subq_7.booking__ds__extract_quarter
+                      , subq_7.booking__ds__extract_month
+                      , subq_7.booking__ds__extract_day
+                      , subq_7.booking__ds__extract_dow
+                      , subq_7.booking__ds__extract_doy
+                      , subq_7.booking__ds_partitioned__day
+                      , subq_7.booking__ds_partitioned__week
+                      , subq_7.booking__ds_partitioned__month
+                      , subq_7.booking__ds_partitioned__quarter
+                      , subq_7.booking__ds_partitioned__year
+                      , subq_7.booking__ds_partitioned__extract_year
+                      , subq_7.booking__ds_partitioned__extract_quarter
+                      , subq_7.booking__ds_partitioned__extract_month
+                      , subq_7.booking__ds_partitioned__extract_day
+                      , subq_7.booking__ds_partitioned__extract_dow
+                      , subq_7.booking__ds_partitioned__extract_doy
+                      , subq_7.booking__paid_at__day
+                      , subq_7.booking__paid_at__week
+                      , subq_7.booking__paid_at__month
+                      , subq_7.booking__paid_at__quarter
+                      , subq_7.booking__paid_at__year
+                      , subq_7.booking__paid_at__extract_year
+                      , subq_7.booking__paid_at__extract_quarter
+                      , subq_7.booking__paid_at__extract_month
+                      , subq_7.booking__paid_at__extract_day
+                      , subq_7.booking__paid_at__extract_dow
+                      , subq_7.booking__paid_at__extract_doy
+                      , subq_7.ds__day AS metric_time__day
+                      , subq_7.ds__week AS metric_time__week
+                      , subq_7.ds__month AS metric_time__month
+                      , subq_7.ds__quarter AS metric_time__quarter
+                      , subq_7.ds__year AS metric_time__year
+                      , subq_7.ds__extract_year AS metric_time__extract_year
+                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_7.ds__extract_month AS metric_time__extract_month
+                      , subq_7.ds__extract_day AS metric_time__extract_day
+                      , subq_7.ds__extract_dow AS metric_time__extract_dow
+                      , subq_7.ds__extract_doy AS metric_time__extract_doy
+                      , subq_7.listing
+                      , subq_7.guest
+                      , subq_7.host
+                      , subq_7.booking__listing
+                      , subq_7.booking__guest
+                      , subq_7.booking__host
+                      , subq_7.is_instant
+                      , subq_7.booking__is_instant
+                      , subq_7.bookings
+                      , subq_7.instant_bookings
+                      , subq_7.booking_value
+                      , subq_7.max_booking_value
+                      , subq_7.min_booking_value
+                      , subq_7.bookers
+                      , subq_7.average_booking_value
+                      , subq_7.referred_bookings
+                      , subq_7.median_booking_value
+                      , subq_7.booking_value_p99
+                      , subq_7.discrete_booking_value_p99
+                      , subq_7.approximate_continuous_booking_value_p99
+                      , subq_7.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_7
+                  ) subq_8
+                ) subq_9
+                GROUP BY
+                  subq_9.guest
+              ) subq_10
+            ) subq_11
+          ) subq_12
+          ON
+            subq_6.guest = subq_12.guest
+        ) subq_13
+      ) subq_14
+      WHERE guest__booking_value > 1.00
+    ) subq_15
+  ) subq_16
+) subq_17

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookers',]
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  COUNT(DISTINCT bookers) AS bookers
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'guest__booking_value']
+  SELECT
+    subq_26.booking_value AS guest__booking_value
+    , subq_20.bookers AS bookers
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'guest']
+    SELECT
+      guest_id AS guest
+      , guest_id AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_20
+  LEFT OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['booking_value', 'guest']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    -- Pass Only Elements: ['guest', 'booking_value']
+    SELECT
+      guest_id AS guest
+      , SUM(booking_value) AS booking_value
+    FROM ***************************.fct_bookings bookings_source_src_28000
+    GROUP BY
+      guest_id
+  ) subq_26
+  ON
+    subq_20.guest = subq_26.guest
+) subq_28
+WHERE guest__booking_value > 1.00

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,0 +1,457 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_17.bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    COUNT(DISTINCT subq_16.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers',]
+    SELECT
+      subq_15.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_14.guest__booking_value
+        , subq_14.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'guest__booking_value']
+        SELECT
+          subq_13.guest__booking_value
+          , subq_13.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_6.guest AS guest
+            , subq_12.booking_value AS guest__booking_value
+            , subq_6.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'guest']
+            SELECT
+              subq_5.guest
+              , subq_5.bookers
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.ds_partitioned__day
+                , subq_4.ds_partitioned__week
+                , subq_4.ds_partitioned__month
+                , subq_4.ds_partitioned__quarter
+                , subq_4.ds_partitioned__year
+                , subq_4.ds_partitioned__extract_year
+                , subq_4.ds_partitioned__extract_quarter
+                , subq_4.ds_partitioned__extract_month
+                , subq_4.ds_partitioned__extract_day
+                , subq_4.ds_partitioned__extract_dow
+                , subq_4.ds_partitioned__extract_doy
+                , subq_4.paid_at__day
+                , subq_4.paid_at__week
+                , subq_4.paid_at__month
+                , subq_4.paid_at__quarter
+                , subq_4.paid_at__year
+                , subq_4.paid_at__extract_year
+                , subq_4.paid_at__extract_quarter
+                , subq_4.paid_at__extract_month
+                , subq_4.paid_at__extract_day
+                , subq_4.paid_at__extract_dow
+                , subq_4.paid_at__extract_doy
+                , subq_4.booking__ds__day
+                , subq_4.booking__ds__week
+                , subq_4.booking__ds__month
+                , subq_4.booking__ds__quarter
+                , subq_4.booking__ds__year
+                , subq_4.booking__ds__extract_year
+                , subq_4.booking__ds__extract_quarter
+                , subq_4.booking__ds__extract_month
+                , subq_4.booking__ds__extract_day
+                , subq_4.booking__ds__extract_dow
+                , subq_4.booking__ds__extract_doy
+                , subq_4.booking__ds_partitioned__day
+                , subq_4.booking__ds_partitioned__week
+                , subq_4.booking__ds_partitioned__month
+                , subq_4.booking__ds_partitioned__quarter
+                , subq_4.booking__ds_partitioned__year
+                , subq_4.booking__ds_partitioned__extract_year
+                , subq_4.booking__ds_partitioned__extract_quarter
+                , subq_4.booking__ds_partitioned__extract_month
+                , subq_4.booking__ds_partitioned__extract_day
+                , subq_4.booking__ds_partitioned__extract_dow
+                , subq_4.booking__ds_partitioned__extract_doy
+                , subq_4.booking__paid_at__day
+                , subq_4.booking__paid_at__week
+                , subq_4.booking__paid_at__month
+                , subq_4.booking__paid_at__quarter
+                , subq_4.booking__paid_at__year
+                , subq_4.booking__paid_at__extract_year
+                , subq_4.booking__paid_at__extract_quarter
+                , subq_4.booking__paid_at__extract_month
+                , subq_4.booking__paid_at__extract_day
+                , subq_4.booking__paid_at__extract_dow
+                , subq_4.booking__paid_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.guest
+                , subq_4.host
+                , subq_4.booking__listing
+                , subq_4.booking__guest
+                , subq_4.booking__host
+                , subq_4.is_instant
+                , subq_4.booking__is_instant
+                , subq_4.bookings
+                , subq_4.instant_bookings
+                , subq_4.booking_value
+                , subq_4.max_booking_value
+                , subq_4.min_booking_value
+                , subq_4.bookers
+                , subq_4.average_booking_value
+                , subq_4.referred_bookings
+                , subq_4.median_booking_value
+                , subq_4.booking_value_p99
+                , subq_4.discrete_booking_value_p99
+                , subq_4.approximate_continuous_booking_value_p99
+                , subq_4.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_4
+            ) subq_5
+          ) subq_6
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['guest', 'booking_value']
+            SELECT
+              subq_11.guest
+              , subq_11.booking_value
+            FROM (
+              -- Compute Metrics via Expressions
+              SELECT
+                subq_10.guest
+                , subq_10.booking_value
+              FROM (
+                -- Aggregate Measures
+                SELECT
+                  subq_9.guest
+                  , SUM(subq_9.booking_value) AS booking_value
+                FROM (
+                  -- Pass Only Elements: ['booking_value', 'guest']
+                  SELECT
+                    subq_8.guest
+                    , subq_8.booking_value
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_7.ds__day
+                      , subq_7.ds__week
+                      , subq_7.ds__month
+                      , subq_7.ds__quarter
+                      , subq_7.ds__year
+                      , subq_7.ds__extract_year
+                      , subq_7.ds__extract_quarter
+                      , subq_7.ds__extract_month
+                      , subq_7.ds__extract_day
+                      , subq_7.ds__extract_dow
+                      , subq_7.ds__extract_doy
+                      , subq_7.ds_partitioned__day
+                      , subq_7.ds_partitioned__week
+                      , subq_7.ds_partitioned__month
+                      , subq_7.ds_partitioned__quarter
+                      , subq_7.ds_partitioned__year
+                      , subq_7.ds_partitioned__extract_year
+                      , subq_7.ds_partitioned__extract_quarter
+                      , subq_7.ds_partitioned__extract_month
+                      , subq_7.ds_partitioned__extract_day
+                      , subq_7.ds_partitioned__extract_dow
+                      , subq_7.ds_partitioned__extract_doy
+                      , subq_7.paid_at__day
+                      , subq_7.paid_at__week
+                      , subq_7.paid_at__month
+                      , subq_7.paid_at__quarter
+                      , subq_7.paid_at__year
+                      , subq_7.paid_at__extract_year
+                      , subq_7.paid_at__extract_quarter
+                      , subq_7.paid_at__extract_month
+                      , subq_7.paid_at__extract_day
+                      , subq_7.paid_at__extract_dow
+                      , subq_7.paid_at__extract_doy
+                      , subq_7.booking__ds__day
+                      , subq_7.booking__ds__week
+                      , subq_7.booking__ds__month
+                      , subq_7.booking__ds__quarter
+                      , subq_7.booking__ds__year
+                      , subq_7.booking__ds__extract_year
+                      , subq_7.booking__ds__extract_quarter
+                      , subq_7.booking__ds__extract_month
+                      , subq_7.booking__ds__extract_day
+                      , subq_7.booking__ds__extract_dow
+                      , subq_7.booking__ds__extract_doy
+                      , subq_7.booking__ds_partitioned__day
+                      , subq_7.booking__ds_partitioned__week
+                      , subq_7.booking__ds_partitioned__month
+                      , subq_7.booking__ds_partitioned__quarter
+                      , subq_7.booking__ds_partitioned__year
+                      , subq_7.booking__ds_partitioned__extract_year
+                      , subq_7.booking__ds_partitioned__extract_quarter
+                      , subq_7.booking__ds_partitioned__extract_month
+                      , subq_7.booking__ds_partitioned__extract_day
+                      , subq_7.booking__ds_partitioned__extract_dow
+                      , subq_7.booking__ds_partitioned__extract_doy
+                      , subq_7.booking__paid_at__day
+                      , subq_7.booking__paid_at__week
+                      , subq_7.booking__paid_at__month
+                      , subq_7.booking__paid_at__quarter
+                      , subq_7.booking__paid_at__year
+                      , subq_7.booking__paid_at__extract_year
+                      , subq_7.booking__paid_at__extract_quarter
+                      , subq_7.booking__paid_at__extract_month
+                      , subq_7.booking__paid_at__extract_day
+                      , subq_7.booking__paid_at__extract_dow
+                      , subq_7.booking__paid_at__extract_doy
+                      , subq_7.ds__day AS metric_time__day
+                      , subq_7.ds__week AS metric_time__week
+                      , subq_7.ds__month AS metric_time__month
+                      , subq_7.ds__quarter AS metric_time__quarter
+                      , subq_7.ds__year AS metric_time__year
+                      , subq_7.ds__extract_year AS metric_time__extract_year
+                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_7.ds__extract_month AS metric_time__extract_month
+                      , subq_7.ds__extract_day AS metric_time__extract_day
+                      , subq_7.ds__extract_dow AS metric_time__extract_dow
+                      , subq_7.ds__extract_doy AS metric_time__extract_doy
+                      , subq_7.listing
+                      , subq_7.guest
+                      , subq_7.host
+                      , subq_7.booking__listing
+                      , subq_7.booking__guest
+                      , subq_7.booking__host
+                      , subq_7.is_instant
+                      , subq_7.booking__is_instant
+                      , subq_7.bookings
+                      , subq_7.instant_bookings
+                      , subq_7.booking_value
+                      , subq_7.max_booking_value
+                      , subq_7.min_booking_value
+                      , subq_7.bookers
+                      , subq_7.average_booking_value
+                      , subq_7.referred_bookings
+                      , subq_7.median_booking_value
+                      , subq_7.booking_value_p99
+                      , subq_7.discrete_booking_value_p99
+                      , subq_7.approximate_continuous_booking_value_p99
+                      , subq_7.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_7
+                  ) subq_8
+                ) subq_9
+                GROUP BY
+                  subq_9.guest
+              ) subq_10
+            ) subq_11
+          ) subq_12
+          ON
+            subq_6.guest = subq_12.guest
+        ) subq_13
+      ) subq_14
+      WHERE guest__booking_value > 1.00
+    ) subq_15
+  ) subq_16
+) subq_17

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookers',]
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  COUNT(DISTINCT bookers) AS bookers
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'guest__booking_value']
+  SELECT
+    subq_26.booking_value AS guest__booking_value
+    , subq_20.bookers AS bookers
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'guest']
+    SELECT
+      guest_id AS guest
+      , guest_id AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_20
+  LEFT OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['booking_value', 'guest']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    -- Pass Only Elements: ['guest', 'booking_value']
+    SELECT
+      guest_id AS guest
+      , SUM(booking_value) AS booking_value
+    FROM ***************************.fct_bookings bookings_source_src_28000
+    GROUP BY
+      guest_id
+  ) subq_26
+  ON
+    subq_20.guest = subq_26.guest
+) subq_28
+WHERE guest__booking_value > 1.00

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,0 +1,457 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_17.bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    COUNT(DISTINCT subq_16.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers',]
+    SELECT
+      subq_15.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_14.guest__booking_value
+        , subq_14.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'guest__booking_value']
+        SELECT
+          subq_13.guest__booking_value
+          , subq_13.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_6.guest AS guest
+            , subq_12.booking_value AS guest__booking_value
+            , subq_6.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'guest']
+            SELECT
+              subq_5.guest
+              , subq_5.bookers
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.ds_partitioned__day
+                , subq_4.ds_partitioned__week
+                , subq_4.ds_partitioned__month
+                , subq_4.ds_partitioned__quarter
+                , subq_4.ds_partitioned__year
+                , subq_4.ds_partitioned__extract_year
+                , subq_4.ds_partitioned__extract_quarter
+                , subq_4.ds_partitioned__extract_month
+                , subq_4.ds_partitioned__extract_day
+                , subq_4.ds_partitioned__extract_dow
+                , subq_4.ds_partitioned__extract_doy
+                , subq_4.paid_at__day
+                , subq_4.paid_at__week
+                , subq_4.paid_at__month
+                , subq_4.paid_at__quarter
+                , subq_4.paid_at__year
+                , subq_4.paid_at__extract_year
+                , subq_4.paid_at__extract_quarter
+                , subq_4.paid_at__extract_month
+                , subq_4.paid_at__extract_day
+                , subq_4.paid_at__extract_dow
+                , subq_4.paid_at__extract_doy
+                , subq_4.booking__ds__day
+                , subq_4.booking__ds__week
+                , subq_4.booking__ds__month
+                , subq_4.booking__ds__quarter
+                , subq_4.booking__ds__year
+                , subq_4.booking__ds__extract_year
+                , subq_4.booking__ds__extract_quarter
+                , subq_4.booking__ds__extract_month
+                , subq_4.booking__ds__extract_day
+                , subq_4.booking__ds__extract_dow
+                , subq_4.booking__ds__extract_doy
+                , subq_4.booking__ds_partitioned__day
+                , subq_4.booking__ds_partitioned__week
+                , subq_4.booking__ds_partitioned__month
+                , subq_4.booking__ds_partitioned__quarter
+                , subq_4.booking__ds_partitioned__year
+                , subq_4.booking__ds_partitioned__extract_year
+                , subq_4.booking__ds_partitioned__extract_quarter
+                , subq_4.booking__ds_partitioned__extract_month
+                , subq_4.booking__ds_partitioned__extract_day
+                , subq_4.booking__ds_partitioned__extract_dow
+                , subq_4.booking__ds_partitioned__extract_doy
+                , subq_4.booking__paid_at__day
+                , subq_4.booking__paid_at__week
+                , subq_4.booking__paid_at__month
+                , subq_4.booking__paid_at__quarter
+                , subq_4.booking__paid_at__year
+                , subq_4.booking__paid_at__extract_year
+                , subq_4.booking__paid_at__extract_quarter
+                , subq_4.booking__paid_at__extract_month
+                , subq_4.booking__paid_at__extract_day
+                , subq_4.booking__paid_at__extract_dow
+                , subq_4.booking__paid_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.guest
+                , subq_4.host
+                , subq_4.booking__listing
+                , subq_4.booking__guest
+                , subq_4.booking__host
+                , subq_4.is_instant
+                , subq_4.booking__is_instant
+                , subq_4.bookings
+                , subq_4.instant_bookings
+                , subq_4.booking_value
+                , subq_4.max_booking_value
+                , subq_4.min_booking_value
+                , subq_4.bookers
+                , subq_4.average_booking_value
+                , subq_4.referred_bookings
+                , subq_4.median_booking_value
+                , subq_4.booking_value_p99
+                , subq_4.discrete_booking_value_p99
+                , subq_4.approximate_continuous_booking_value_p99
+                , subq_4.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_4
+            ) subq_5
+          ) subq_6
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['guest', 'booking_value']
+            SELECT
+              subq_11.guest
+              , subq_11.booking_value
+            FROM (
+              -- Compute Metrics via Expressions
+              SELECT
+                subq_10.guest
+                , subq_10.booking_value
+              FROM (
+                -- Aggregate Measures
+                SELECT
+                  subq_9.guest
+                  , SUM(subq_9.booking_value) AS booking_value
+                FROM (
+                  -- Pass Only Elements: ['booking_value', 'guest']
+                  SELECT
+                    subq_8.guest
+                    , subq_8.booking_value
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_7.ds__day
+                      , subq_7.ds__week
+                      , subq_7.ds__month
+                      , subq_7.ds__quarter
+                      , subq_7.ds__year
+                      , subq_7.ds__extract_year
+                      , subq_7.ds__extract_quarter
+                      , subq_7.ds__extract_month
+                      , subq_7.ds__extract_day
+                      , subq_7.ds__extract_dow
+                      , subq_7.ds__extract_doy
+                      , subq_7.ds_partitioned__day
+                      , subq_7.ds_partitioned__week
+                      , subq_7.ds_partitioned__month
+                      , subq_7.ds_partitioned__quarter
+                      , subq_7.ds_partitioned__year
+                      , subq_7.ds_partitioned__extract_year
+                      , subq_7.ds_partitioned__extract_quarter
+                      , subq_7.ds_partitioned__extract_month
+                      , subq_7.ds_partitioned__extract_day
+                      , subq_7.ds_partitioned__extract_dow
+                      , subq_7.ds_partitioned__extract_doy
+                      , subq_7.paid_at__day
+                      , subq_7.paid_at__week
+                      , subq_7.paid_at__month
+                      , subq_7.paid_at__quarter
+                      , subq_7.paid_at__year
+                      , subq_7.paid_at__extract_year
+                      , subq_7.paid_at__extract_quarter
+                      , subq_7.paid_at__extract_month
+                      , subq_7.paid_at__extract_day
+                      , subq_7.paid_at__extract_dow
+                      , subq_7.paid_at__extract_doy
+                      , subq_7.booking__ds__day
+                      , subq_7.booking__ds__week
+                      , subq_7.booking__ds__month
+                      , subq_7.booking__ds__quarter
+                      , subq_7.booking__ds__year
+                      , subq_7.booking__ds__extract_year
+                      , subq_7.booking__ds__extract_quarter
+                      , subq_7.booking__ds__extract_month
+                      , subq_7.booking__ds__extract_day
+                      , subq_7.booking__ds__extract_dow
+                      , subq_7.booking__ds__extract_doy
+                      , subq_7.booking__ds_partitioned__day
+                      , subq_7.booking__ds_partitioned__week
+                      , subq_7.booking__ds_partitioned__month
+                      , subq_7.booking__ds_partitioned__quarter
+                      , subq_7.booking__ds_partitioned__year
+                      , subq_7.booking__ds_partitioned__extract_year
+                      , subq_7.booking__ds_partitioned__extract_quarter
+                      , subq_7.booking__ds_partitioned__extract_month
+                      , subq_7.booking__ds_partitioned__extract_day
+                      , subq_7.booking__ds_partitioned__extract_dow
+                      , subq_7.booking__ds_partitioned__extract_doy
+                      , subq_7.booking__paid_at__day
+                      , subq_7.booking__paid_at__week
+                      , subq_7.booking__paid_at__month
+                      , subq_7.booking__paid_at__quarter
+                      , subq_7.booking__paid_at__year
+                      , subq_7.booking__paid_at__extract_year
+                      , subq_7.booking__paid_at__extract_quarter
+                      , subq_7.booking__paid_at__extract_month
+                      , subq_7.booking__paid_at__extract_day
+                      , subq_7.booking__paid_at__extract_dow
+                      , subq_7.booking__paid_at__extract_doy
+                      , subq_7.ds__day AS metric_time__day
+                      , subq_7.ds__week AS metric_time__week
+                      , subq_7.ds__month AS metric_time__month
+                      , subq_7.ds__quarter AS metric_time__quarter
+                      , subq_7.ds__year AS metric_time__year
+                      , subq_7.ds__extract_year AS metric_time__extract_year
+                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_7.ds__extract_month AS metric_time__extract_month
+                      , subq_7.ds__extract_day AS metric_time__extract_day
+                      , subq_7.ds__extract_dow AS metric_time__extract_dow
+                      , subq_7.ds__extract_doy AS metric_time__extract_doy
+                      , subq_7.listing
+                      , subq_7.guest
+                      , subq_7.host
+                      , subq_7.booking__listing
+                      , subq_7.booking__guest
+                      , subq_7.booking__host
+                      , subq_7.is_instant
+                      , subq_7.booking__is_instant
+                      , subq_7.bookings
+                      , subq_7.instant_bookings
+                      , subq_7.booking_value
+                      , subq_7.max_booking_value
+                      , subq_7.min_booking_value
+                      , subq_7.bookers
+                      , subq_7.average_booking_value
+                      , subq_7.referred_bookings
+                      , subq_7.median_booking_value
+                      , subq_7.booking_value_p99
+                      , subq_7.discrete_booking_value_p99
+                      , subq_7.approximate_continuous_booking_value_p99
+                      , subq_7.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_7
+                  ) subq_8
+                ) subq_9
+                GROUP BY
+                  subq_9.guest
+              ) subq_10
+            ) subq_11
+          ) subq_12
+          ON
+            subq_6.guest = subq_12.guest
+        ) subq_13
+      ) subq_14
+      WHERE guest__booking_value > 1.00
+    ) subq_15
+  ) subq_16
+) subq_17

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookers',]
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  COUNT(DISTINCT bookers) AS bookers
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'guest__booking_value']
+  SELECT
+    subq_26.booking_value AS guest__booking_value
+    , subq_20.bookers AS bookers
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'guest']
+    SELECT
+      guest_id AS guest
+      , guest_id AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_20
+  LEFT OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['booking_value', 'guest']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    -- Pass Only Elements: ['guest', 'booking_value']
+    SELECT
+      guest_id AS guest
+      , SUM(booking_value) AS booking_value
+    FROM ***************************.fct_bookings bookings_source_src_28000
+    GROUP BY
+      guest_id
+  ) subq_26
+  ON
+    subq_20.guest = subq_26.guest
+) subq_28
+WHERE guest__booking_value > 1.00

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,0 +1,457 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_17.bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    COUNT(DISTINCT subq_16.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers',]
+    SELECT
+      subq_15.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_14.guest__booking_value
+        , subq_14.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'guest__booking_value']
+        SELECT
+          subq_13.guest__booking_value
+          , subq_13.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_6.guest AS guest
+            , subq_12.booking_value AS guest__booking_value
+            , subq_6.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'guest']
+            SELECT
+              subq_5.guest
+              , subq_5.bookers
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.ds_partitioned__day
+                , subq_4.ds_partitioned__week
+                , subq_4.ds_partitioned__month
+                , subq_4.ds_partitioned__quarter
+                , subq_4.ds_partitioned__year
+                , subq_4.ds_partitioned__extract_year
+                , subq_4.ds_partitioned__extract_quarter
+                , subq_4.ds_partitioned__extract_month
+                , subq_4.ds_partitioned__extract_day
+                , subq_4.ds_partitioned__extract_dow
+                , subq_4.ds_partitioned__extract_doy
+                , subq_4.paid_at__day
+                , subq_4.paid_at__week
+                , subq_4.paid_at__month
+                , subq_4.paid_at__quarter
+                , subq_4.paid_at__year
+                , subq_4.paid_at__extract_year
+                , subq_4.paid_at__extract_quarter
+                , subq_4.paid_at__extract_month
+                , subq_4.paid_at__extract_day
+                , subq_4.paid_at__extract_dow
+                , subq_4.paid_at__extract_doy
+                , subq_4.booking__ds__day
+                , subq_4.booking__ds__week
+                , subq_4.booking__ds__month
+                , subq_4.booking__ds__quarter
+                , subq_4.booking__ds__year
+                , subq_4.booking__ds__extract_year
+                , subq_4.booking__ds__extract_quarter
+                , subq_4.booking__ds__extract_month
+                , subq_4.booking__ds__extract_day
+                , subq_4.booking__ds__extract_dow
+                , subq_4.booking__ds__extract_doy
+                , subq_4.booking__ds_partitioned__day
+                , subq_4.booking__ds_partitioned__week
+                , subq_4.booking__ds_partitioned__month
+                , subq_4.booking__ds_partitioned__quarter
+                , subq_4.booking__ds_partitioned__year
+                , subq_4.booking__ds_partitioned__extract_year
+                , subq_4.booking__ds_partitioned__extract_quarter
+                , subq_4.booking__ds_partitioned__extract_month
+                , subq_4.booking__ds_partitioned__extract_day
+                , subq_4.booking__ds_partitioned__extract_dow
+                , subq_4.booking__ds_partitioned__extract_doy
+                , subq_4.booking__paid_at__day
+                , subq_4.booking__paid_at__week
+                , subq_4.booking__paid_at__month
+                , subq_4.booking__paid_at__quarter
+                , subq_4.booking__paid_at__year
+                , subq_4.booking__paid_at__extract_year
+                , subq_4.booking__paid_at__extract_quarter
+                , subq_4.booking__paid_at__extract_month
+                , subq_4.booking__paid_at__extract_day
+                , subq_4.booking__paid_at__extract_dow
+                , subq_4.booking__paid_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.guest
+                , subq_4.host
+                , subq_4.booking__listing
+                , subq_4.booking__guest
+                , subq_4.booking__host
+                , subq_4.is_instant
+                , subq_4.booking__is_instant
+                , subq_4.bookings
+                , subq_4.instant_bookings
+                , subq_4.booking_value
+                , subq_4.max_booking_value
+                , subq_4.min_booking_value
+                , subq_4.bookers
+                , subq_4.average_booking_value
+                , subq_4.referred_bookings
+                , subq_4.median_booking_value
+                , subq_4.booking_value_p99
+                , subq_4.discrete_booking_value_p99
+                , subq_4.approximate_continuous_booking_value_p99
+                , subq_4.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_4
+            ) subq_5
+          ) subq_6
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['guest', 'booking_value']
+            SELECT
+              subq_11.guest
+              , subq_11.booking_value
+            FROM (
+              -- Compute Metrics via Expressions
+              SELECT
+                subq_10.guest
+                , subq_10.booking_value
+              FROM (
+                -- Aggregate Measures
+                SELECT
+                  subq_9.guest
+                  , SUM(subq_9.booking_value) AS booking_value
+                FROM (
+                  -- Pass Only Elements: ['booking_value', 'guest']
+                  SELECT
+                    subq_8.guest
+                    , subq_8.booking_value
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_7.ds__day
+                      , subq_7.ds__week
+                      , subq_7.ds__month
+                      , subq_7.ds__quarter
+                      , subq_7.ds__year
+                      , subq_7.ds__extract_year
+                      , subq_7.ds__extract_quarter
+                      , subq_7.ds__extract_month
+                      , subq_7.ds__extract_day
+                      , subq_7.ds__extract_dow
+                      , subq_7.ds__extract_doy
+                      , subq_7.ds_partitioned__day
+                      , subq_7.ds_partitioned__week
+                      , subq_7.ds_partitioned__month
+                      , subq_7.ds_partitioned__quarter
+                      , subq_7.ds_partitioned__year
+                      , subq_7.ds_partitioned__extract_year
+                      , subq_7.ds_partitioned__extract_quarter
+                      , subq_7.ds_partitioned__extract_month
+                      , subq_7.ds_partitioned__extract_day
+                      , subq_7.ds_partitioned__extract_dow
+                      , subq_7.ds_partitioned__extract_doy
+                      , subq_7.paid_at__day
+                      , subq_7.paid_at__week
+                      , subq_7.paid_at__month
+                      , subq_7.paid_at__quarter
+                      , subq_7.paid_at__year
+                      , subq_7.paid_at__extract_year
+                      , subq_7.paid_at__extract_quarter
+                      , subq_7.paid_at__extract_month
+                      , subq_7.paid_at__extract_day
+                      , subq_7.paid_at__extract_dow
+                      , subq_7.paid_at__extract_doy
+                      , subq_7.booking__ds__day
+                      , subq_7.booking__ds__week
+                      , subq_7.booking__ds__month
+                      , subq_7.booking__ds__quarter
+                      , subq_7.booking__ds__year
+                      , subq_7.booking__ds__extract_year
+                      , subq_7.booking__ds__extract_quarter
+                      , subq_7.booking__ds__extract_month
+                      , subq_7.booking__ds__extract_day
+                      , subq_7.booking__ds__extract_dow
+                      , subq_7.booking__ds__extract_doy
+                      , subq_7.booking__ds_partitioned__day
+                      , subq_7.booking__ds_partitioned__week
+                      , subq_7.booking__ds_partitioned__month
+                      , subq_7.booking__ds_partitioned__quarter
+                      , subq_7.booking__ds_partitioned__year
+                      , subq_7.booking__ds_partitioned__extract_year
+                      , subq_7.booking__ds_partitioned__extract_quarter
+                      , subq_7.booking__ds_partitioned__extract_month
+                      , subq_7.booking__ds_partitioned__extract_day
+                      , subq_7.booking__ds_partitioned__extract_dow
+                      , subq_7.booking__ds_partitioned__extract_doy
+                      , subq_7.booking__paid_at__day
+                      , subq_7.booking__paid_at__week
+                      , subq_7.booking__paid_at__month
+                      , subq_7.booking__paid_at__quarter
+                      , subq_7.booking__paid_at__year
+                      , subq_7.booking__paid_at__extract_year
+                      , subq_7.booking__paid_at__extract_quarter
+                      , subq_7.booking__paid_at__extract_month
+                      , subq_7.booking__paid_at__extract_day
+                      , subq_7.booking__paid_at__extract_dow
+                      , subq_7.booking__paid_at__extract_doy
+                      , subq_7.ds__day AS metric_time__day
+                      , subq_7.ds__week AS metric_time__week
+                      , subq_7.ds__month AS metric_time__month
+                      , subq_7.ds__quarter AS metric_time__quarter
+                      , subq_7.ds__year AS metric_time__year
+                      , subq_7.ds__extract_year AS metric_time__extract_year
+                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_7.ds__extract_month AS metric_time__extract_month
+                      , subq_7.ds__extract_day AS metric_time__extract_day
+                      , subq_7.ds__extract_dow AS metric_time__extract_dow
+                      , subq_7.ds__extract_doy AS metric_time__extract_doy
+                      , subq_7.listing
+                      , subq_7.guest
+                      , subq_7.host
+                      , subq_7.booking__listing
+                      , subq_7.booking__guest
+                      , subq_7.booking__host
+                      , subq_7.is_instant
+                      , subq_7.booking__is_instant
+                      , subq_7.bookings
+                      , subq_7.instant_bookings
+                      , subq_7.booking_value
+                      , subq_7.max_booking_value
+                      , subq_7.min_booking_value
+                      , subq_7.bookers
+                      , subq_7.average_booking_value
+                      , subq_7.referred_bookings
+                      , subq_7.median_booking_value
+                      , subq_7.booking_value_p99
+                      , subq_7.discrete_booking_value_p99
+                      , subq_7.approximate_continuous_booking_value_p99
+                      , subq_7.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_7
+                  ) subq_8
+                ) subq_9
+                GROUP BY
+                  subq_9.guest
+              ) subq_10
+            ) subq_11
+          ) subq_12
+          ON
+            subq_6.guest = subq_12.guest
+        ) subq_13
+      ) subq_14
+      WHERE guest__booking_value > 1.00
+    ) subq_15
+  ) subq_16
+) subq_17

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookers',]
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  COUNT(DISTINCT bookers) AS bookers
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'guest__booking_value']
+  SELECT
+    subq_26.booking_value AS guest__booking_value
+    , subq_20.bookers AS bookers
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'guest']
+    SELECT
+      guest_id AS guest
+      , guest_id AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_20
+  LEFT OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['booking_value', 'guest']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    -- Pass Only Elements: ['guest', 'booking_value']
+    SELECT
+      guest_id AS guest
+      , SUM(booking_value) AS booking_value
+    FROM ***************************.fct_bookings bookings_source_src_28000
+    GROUP BY
+      guest_id
+  ) subq_26
+  ON
+    subq_20.guest = subq_26.guest
+) subq_28
+WHERE guest__booking_value > 1.00

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -1,0 +1,457 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_17.bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    COUNT(DISTINCT subq_16.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers',]
+    SELECT
+      subq_15.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_14.guest__booking_value
+        , subq_14.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'guest__booking_value']
+        SELECT
+          subq_13.guest__booking_value
+          , subq_13.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_6.guest AS guest
+            , subq_12.booking_value AS guest__booking_value
+            , subq_6.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'guest']
+            SELECT
+              subq_5.guest
+              , subq_5.bookers
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_4.ds__day
+                , subq_4.ds__week
+                , subq_4.ds__month
+                , subq_4.ds__quarter
+                , subq_4.ds__year
+                , subq_4.ds__extract_year
+                , subq_4.ds__extract_quarter
+                , subq_4.ds__extract_month
+                , subq_4.ds__extract_day
+                , subq_4.ds__extract_dow
+                , subq_4.ds__extract_doy
+                , subq_4.ds_partitioned__day
+                , subq_4.ds_partitioned__week
+                , subq_4.ds_partitioned__month
+                , subq_4.ds_partitioned__quarter
+                , subq_4.ds_partitioned__year
+                , subq_4.ds_partitioned__extract_year
+                , subq_4.ds_partitioned__extract_quarter
+                , subq_4.ds_partitioned__extract_month
+                , subq_4.ds_partitioned__extract_day
+                , subq_4.ds_partitioned__extract_dow
+                , subq_4.ds_partitioned__extract_doy
+                , subq_4.paid_at__day
+                , subq_4.paid_at__week
+                , subq_4.paid_at__month
+                , subq_4.paid_at__quarter
+                , subq_4.paid_at__year
+                , subq_4.paid_at__extract_year
+                , subq_4.paid_at__extract_quarter
+                , subq_4.paid_at__extract_month
+                , subq_4.paid_at__extract_day
+                , subq_4.paid_at__extract_dow
+                , subq_4.paid_at__extract_doy
+                , subq_4.booking__ds__day
+                , subq_4.booking__ds__week
+                , subq_4.booking__ds__month
+                , subq_4.booking__ds__quarter
+                , subq_4.booking__ds__year
+                , subq_4.booking__ds__extract_year
+                , subq_4.booking__ds__extract_quarter
+                , subq_4.booking__ds__extract_month
+                , subq_4.booking__ds__extract_day
+                , subq_4.booking__ds__extract_dow
+                , subq_4.booking__ds__extract_doy
+                , subq_4.booking__ds_partitioned__day
+                , subq_4.booking__ds_partitioned__week
+                , subq_4.booking__ds_partitioned__month
+                , subq_4.booking__ds_partitioned__quarter
+                , subq_4.booking__ds_partitioned__year
+                , subq_4.booking__ds_partitioned__extract_year
+                , subq_4.booking__ds_partitioned__extract_quarter
+                , subq_4.booking__ds_partitioned__extract_month
+                , subq_4.booking__ds_partitioned__extract_day
+                , subq_4.booking__ds_partitioned__extract_dow
+                , subq_4.booking__ds_partitioned__extract_doy
+                , subq_4.booking__paid_at__day
+                , subq_4.booking__paid_at__week
+                , subq_4.booking__paid_at__month
+                , subq_4.booking__paid_at__quarter
+                , subq_4.booking__paid_at__year
+                , subq_4.booking__paid_at__extract_year
+                , subq_4.booking__paid_at__extract_quarter
+                , subq_4.booking__paid_at__extract_month
+                , subq_4.booking__paid_at__extract_day
+                , subq_4.booking__paid_at__extract_dow
+                , subq_4.booking__paid_at__extract_doy
+                , subq_4.ds__day AS metric_time__day
+                , subq_4.ds__week AS metric_time__week
+                , subq_4.ds__month AS metric_time__month
+                , subq_4.ds__quarter AS metric_time__quarter
+                , subq_4.ds__year AS metric_time__year
+                , subq_4.ds__extract_year AS metric_time__extract_year
+                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_4.ds__extract_month AS metric_time__extract_month
+                , subq_4.ds__extract_day AS metric_time__extract_day
+                , subq_4.ds__extract_dow AS metric_time__extract_dow
+                , subq_4.ds__extract_doy AS metric_time__extract_doy
+                , subq_4.listing
+                , subq_4.guest
+                , subq_4.host
+                , subq_4.booking__listing
+                , subq_4.booking__guest
+                , subq_4.booking__host
+                , subq_4.is_instant
+                , subq_4.booking__is_instant
+                , subq_4.bookings
+                , subq_4.instant_bookings
+                , subq_4.booking_value
+                , subq_4.max_booking_value
+                , subq_4.min_booking_value
+                , subq_4.bookers
+                , subq_4.average_booking_value
+                , subq_4.referred_bookings
+                , subq_4.median_booking_value
+                , subq_4.booking_value_p99
+                , subq_4.discrete_booking_value_p99
+                , subq_4.approximate_continuous_booking_value_p99
+                , subq_4.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_4
+            ) subq_5
+          ) subq_6
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['guest', 'booking_value']
+            SELECT
+              subq_11.guest
+              , subq_11.booking_value
+            FROM (
+              -- Compute Metrics via Expressions
+              SELECT
+                subq_10.guest
+                , subq_10.booking_value
+              FROM (
+                -- Aggregate Measures
+                SELECT
+                  subq_9.guest
+                  , SUM(subq_9.booking_value) AS booking_value
+                FROM (
+                  -- Pass Only Elements: ['booking_value', 'guest']
+                  SELECT
+                    subq_8.guest
+                    , subq_8.booking_value
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_7.ds__day
+                      , subq_7.ds__week
+                      , subq_7.ds__month
+                      , subq_7.ds__quarter
+                      , subq_7.ds__year
+                      , subq_7.ds__extract_year
+                      , subq_7.ds__extract_quarter
+                      , subq_7.ds__extract_month
+                      , subq_7.ds__extract_day
+                      , subq_7.ds__extract_dow
+                      , subq_7.ds__extract_doy
+                      , subq_7.ds_partitioned__day
+                      , subq_7.ds_partitioned__week
+                      , subq_7.ds_partitioned__month
+                      , subq_7.ds_partitioned__quarter
+                      , subq_7.ds_partitioned__year
+                      , subq_7.ds_partitioned__extract_year
+                      , subq_7.ds_partitioned__extract_quarter
+                      , subq_7.ds_partitioned__extract_month
+                      , subq_7.ds_partitioned__extract_day
+                      , subq_7.ds_partitioned__extract_dow
+                      , subq_7.ds_partitioned__extract_doy
+                      , subq_7.paid_at__day
+                      , subq_7.paid_at__week
+                      , subq_7.paid_at__month
+                      , subq_7.paid_at__quarter
+                      , subq_7.paid_at__year
+                      , subq_7.paid_at__extract_year
+                      , subq_7.paid_at__extract_quarter
+                      , subq_7.paid_at__extract_month
+                      , subq_7.paid_at__extract_day
+                      , subq_7.paid_at__extract_dow
+                      , subq_7.paid_at__extract_doy
+                      , subq_7.booking__ds__day
+                      , subq_7.booking__ds__week
+                      , subq_7.booking__ds__month
+                      , subq_7.booking__ds__quarter
+                      , subq_7.booking__ds__year
+                      , subq_7.booking__ds__extract_year
+                      , subq_7.booking__ds__extract_quarter
+                      , subq_7.booking__ds__extract_month
+                      , subq_7.booking__ds__extract_day
+                      , subq_7.booking__ds__extract_dow
+                      , subq_7.booking__ds__extract_doy
+                      , subq_7.booking__ds_partitioned__day
+                      , subq_7.booking__ds_partitioned__week
+                      , subq_7.booking__ds_partitioned__month
+                      , subq_7.booking__ds_partitioned__quarter
+                      , subq_7.booking__ds_partitioned__year
+                      , subq_7.booking__ds_partitioned__extract_year
+                      , subq_7.booking__ds_partitioned__extract_quarter
+                      , subq_7.booking__ds_partitioned__extract_month
+                      , subq_7.booking__ds_partitioned__extract_day
+                      , subq_7.booking__ds_partitioned__extract_dow
+                      , subq_7.booking__ds_partitioned__extract_doy
+                      , subq_7.booking__paid_at__day
+                      , subq_7.booking__paid_at__week
+                      , subq_7.booking__paid_at__month
+                      , subq_7.booking__paid_at__quarter
+                      , subq_7.booking__paid_at__year
+                      , subq_7.booking__paid_at__extract_year
+                      , subq_7.booking__paid_at__extract_quarter
+                      , subq_7.booking__paid_at__extract_month
+                      , subq_7.booking__paid_at__extract_day
+                      , subq_7.booking__paid_at__extract_dow
+                      , subq_7.booking__paid_at__extract_doy
+                      , subq_7.ds__day AS metric_time__day
+                      , subq_7.ds__week AS metric_time__week
+                      , subq_7.ds__month AS metric_time__month
+                      , subq_7.ds__quarter AS metric_time__quarter
+                      , subq_7.ds__year AS metric_time__year
+                      , subq_7.ds__extract_year AS metric_time__extract_year
+                      , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_7.ds__extract_month AS metric_time__extract_month
+                      , subq_7.ds__extract_day AS metric_time__extract_day
+                      , subq_7.ds__extract_dow AS metric_time__extract_dow
+                      , subq_7.ds__extract_doy AS metric_time__extract_doy
+                      , subq_7.listing
+                      , subq_7.guest
+                      , subq_7.host
+                      , subq_7.booking__listing
+                      , subq_7.booking__guest
+                      , subq_7.booking__host
+                      , subq_7.is_instant
+                      , subq_7.booking__is_instant
+                      , subq_7.bookings
+                      , subq_7.instant_bookings
+                      , subq_7.booking_value
+                      , subq_7.max_booking_value
+                      , subq_7.min_booking_value
+                      , subq_7.bookers
+                      , subq_7.average_booking_value
+                      , subq_7.referred_bookings
+                      , subq_7.median_booking_value
+                      , subq_7.booking_value_p99
+                      , subq_7.discrete_booking_value_p99
+                      , subq_7.approximate_continuous_booking_value_p99
+                      , subq_7.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_7
+                  ) subq_8
+                ) subq_9
+                GROUP BY
+                  subq_9.guest
+              ) subq_10
+            ) subq_11
+          ) subq_12
+          ON
+            subq_6.guest = subq_12.guest
+        ) subq_13
+      ) subq_14
+      WHERE guest__booking_value > 1.00
+    ) subq_15
+  ) subq_16
+) subq_17

--- a/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookers',]
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  COUNT(DISTINCT bookers) AS bookers
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'guest__booking_value']
+  SELECT
+    subq_26.booking_value AS guest__booking_value
+    , subq_20.bookers AS bookers
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookers', 'guest']
+    SELECT
+      guest_id AS guest
+      , guest_id AS bookers
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_20
+  LEFT OUTER JOIN (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['booking_value', 'guest']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    -- Pass Only Elements: ['guest', 'booking_value']
+    SELECT
+      guest_id AS guest
+      , SUM(booking_value) AS booking_value
+    FROM ***************************.fct_bookings bookings_source_src_28000
+    GROUP BY
+      guest_id
+  ) subq_26
+  ON
+    subq_20.guest = subq_26.guest
+) subq_28
+WHERE guest__booking_value > 1.00


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
In the initial release of Metrics as Dimensions, I overlooked some logic around local elements, resulting in a bug where you can't filter on a metric that's in the same semantic model as the metric you're querying. This fixes that!

Note that the commit `Add METRIC property to all_properties()` is duplicated in https://github.com/dbt-labs/metricflow/pull/1107, so I'll make sure to resolve any resulting merge conflicts based on whichever PR merges first.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
