### PR TITLE
Bug fix: selective where filters after join to time spine

### DIFF
--- a/.changes/unreleased/Fixes-20240521-165853.yaml
+++ b/.changes/unreleased/Fixes-20240521-165853.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: For metrics that join to time spine, apply post-join filters only for specs
+  that are in the group by.
+time: 2024-05-21T16:58:53.09277-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1119"

--- a/tests_metricflow/integration/test_cases/itest_metrics.yaml
+++ b/tests_metricflow/integration/test_cases/itest_metrics.yaml
@@ -2191,7 +2191,7 @@ integration_test:
 ---
 integration_test:
   name: join_to_time_spine_with_queried_time_constraint
-  description: Test join to time spine with time constraint that isn't in group by. Should apply constraint twice.
+  description: Test join to time spine with time constraint that is in group by. Should apply constraint twice.
   model: SIMPLE_MODEL
   metrics: ["bookings_join_to_time_spine"]
   group_by_objs: [{"name": "metric_time"}]

--- a/tests_metricflow/integration/test_cases/itest_metrics.yaml
+++ b/tests_metricflow/integration/test_cases/itest_metrics.yaml
@@ -2131,3 +2131,82 @@ integration_test:
     ) metric_subquery
     ON t.customer_third_hop_id = metric_subquery.customer_third_hop_id
     WHERE txn_count > 0
+---
+integration_test:
+  name: simple_join_to_time_spine_with_filter
+  description: Test a simple metric that joins to time spine, but doesn't fill nulls, filtered by a dimension that's not in the group by. Should apply constraint only once.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_join_to_time_spine"]
+  group_by_objs: [{"name": "metric_time"}]
+  where_filter:  "{{ render_dimension_template('booking__is_instant') }}"
+  check_query: |
+    SELECT
+      b.ds AS metric_time__day
+      , a.bookings AS bookings_join_to_time_spine
+    FROM {{ source_schema }}.mf_time_spine b
+    LEFT JOIN (
+      SELECT
+        {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS ds
+        , SUM(1) AS bookings
+      FROM {{ source_schema }}.fct_bookings
+      WHERE is_instant
+      GROUP BY {{ render_date_trunc("ds", TimeGranularity.DAY) }}
+    ) a ON b.ds = a.ds
+---
+integration_test:
+  name: simple_join_to_time_spine_with_queried_filter
+  description: Test a simple metric that joins to time spine, but doesn't fill nulls, filtered by a dimension that is in the group by. Should apply constraint twice.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_join_to_time_spine"]
+  group_by_objs: [{"name": "metric_time"}, {"name": "booking__is_instant"}]
+  where_filter:  "{{ render_dimension_template('booking__is_instant') }}"
+  check_query: |
+    SELECT
+      b.ds AS metric_time__day
+      , a.is_instant AS booking__is_instant
+      , a.bookings AS bookings_join_to_time_spine
+    FROM {{ source_schema }}.mf_time_spine b
+    LEFT JOIN (
+      SELECT
+        {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS ds
+        , is_instant
+        , SUM(1) AS bookings
+      FROM {{ source_schema }}.fct_bookings
+      WHERE is_instant
+      GROUP BY {{ render_date_trunc("ds", TimeGranularity.DAY) }}, is_instant
+    ) a ON b.ds = a.ds
+    WHERE is_instant
+---
+integration_test:
+  name: join_to_time_spine_with_time_constraint
+  description: Test join to time spine with time constraint that isn't in group by. Should skip both time spine join and second constraint.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_join_to_time_spine"]
+  time_constraint: ["2020-01-03", "2020-01-03"]
+  check_query: |
+    SELECT
+      SUM(1) AS bookings_join_to_time_spine
+    FROM {{ source_schema }}.fct_bookings
+    WHERE {{ render_between_time_constraint("ds", "2020-01-03", "2020-01-03") }}
+---
+integration_test:
+  name: join_to_time_spine_with_queried_time_constraint
+  description: Test join to time spine with time constraint that isn't in group by. Should apply constraint twice.
+  model: SIMPLE_MODEL
+  metrics: ["bookings_join_to_time_spine"]
+  group_by_objs: [{"name": "metric_time"}]
+  time_constraint: ["2020-01-03", "2020-01-03"]
+  check_query: |
+    SELECT
+      b.ds AS metric_time__day
+      , a.bookings AS bookings_join_to_time_spine
+    FROM {{ source_schema }}.mf_time_spine b
+    LEFT JOIN (
+      SELECT
+        {{ render_date_trunc("ds", TimeGranularity.DAY) }} AS ds
+        , SUM(1) AS bookings
+      FROM {{ source_schema }}.fct_bookings
+      WHERE {{ render_between_time_constraint("ds", "2020-01-03", "2020-01-03") }}
+      GROUP BY {{ render_date_trunc("ds", TimeGranularity.DAY) }}
+    ) a ON b.ds = a.ds
+    WHERE {{ render_between_time_constraint("b.ds", "2020-01-03", "2020-01-03") }}

--- a/tests_metricflow/query_rendering/test_time_spine_join_rendering.py
+++ b/tests_metricflow/query_rendering/test_time_spine_join_rendering.py
@@ -8,13 +8,15 @@ rows covering each sub-interval in the range (e.g., for measure defined in SCD d
 
 from __future__ import annotations
 
+import datetime
+
 import pytest
 from _pytest.fixtures import FixtureRequest
+from dbt_semantic_interfaces.implementations.filters.where_filter import PydanticWhereFilter
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
-from metricflow_semantics.specs.spec_classes import (
-    MetricSpec,
-)
+from metricflow_semantics.specs.spec_classes import MetricSpec
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
@@ -38,6 +40,111 @@ def test_simple_join_to_time_spine(  # noqa: D103
             time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
         )
     )
+
+    convert_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_simple_join_to_time_spine_with_filter(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    query_parser: MetricFlowQueryParser,
+) -> None:
+    """Test case where metric fills nulls and filter is not in group by. Should apply constraint once."""
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("bookings_fill_nulls_with_0",),
+        group_by_names=("metric_time__day",),
+        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+    ).query_spec
+    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
+
+    convert_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_simple_join_to_time_spine_with_queried_filter(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    query_parser: MetricFlowQueryParser,
+) -> None:
+    """Test case where metric fills nulls and filter is in group by. Should apply constraint twice."""
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("bookings_fill_nulls_with_0",),
+        group_by_names=("metric_time__day", "booking__is_instant"),
+        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+    ).query_spec
+    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
+
+    convert_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_join_to_time_spine_with_time_constraint(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    query_parser: MetricFlowQueryParser,
+) -> None:
+    """Test case where metric that fills nulls is queried with a time constraint. Should apply constraint once."""
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("bookings_fill_nulls_with_0",),
+        time_constraint_start=datetime.datetime(2020, 1, 3),
+        time_constraint_end=datetime.datetime(2020, 1, 5),
+    ).query_spec
+    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
+
+    convert_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_join_to_time_spine_with_queried_time_constraint(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+    query_parser: MetricFlowQueryParser,
+) -> None:
+    """Test case where metric that fills nulls is queried with metric time and a time constraint. Should apply constraint twice."""
+    query_spec = query_parser.parse_and_validate_query(
+        metric_names=("bookings_fill_nulls_with_0",),
+        group_by_names=("metric_time__day",),
+        time_constraint_start=datetime.datetime(2020, 1, 3),
+        time_constraint_end=datetime.datetime(2020, 1, 5),
+    ).query_spec
+    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
         request=request,

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,0 +1,338 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_9.metric_time__day
+    , subq_9.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_7.metric_time__day AS metric_time__day
+      , subq_6.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_8.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_8
+      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_7
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_5.metric_time__day
+        , SUM(subq_5.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          subq_4.metric_time__day
+          , subq_4.bookings
+        FROM (
+          -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+          SELECT
+            subq_3.ds__day
+            , subq_3.ds__week
+            , subq_3.ds__month
+            , subq_3.ds__quarter
+            , subq_3.ds__year
+            , subq_3.ds__extract_year
+            , subq_3.ds__extract_quarter
+            , subq_3.ds__extract_month
+            , subq_3.ds__extract_day
+            , subq_3.ds__extract_dow
+            , subq_3.ds__extract_doy
+            , subq_3.ds_partitioned__day
+            , subq_3.ds_partitioned__week
+            , subq_3.ds_partitioned__month
+            , subq_3.ds_partitioned__quarter
+            , subq_3.ds_partitioned__year
+            , subq_3.ds_partitioned__extract_year
+            , subq_3.ds_partitioned__extract_quarter
+            , subq_3.ds_partitioned__extract_month
+            , subq_3.ds_partitioned__extract_day
+            , subq_3.ds_partitioned__extract_dow
+            , subq_3.ds_partitioned__extract_doy
+            , subq_3.paid_at__day
+            , subq_3.paid_at__week
+            , subq_3.paid_at__month
+            , subq_3.paid_at__quarter
+            , subq_3.paid_at__year
+            , subq_3.paid_at__extract_year
+            , subq_3.paid_at__extract_quarter
+            , subq_3.paid_at__extract_month
+            , subq_3.paid_at__extract_day
+            , subq_3.paid_at__extract_dow
+            , subq_3.paid_at__extract_doy
+            , subq_3.booking__ds__day
+            , subq_3.booking__ds__week
+            , subq_3.booking__ds__month
+            , subq_3.booking__ds__quarter
+            , subq_3.booking__ds__year
+            , subq_3.booking__ds__extract_year
+            , subq_3.booking__ds__extract_quarter
+            , subq_3.booking__ds__extract_month
+            , subq_3.booking__ds__extract_day
+            , subq_3.booking__ds__extract_dow
+            , subq_3.booking__ds__extract_doy
+            , subq_3.booking__ds_partitioned__day
+            , subq_3.booking__ds_partitioned__week
+            , subq_3.booking__ds_partitioned__month
+            , subq_3.booking__ds_partitioned__quarter
+            , subq_3.booking__ds_partitioned__year
+            , subq_3.booking__ds_partitioned__extract_year
+            , subq_3.booking__ds_partitioned__extract_quarter
+            , subq_3.booking__ds_partitioned__extract_month
+            , subq_3.booking__ds_partitioned__extract_day
+            , subq_3.booking__ds_partitioned__extract_dow
+            , subq_3.booking__ds_partitioned__extract_doy
+            , subq_3.booking__paid_at__day
+            , subq_3.booking__paid_at__week
+            , subq_3.booking__paid_at__month
+            , subq_3.booking__paid_at__quarter
+            , subq_3.booking__paid_at__year
+            , subq_3.booking__paid_at__extract_year
+            , subq_3.booking__paid_at__extract_quarter
+            , subq_3.booking__paid_at__extract_month
+            , subq_3.booking__paid_at__extract_day
+            , subq_3.booking__paid_at__extract_dow
+            , subq_3.booking__paid_at__extract_doy
+            , subq_3.metric_time__day
+            , subq_3.metric_time__week
+            , subq_3.metric_time__month
+            , subq_3.metric_time__quarter
+            , subq_3.metric_time__year
+            , subq_3.metric_time__extract_year
+            , subq_3.metric_time__extract_quarter
+            , subq_3.metric_time__extract_month
+            , subq_3.metric_time__extract_day
+            , subq_3.metric_time__extract_dow
+            , subq_3.metric_time__extract_doy
+            , subq_3.listing
+            , subq_3.guest
+            , subq_3.host
+            , subq_3.booking__listing
+            , subq_3.booking__guest
+            , subq_3.booking__host
+            , subq_3.is_instant
+            , subq_3.booking__is_instant
+            , subq_3.bookings
+            , subq_3.instant_bookings
+            , subq_3.booking_value
+            , subq_3.max_booking_value
+            , subq_3.min_booking_value
+            , subq_3.bookers
+            , subq_3.average_booking_value
+            , subq_3.referred_bookings
+            , subq_3.median_booking_value
+            , subq_3.booking_value_p99
+            , subq_3.discrete_booking_value_p99
+            , subq_3.approximate_continuous_booking_value_p99
+            , subq_3.approximate_discrete_booking_value_p99
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_2.ds__day
+              , subq_2.ds__week
+              , subq_2.ds__month
+              , subq_2.ds__quarter
+              , subq_2.ds__year
+              , subq_2.ds__extract_year
+              , subq_2.ds__extract_quarter
+              , subq_2.ds__extract_month
+              , subq_2.ds__extract_day
+              , subq_2.ds__extract_dow
+              , subq_2.ds__extract_doy
+              , subq_2.ds_partitioned__day
+              , subq_2.ds_partitioned__week
+              , subq_2.ds_partitioned__month
+              , subq_2.ds_partitioned__quarter
+              , subq_2.ds_partitioned__year
+              , subq_2.ds_partitioned__extract_year
+              , subq_2.ds_partitioned__extract_quarter
+              , subq_2.ds_partitioned__extract_month
+              , subq_2.ds_partitioned__extract_day
+              , subq_2.ds_partitioned__extract_dow
+              , subq_2.ds_partitioned__extract_doy
+              , subq_2.paid_at__day
+              , subq_2.paid_at__week
+              , subq_2.paid_at__month
+              , subq_2.paid_at__quarter
+              , subq_2.paid_at__year
+              , subq_2.paid_at__extract_year
+              , subq_2.paid_at__extract_quarter
+              , subq_2.paid_at__extract_month
+              , subq_2.paid_at__extract_day
+              , subq_2.paid_at__extract_dow
+              , subq_2.paid_at__extract_doy
+              , subq_2.booking__ds__day
+              , subq_2.booking__ds__week
+              , subq_2.booking__ds__month
+              , subq_2.booking__ds__quarter
+              , subq_2.booking__ds__year
+              , subq_2.booking__ds__extract_year
+              , subq_2.booking__ds__extract_quarter
+              , subq_2.booking__ds__extract_month
+              , subq_2.booking__ds__extract_day
+              , subq_2.booking__ds__extract_dow
+              , subq_2.booking__ds__extract_doy
+              , subq_2.booking__ds_partitioned__day
+              , subq_2.booking__ds_partitioned__week
+              , subq_2.booking__ds_partitioned__month
+              , subq_2.booking__ds_partitioned__quarter
+              , subq_2.booking__ds_partitioned__year
+              , subq_2.booking__ds_partitioned__extract_year
+              , subq_2.booking__ds_partitioned__extract_quarter
+              , subq_2.booking__ds_partitioned__extract_month
+              , subq_2.booking__ds_partitioned__extract_day
+              , subq_2.booking__ds_partitioned__extract_dow
+              , subq_2.booking__ds_partitioned__extract_doy
+              , subq_2.booking__paid_at__day
+              , subq_2.booking__paid_at__week
+              , subq_2.booking__paid_at__month
+              , subq_2.booking__paid_at__quarter
+              , subq_2.booking__paid_at__year
+              , subq_2.booking__paid_at__extract_year
+              , subq_2.booking__paid_at__extract_quarter
+              , subq_2.booking__paid_at__extract_month
+              , subq_2.booking__paid_at__extract_day
+              , subq_2.booking__paid_at__extract_dow
+              , subq_2.booking__paid_at__extract_doy
+              , subq_2.ds__day AS metric_time__day
+              , subq_2.ds__week AS metric_time__week
+              , subq_2.ds__month AS metric_time__month
+              , subq_2.ds__quarter AS metric_time__quarter
+              , subq_2.ds__year AS metric_time__year
+              , subq_2.ds__extract_year AS metric_time__extract_year
+              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_2.ds__extract_month AS metric_time__extract_month
+              , subq_2.ds__extract_day AS metric_time__extract_day
+              , subq_2.ds__extract_dow AS metric_time__extract_dow
+              , subq_2.ds__extract_doy AS metric_time__extract_doy
+              , subq_2.listing
+              , subq_2.guest
+              , subq_2.host
+              , subq_2.booking__listing
+              , subq_2.booking__guest
+              , subq_2.booking__host
+              , subq_2.is_instant
+              , subq_2.booking__is_instant
+              , subq_2.bookings
+              , subq_2.instant_bookings
+              , subq_2.booking_value
+              , subq_2.max_booking_value
+              , subq_2.min_booking_value
+              , subq_2.bookers
+              , subq_2.average_booking_value
+              , subq_2.referred_bookings
+              , subq_2.median_booking_value
+              , subq_2.booking_value_p99
+              , subq_2.discrete_booking_value_p99
+              , subq_2.approximate_continuous_booking_value_p99
+              , subq_2.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                , DATE_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_2
+          ) subq_3
+          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        metric_time__day
+    ) subq_6
+    ON
+      subq_7.metric_time__day = subq_6.metric_time__day
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -1,0 +1,40 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_16.metric_time__day AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_17
+    WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+  ) subq_16
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC(ds, day) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+      WHERE DATE_TRUNC(ds, day) BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_14
+    GROUP BY
+      metric_time__day
+  ) subq_15
+  ON
+    subq_16.metric_time__day = subq_15.metric_time__day
+  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,0 +1,311 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_5.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings',]
+    SELECT
+      subq_4.bookings
+    FROM (
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      SELECT
+        subq_3.ds__day
+        , subq_3.ds__week
+        , subq_3.ds__month
+        , subq_3.ds__quarter
+        , subq_3.ds__year
+        , subq_3.ds__extract_year
+        , subq_3.ds__extract_quarter
+        , subq_3.ds__extract_month
+        , subq_3.ds__extract_day
+        , subq_3.ds__extract_dow
+        , subq_3.ds__extract_doy
+        , subq_3.ds_partitioned__day
+        , subq_3.ds_partitioned__week
+        , subq_3.ds_partitioned__month
+        , subq_3.ds_partitioned__quarter
+        , subq_3.ds_partitioned__year
+        , subq_3.ds_partitioned__extract_year
+        , subq_3.ds_partitioned__extract_quarter
+        , subq_3.ds_partitioned__extract_month
+        , subq_3.ds_partitioned__extract_day
+        , subq_3.ds_partitioned__extract_dow
+        , subq_3.ds_partitioned__extract_doy
+        , subq_3.paid_at__day
+        , subq_3.paid_at__week
+        , subq_3.paid_at__month
+        , subq_3.paid_at__quarter
+        , subq_3.paid_at__year
+        , subq_3.paid_at__extract_year
+        , subq_3.paid_at__extract_quarter
+        , subq_3.paid_at__extract_month
+        , subq_3.paid_at__extract_day
+        , subq_3.paid_at__extract_dow
+        , subq_3.paid_at__extract_doy
+        , subq_3.booking__ds__day
+        , subq_3.booking__ds__week
+        , subq_3.booking__ds__month
+        , subq_3.booking__ds__quarter
+        , subq_3.booking__ds__year
+        , subq_3.booking__ds__extract_year
+        , subq_3.booking__ds__extract_quarter
+        , subq_3.booking__ds__extract_month
+        , subq_3.booking__ds__extract_day
+        , subq_3.booking__ds__extract_dow
+        , subq_3.booking__ds__extract_doy
+        , subq_3.booking__ds_partitioned__day
+        , subq_3.booking__ds_partitioned__week
+        , subq_3.booking__ds_partitioned__month
+        , subq_3.booking__ds_partitioned__quarter
+        , subq_3.booking__ds_partitioned__year
+        , subq_3.booking__ds_partitioned__extract_year
+        , subq_3.booking__ds_partitioned__extract_quarter
+        , subq_3.booking__ds_partitioned__extract_month
+        , subq_3.booking__ds_partitioned__extract_day
+        , subq_3.booking__ds_partitioned__extract_dow
+        , subq_3.booking__ds_partitioned__extract_doy
+        , subq_3.booking__paid_at__day
+        , subq_3.booking__paid_at__week
+        , subq_3.booking__paid_at__month
+        , subq_3.booking__paid_at__quarter
+        , subq_3.booking__paid_at__year
+        , subq_3.booking__paid_at__extract_year
+        , subq_3.booking__paid_at__extract_quarter
+        , subq_3.booking__paid_at__extract_month
+        , subq_3.booking__paid_at__extract_day
+        , subq_3.booking__paid_at__extract_dow
+        , subq_3.booking__paid_at__extract_doy
+        , subq_3.metric_time__day
+        , subq_3.metric_time__week
+        , subq_3.metric_time__month
+        , subq_3.metric_time__quarter
+        , subq_3.metric_time__year
+        , subq_3.metric_time__extract_year
+        , subq_3.metric_time__extract_quarter
+        , subq_3.metric_time__extract_month
+        , subq_3.metric_time__extract_day
+        , subq_3.metric_time__extract_dow
+        , subq_3.metric_time__extract_doy
+        , subq_3.listing
+        , subq_3.guest
+        , subq_3.host
+        , subq_3.booking__listing
+        , subq_3.booking__guest
+        , subq_3.booking__host
+        , subq_3.is_instant
+        , subq_3.booking__is_instant
+        , subq_3.bookings
+        , subq_3.instant_bookings
+        , subq_3.booking_value
+        , subq_3.max_booking_value
+        , subq_3.min_booking_value
+        , subq_3.bookers
+        , subq_3.average_booking_value
+        , subq_3.referred_bookings
+        , subq_3.median_booking_value
+        , subq_3.booking_value_p99
+        , subq_3.discrete_booking_value_p99
+        , subq_3.approximate_continuous_booking_value_p99
+        , subq_3.approximate_discrete_booking_value_p99
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_2.ds__day
+          , subq_2.ds__week
+          , subq_2.ds__month
+          , subq_2.ds__quarter
+          , subq_2.ds__year
+          , subq_2.ds__extract_year
+          , subq_2.ds__extract_quarter
+          , subq_2.ds__extract_month
+          , subq_2.ds__extract_day
+          , subq_2.ds__extract_dow
+          , subq_2.ds__extract_doy
+          , subq_2.ds_partitioned__day
+          , subq_2.ds_partitioned__week
+          , subq_2.ds_partitioned__month
+          , subq_2.ds_partitioned__quarter
+          , subq_2.ds_partitioned__year
+          , subq_2.ds_partitioned__extract_year
+          , subq_2.ds_partitioned__extract_quarter
+          , subq_2.ds_partitioned__extract_month
+          , subq_2.ds_partitioned__extract_day
+          , subq_2.ds_partitioned__extract_dow
+          , subq_2.ds_partitioned__extract_doy
+          , subq_2.paid_at__day
+          , subq_2.paid_at__week
+          , subq_2.paid_at__month
+          , subq_2.paid_at__quarter
+          , subq_2.paid_at__year
+          , subq_2.paid_at__extract_year
+          , subq_2.paid_at__extract_quarter
+          , subq_2.paid_at__extract_month
+          , subq_2.paid_at__extract_day
+          , subq_2.paid_at__extract_dow
+          , subq_2.paid_at__extract_doy
+          , subq_2.booking__ds__day
+          , subq_2.booking__ds__week
+          , subq_2.booking__ds__month
+          , subq_2.booking__ds__quarter
+          , subq_2.booking__ds__year
+          , subq_2.booking__ds__extract_year
+          , subq_2.booking__ds__extract_quarter
+          , subq_2.booking__ds__extract_month
+          , subq_2.booking__ds__extract_day
+          , subq_2.booking__ds__extract_dow
+          , subq_2.booking__ds__extract_doy
+          , subq_2.booking__ds_partitioned__day
+          , subq_2.booking__ds_partitioned__week
+          , subq_2.booking__ds_partitioned__month
+          , subq_2.booking__ds_partitioned__quarter
+          , subq_2.booking__ds_partitioned__year
+          , subq_2.booking__ds_partitioned__extract_year
+          , subq_2.booking__ds_partitioned__extract_quarter
+          , subq_2.booking__ds_partitioned__extract_month
+          , subq_2.booking__ds_partitioned__extract_day
+          , subq_2.booking__ds_partitioned__extract_dow
+          , subq_2.booking__ds_partitioned__extract_doy
+          , subq_2.booking__paid_at__day
+          , subq_2.booking__paid_at__week
+          , subq_2.booking__paid_at__month
+          , subq_2.booking__paid_at__quarter
+          , subq_2.booking__paid_at__year
+          , subq_2.booking__paid_at__extract_year
+          , subq_2.booking__paid_at__extract_quarter
+          , subq_2.booking__paid_at__extract_month
+          , subq_2.booking__paid_at__extract_day
+          , subq_2.booking__paid_at__extract_dow
+          , subq_2.booking__paid_at__extract_doy
+          , subq_2.ds__day AS metric_time__day
+          , subq_2.ds__week AS metric_time__week
+          , subq_2.ds__month AS metric_time__month
+          , subq_2.ds__quarter AS metric_time__quarter
+          , subq_2.ds__year AS metric_time__year
+          , subq_2.ds__extract_year AS metric_time__extract_year
+          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_2.ds__extract_month AS metric_time__extract_month
+          , subq_2.ds__extract_day AS metric_time__extract_day
+          , subq_2.ds__extract_dow AS metric_time__extract_dow
+          , subq_2.ds__extract_doy AS metric_time__extract_doy
+          , subq_2.listing
+          , subq_2.guest
+          , subq_2.host
+          , subq_2.booking__listing
+          , subq_2.booking__guest
+          , subq_2.booking__host
+          , subq_2.is_instant
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+          , subq_2.instant_bookings
+          , subq_2.booking_value
+          , subq_2.max_booking_value
+          , subq_2.min_booking_value
+          , subq_2.bookers
+          , subq_2.average_booking_value
+          , subq_2.referred_bookings
+          , subq_2.median_booking_value
+          , subq_2.booking_value_p99
+          , subq_2.discrete_booking_value_p99
+          , subq_2.approximate_continuous_booking_value_p99
+          , subq_2.approximate_discrete_booking_value_p99
+        FROM (
+          -- Read Elements From Semantic Model 'bookings_source'
+          SELECT
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_28000.booking_value
+            , bookings_source_src_28000.booking_value AS max_booking_value
+            , bookings_source_src_28000.booking_value AS min_booking_value
+            , bookings_source_src_28000.guest_id AS bookers
+            , bookings_source_src_28000.booking_value AS average_booking_value
+            , bookings_source_src_28000.booking_value AS booking_payments
+            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+            , bookings_source_src_28000.booking_value AS median_booking_value
+            , bookings_source_src_28000.booking_value AS booking_value_p99
+            , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+            , bookings_source_src_28000.is_instant
+            , DATE_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+            , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+            , DATE_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+            , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+            , DATE_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+            , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+            , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+            , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+            , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+            , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+            , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+            , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+            , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+            , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+            , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+            , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+            , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+            , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+            , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+            , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+            , bookings_source_src_28000.is_instant AS booking__is_instant
+            , DATE_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+            , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+            , DATE_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+            , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+            , DATE_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+            , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+            , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+            , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+            , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+            , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+            , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+            , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+            , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+            , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+            , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+            , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+            , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+            , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+            , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+            , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+            , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+            , bookings_source_src_28000.listing_id AS listing
+            , bookings_source_src_28000.guest_id AS guest
+            , bookings_source_src_28000.host_id AS host
+            , bookings_source_src_28000.listing_id AS booking__listing
+            , bookings_source_src_28000.guest_id AS booking__guest
+            , bookings_source_src_28000.host_id AS booking__host
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_2
+      ) subq_3
+      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_4
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  -- Pass Only Elements: ['bookings',]
+  -- Aggregate Measures
+  SELECT
+    SUM(1) AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+  WHERE DATE_TRUNC(ds, day) BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_11

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,0 +1,242 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                , DATE_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+    ) subq_4
+    GROUP BY
+      metric_time__day
+  ) subq_5
+  ON
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -1,0 +1,34 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        DATE_TRUNC(ds, day) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_11
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+  ) subq_14
+  ON
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                , DATE_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                , DATE_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                , DATE_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                , DATE_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                , DATE_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        metric_time__day
+        , booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -1,0 +1,45 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , booking__is_instant
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , booking__is_instant
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          DATE_TRUNC(ds, day) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_11
+      WHERE booking__is_instant
+      GROUP BY
+        metric_time__day
+        , booking__is_instant
+    ) subq_13
+    ON
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
+  WHERE booking__is_instant
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,0 +1,338 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_9.metric_time__day
+    , subq_9.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_7.metric_time__day AS metric_time__day
+      , subq_6.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_8.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_8
+      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_7
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_5.metric_time__day
+        , SUM(subq_5.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          subq_4.metric_time__day
+          , subq_4.bookings
+        FROM (
+          -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+          SELECT
+            subq_3.ds__day
+            , subq_3.ds__week
+            , subq_3.ds__month
+            , subq_3.ds__quarter
+            , subq_3.ds__year
+            , subq_3.ds__extract_year
+            , subq_3.ds__extract_quarter
+            , subq_3.ds__extract_month
+            , subq_3.ds__extract_day
+            , subq_3.ds__extract_dow
+            , subq_3.ds__extract_doy
+            , subq_3.ds_partitioned__day
+            , subq_3.ds_partitioned__week
+            , subq_3.ds_partitioned__month
+            , subq_3.ds_partitioned__quarter
+            , subq_3.ds_partitioned__year
+            , subq_3.ds_partitioned__extract_year
+            , subq_3.ds_partitioned__extract_quarter
+            , subq_3.ds_partitioned__extract_month
+            , subq_3.ds_partitioned__extract_day
+            , subq_3.ds_partitioned__extract_dow
+            , subq_3.ds_partitioned__extract_doy
+            , subq_3.paid_at__day
+            , subq_3.paid_at__week
+            , subq_3.paid_at__month
+            , subq_3.paid_at__quarter
+            , subq_3.paid_at__year
+            , subq_3.paid_at__extract_year
+            , subq_3.paid_at__extract_quarter
+            , subq_3.paid_at__extract_month
+            , subq_3.paid_at__extract_day
+            , subq_3.paid_at__extract_dow
+            , subq_3.paid_at__extract_doy
+            , subq_3.booking__ds__day
+            , subq_3.booking__ds__week
+            , subq_3.booking__ds__month
+            , subq_3.booking__ds__quarter
+            , subq_3.booking__ds__year
+            , subq_3.booking__ds__extract_year
+            , subq_3.booking__ds__extract_quarter
+            , subq_3.booking__ds__extract_month
+            , subq_3.booking__ds__extract_day
+            , subq_3.booking__ds__extract_dow
+            , subq_3.booking__ds__extract_doy
+            , subq_3.booking__ds_partitioned__day
+            , subq_3.booking__ds_partitioned__week
+            , subq_3.booking__ds_partitioned__month
+            , subq_3.booking__ds_partitioned__quarter
+            , subq_3.booking__ds_partitioned__year
+            , subq_3.booking__ds_partitioned__extract_year
+            , subq_3.booking__ds_partitioned__extract_quarter
+            , subq_3.booking__ds_partitioned__extract_month
+            , subq_3.booking__ds_partitioned__extract_day
+            , subq_3.booking__ds_partitioned__extract_dow
+            , subq_3.booking__ds_partitioned__extract_doy
+            , subq_3.booking__paid_at__day
+            , subq_3.booking__paid_at__week
+            , subq_3.booking__paid_at__month
+            , subq_3.booking__paid_at__quarter
+            , subq_3.booking__paid_at__year
+            , subq_3.booking__paid_at__extract_year
+            , subq_3.booking__paid_at__extract_quarter
+            , subq_3.booking__paid_at__extract_month
+            , subq_3.booking__paid_at__extract_day
+            , subq_3.booking__paid_at__extract_dow
+            , subq_3.booking__paid_at__extract_doy
+            , subq_3.metric_time__day
+            , subq_3.metric_time__week
+            , subq_3.metric_time__month
+            , subq_3.metric_time__quarter
+            , subq_3.metric_time__year
+            , subq_3.metric_time__extract_year
+            , subq_3.metric_time__extract_quarter
+            , subq_3.metric_time__extract_month
+            , subq_3.metric_time__extract_day
+            , subq_3.metric_time__extract_dow
+            , subq_3.metric_time__extract_doy
+            , subq_3.listing
+            , subq_3.guest
+            , subq_3.host
+            , subq_3.booking__listing
+            , subq_3.booking__guest
+            , subq_3.booking__host
+            , subq_3.is_instant
+            , subq_3.booking__is_instant
+            , subq_3.bookings
+            , subq_3.instant_bookings
+            , subq_3.booking_value
+            , subq_3.max_booking_value
+            , subq_3.min_booking_value
+            , subq_3.bookers
+            , subq_3.average_booking_value
+            , subq_3.referred_bookings
+            , subq_3.median_booking_value
+            , subq_3.booking_value_p99
+            , subq_3.discrete_booking_value_p99
+            , subq_3.approximate_continuous_booking_value_p99
+            , subq_3.approximate_discrete_booking_value_p99
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_2.ds__day
+              , subq_2.ds__week
+              , subq_2.ds__month
+              , subq_2.ds__quarter
+              , subq_2.ds__year
+              , subq_2.ds__extract_year
+              , subq_2.ds__extract_quarter
+              , subq_2.ds__extract_month
+              , subq_2.ds__extract_day
+              , subq_2.ds__extract_dow
+              , subq_2.ds__extract_doy
+              , subq_2.ds_partitioned__day
+              , subq_2.ds_partitioned__week
+              , subq_2.ds_partitioned__month
+              , subq_2.ds_partitioned__quarter
+              , subq_2.ds_partitioned__year
+              , subq_2.ds_partitioned__extract_year
+              , subq_2.ds_partitioned__extract_quarter
+              , subq_2.ds_partitioned__extract_month
+              , subq_2.ds_partitioned__extract_day
+              , subq_2.ds_partitioned__extract_dow
+              , subq_2.ds_partitioned__extract_doy
+              , subq_2.paid_at__day
+              , subq_2.paid_at__week
+              , subq_2.paid_at__month
+              , subq_2.paid_at__quarter
+              , subq_2.paid_at__year
+              , subq_2.paid_at__extract_year
+              , subq_2.paid_at__extract_quarter
+              , subq_2.paid_at__extract_month
+              , subq_2.paid_at__extract_day
+              , subq_2.paid_at__extract_dow
+              , subq_2.paid_at__extract_doy
+              , subq_2.booking__ds__day
+              , subq_2.booking__ds__week
+              , subq_2.booking__ds__month
+              , subq_2.booking__ds__quarter
+              , subq_2.booking__ds__year
+              , subq_2.booking__ds__extract_year
+              , subq_2.booking__ds__extract_quarter
+              , subq_2.booking__ds__extract_month
+              , subq_2.booking__ds__extract_day
+              , subq_2.booking__ds__extract_dow
+              , subq_2.booking__ds__extract_doy
+              , subq_2.booking__ds_partitioned__day
+              , subq_2.booking__ds_partitioned__week
+              , subq_2.booking__ds_partitioned__month
+              , subq_2.booking__ds_partitioned__quarter
+              , subq_2.booking__ds_partitioned__year
+              , subq_2.booking__ds_partitioned__extract_year
+              , subq_2.booking__ds_partitioned__extract_quarter
+              , subq_2.booking__ds_partitioned__extract_month
+              , subq_2.booking__ds_partitioned__extract_day
+              , subq_2.booking__ds_partitioned__extract_dow
+              , subq_2.booking__ds_partitioned__extract_doy
+              , subq_2.booking__paid_at__day
+              , subq_2.booking__paid_at__week
+              , subq_2.booking__paid_at__month
+              , subq_2.booking__paid_at__quarter
+              , subq_2.booking__paid_at__year
+              , subq_2.booking__paid_at__extract_year
+              , subq_2.booking__paid_at__extract_quarter
+              , subq_2.booking__paid_at__extract_month
+              , subq_2.booking__paid_at__extract_day
+              , subq_2.booking__paid_at__extract_dow
+              , subq_2.booking__paid_at__extract_doy
+              , subq_2.ds__day AS metric_time__day
+              , subq_2.ds__week AS metric_time__week
+              , subq_2.ds__month AS metric_time__month
+              , subq_2.ds__quarter AS metric_time__quarter
+              , subq_2.ds__year AS metric_time__year
+              , subq_2.ds__extract_year AS metric_time__extract_year
+              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_2.ds__extract_month AS metric_time__extract_month
+              , subq_2.ds__extract_day AS metric_time__extract_day
+              , subq_2.ds__extract_dow AS metric_time__extract_dow
+              , subq_2.ds__extract_doy AS metric_time__extract_doy
+              , subq_2.listing
+              , subq_2.guest
+              , subq_2.host
+              , subq_2.booking__listing
+              , subq_2.booking__guest
+              , subq_2.booking__host
+              , subq_2.is_instant
+              , subq_2.booking__is_instant
+              , subq_2.bookings
+              , subq_2.instant_bookings
+              , subq_2.booking_value
+              , subq_2.max_booking_value
+              , subq_2.min_booking_value
+              , subq_2.bookers
+              , subq_2.average_booking_value
+              , subq_2.referred_bookings
+              , subq_2.median_booking_value
+              , subq_2.booking_value_p99
+              , subq_2.discrete_booking_value_p99
+              , subq_2.approximate_continuous_booking_value_p99
+              , subq_2.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_2
+          ) subq_3
+          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.metric_time__day
+    ) subq_6
+    ON
+      subq_7.metric_time__day = subq_6.metric_time__day
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -1,0 +1,40 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_16.metric_time__day AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_17
+    WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+  ) subq_16
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_14
+    GROUP BY
+      metric_time__day
+  ) subq_15
+  ON
+    subq_16.metric_time__day = subq_15.metric_time__day
+  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,0 +1,311 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_5.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings',]
+    SELECT
+      subq_4.bookings
+    FROM (
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      SELECT
+        subq_3.ds__day
+        , subq_3.ds__week
+        , subq_3.ds__month
+        , subq_3.ds__quarter
+        , subq_3.ds__year
+        , subq_3.ds__extract_year
+        , subq_3.ds__extract_quarter
+        , subq_3.ds__extract_month
+        , subq_3.ds__extract_day
+        , subq_3.ds__extract_dow
+        , subq_3.ds__extract_doy
+        , subq_3.ds_partitioned__day
+        , subq_3.ds_partitioned__week
+        , subq_3.ds_partitioned__month
+        , subq_3.ds_partitioned__quarter
+        , subq_3.ds_partitioned__year
+        , subq_3.ds_partitioned__extract_year
+        , subq_3.ds_partitioned__extract_quarter
+        , subq_3.ds_partitioned__extract_month
+        , subq_3.ds_partitioned__extract_day
+        , subq_3.ds_partitioned__extract_dow
+        , subq_3.ds_partitioned__extract_doy
+        , subq_3.paid_at__day
+        , subq_3.paid_at__week
+        , subq_3.paid_at__month
+        , subq_3.paid_at__quarter
+        , subq_3.paid_at__year
+        , subq_3.paid_at__extract_year
+        , subq_3.paid_at__extract_quarter
+        , subq_3.paid_at__extract_month
+        , subq_3.paid_at__extract_day
+        , subq_3.paid_at__extract_dow
+        , subq_3.paid_at__extract_doy
+        , subq_3.booking__ds__day
+        , subq_3.booking__ds__week
+        , subq_3.booking__ds__month
+        , subq_3.booking__ds__quarter
+        , subq_3.booking__ds__year
+        , subq_3.booking__ds__extract_year
+        , subq_3.booking__ds__extract_quarter
+        , subq_3.booking__ds__extract_month
+        , subq_3.booking__ds__extract_day
+        , subq_3.booking__ds__extract_dow
+        , subq_3.booking__ds__extract_doy
+        , subq_3.booking__ds_partitioned__day
+        , subq_3.booking__ds_partitioned__week
+        , subq_3.booking__ds_partitioned__month
+        , subq_3.booking__ds_partitioned__quarter
+        , subq_3.booking__ds_partitioned__year
+        , subq_3.booking__ds_partitioned__extract_year
+        , subq_3.booking__ds_partitioned__extract_quarter
+        , subq_3.booking__ds_partitioned__extract_month
+        , subq_3.booking__ds_partitioned__extract_day
+        , subq_3.booking__ds_partitioned__extract_dow
+        , subq_3.booking__ds_partitioned__extract_doy
+        , subq_3.booking__paid_at__day
+        , subq_3.booking__paid_at__week
+        , subq_3.booking__paid_at__month
+        , subq_3.booking__paid_at__quarter
+        , subq_3.booking__paid_at__year
+        , subq_3.booking__paid_at__extract_year
+        , subq_3.booking__paid_at__extract_quarter
+        , subq_3.booking__paid_at__extract_month
+        , subq_3.booking__paid_at__extract_day
+        , subq_3.booking__paid_at__extract_dow
+        , subq_3.booking__paid_at__extract_doy
+        , subq_3.metric_time__day
+        , subq_3.metric_time__week
+        , subq_3.metric_time__month
+        , subq_3.metric_time__quarter
+        , subq_3.metric_time__year
+        , subq_3.metric_time__extract_year
+        , subq_3.metric_time__extract_quarter
+        , subq_3.metric_time__extract_month
+        , subq_3.metric_time__extract_day
+        , subq_3.metric_time__extract_dow
+        , subq_3.metric_time__extract_doy
+        , subq_3.listing
+        , subq_3.guest
+        , subq_3.host
+        , subq_3.booking__listing
+        , subq_3.booking__guest
+        , subq_3.booking__host
+        , subq_3.is_instant
+        , subq_3.booking__is_instant
+        , subq_3.bookings
+        , subq_3.instant_bookings
+        , subq_3.booking_value
+        , subq_3.max_booking_value
+        , subq_3.min_booking_value
+        , subq_3.bookers
+        , subq_3.average_booking_value
+        , subq_3.referred_bookings
+        , subq_3.median_booking_value
+        , subq_3.booking_value_p99
+        , subq_3.discrete_booking_value_p99
+        , subq_3.approximate_continuous_booking_value_p99
+        , subq_3.approximate_discrete_booking_value_p99
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_2.ds__day
+          , subq_2.ds__week
+          , subq_2.ds__month
+          , subq_2.ds__quarter
+          , subq_2.ds__year
+          , subq_2.ds__extract_year
+          , subq_2.ds__extract_quarter
+          , subq_2.ds__extract_month
+          , subq_2.ds__extract_day
+          , subq_2.ds__extract_dow
+          , subq_2.ds__extract_doy
+          , subq_2.ds_partitioned__day
+          , subq_2.ds_partitioned__week
+          , subq_2.ds_partitioned__month
+          , subq_2.ds_partitioned__quarter
+          , subq_2.ds_partitioned__year
+          , subq_2.ds_partitioned__extract_year
+          , subq_2.ds_partitioned__extract_quarter
+          , subq_2.ds_partitioned__extract_month
+          , subq_2.ds_partitioned__extract_day
+          , subq_2.ds_partitioned__extract_dow
+          , subq_2.ds_partitioned__extract_doy
+          , subq_2.paid_at__day
+          , subq_2.paid_at__week
+          , subq_2.paid_at__month
+          , subq_2.paid_at__quarter
+          , subq_2.paid_at__year
+          , subq_2.paid_at__extract_year
+          , subq_2.paid_at__extract_quarter
+          , subq_2.paid_at__extract_month
+          , subq_2.paid_at__extract_day
+          , subq_2.paid_at__extract_dow
+          , subq_2.paid_at__extract_doy
+          , subq_2.booking__ds__day
+          , subq_2.booking__ds__week
+          , subq_2.booking__ds__month
+          , subq_2.booking__ds__quarter
+          , subq_2.booking__ds__year
+          , subq_2.booking__ds__extract_year
+          , subq_2.booking__ds__extract_quarter
+          , subq_2.booking__ds__extract_month
+          , subq_2.booking__ds__extract_day
+          , subq_2.booking__ds__extract_dow
+          , subq_2.booking__ds__extract_doy
+          , subq_2.booking__ds_partitioned__day
+          , subq_2.booking__ds_partitioned__week
+          , subq_2.booking__ds_partitioned__month
+          , subq_2.booking__ds_partitioned__quarter
+          , subq_2.booking__ds_partitioned__year
+          , subq_2.booking__ds_partitioned__extract_year
+          , subq_2.booking__ds_partitioned__extract_quarter
+          , subq_2.booking__ds_partitioned__extract_month
+          , subq_2.booking__ds_partitioned__extract_day
+          , subq_2.booking__ds_partitioned__extract_dow
+          , subq_2.booking__ds_partitioned__extract_doy
+          , subq_2.booking__paid_at__day
+          , subq_2.booking__paid_at__week
+          , subq_2.booking__paid_at__month
+          , subq_2.booking__paid_at__quarter
+          , subq_2.booking__paid_at__year
+          , subq_2.booking__paid_at__extract_year
+          , subq_2.booking__paid_at__extract_quarter
+          , subq_2.booking__paid_at__extract_month
+          , subq_2.booking__paid_at__extract_day
+          , subq_2.booking__paid_at__extract_dow
+          , subq_2.booking__paid_at__extract_doy
+          , subq_2.ds__day AS metric_time__day
+          , subq_2.ds__week AS metric_time__week
+          , subq_2.ds__month AS metric_time__month
+          , subq_2.ds__quarter AS metric_time__quarter
+          , subq_2.ds__year AS metric_time__year
+          , subq_2.ds__extract_year AS metric_time__extract_year
+          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_2.ds__extract_month AS metric_time__extract_month
+          , subq_2.ds__extract_day AS metric_time__extract_day
+          , subq_2.ds__extract_dow AS metric_time__extract_dow
+          , subq_2.ds__extract_doy AS metric_time__extract_doy
+          , subq_2.listing
+          , subq_2.guest
+          , subq_2.host
+          , subq_2.booking__listing
+          , subq_2.booking__guest
+          , subq_2.booking__host
+          , subq_2.is_instant
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+          , subq_2.instant_bookings
+          , subq_2.booking_value
+          , subq_2.max_booking_value
+          , subq_2.min_booking_value
+          , subq_2.bookers
+          , subq_2.average_booking_value
+          , subq_2.referred_bookings
+          , subq_2.median_booking_value
+          , subq_2.booking_value_p99
+          , subq_2.discrete_booking_value_p99
+          , subq_2.approximate_continuous_booking_value_p99
+          , subq_2.approximate_discrete_booking_value_p99
+        FROM (
+          -- Read Elements From Semantic Model 'bookings_source'
+          SELECT
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_28000.booking_value
+            , bookings_source_src_28000.booking_value AS max_booking_value
+            , bookings_source_src_28000.booking_value AS min_booking_value
+            , bookings_source_src_28000.guest_id AS bookers
+            , bookings_source_src_28000.booking_value AS average_booking_value
+            , bookings_source_src_28000.booking_value AS booking_payments
+            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+            , bookings_source_src_28000.booking_value AS median_booking_value
+            , bookings_source_src_28000.booking_value AS booking_value_p99
+            , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+            , bookings_source_src_28000.is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+            , bookings_source_src_28000.is_instant AS booking__is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+            , bookings_source_src_28000.listing_id AS listing
+            , bookings_source_src_28000.guest_id AS guest
+            , bookings_source_src_28000.host_id AS host
+            , bookings_source_src_28000.listing_id AS booking__listing
+            , bookings_source_src_28000.guest_id AS booking__guest
+            , bookings_source_src_28000.host_id AS booking__host
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_2
+      ) subq_3
+      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_4
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  -- Pass Only Elements: ['bookings',]
+  -- Aggregate Measures
+  SELECT
+    SUM(1) AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_11

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,0 +1,242 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+    ) subq_4
+    GROUP BY
+      subq_4.metric_time__day
+  ) subq_5
+  ON
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -1,0 +1,34 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_11
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+  ) subq_14
+  ON
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -1,0 +1,45 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , booking__is_instant
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , booking__is_instant
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_11
+      WHERE booking__is_instant
+      GROUP BY
+        metric_time__day
+        , booking__is_instant
+    ) subq_13
+    ON
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
+  WHERE booking__is_instant
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,0 +1,338 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_9.metric_time__day
+    , subq_9.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_7.metric_time__day AS metric_time__day
+      , subq_6.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_8.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_8
+      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_7
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_5.metric_time__day
+        , SUM(subq_5.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          subq_4.metric_time__day
+          , subq_4.bookings
+        FROM (
+          -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+          SELECT
+            subq_3.ds__day
+            , subq_3.ds__week
+            , subq_3.ds__month
+            , subq_3.ds__quarter
+            , subq_3.ds__year
+            , subq_3.ds__extract_year
+            , subq_3.ds__extract_quarter
+            , subq_3.ds__extract_month
+            , subq_3.ds__extract_day
+            , subq_3.ds__extract_dow
+            , subq_3.ds__extract_doy
+            , subq_3.ds_partitioned__day
+            , subq_3.ds_partitioned__week
+            , subq_3.ds_partitioned__month
+            , subq_3.ds_partitioned__quarter
+            , subq_3.ds_partitioned__year
+            , subq_3.ds_partitioned__extract_year
+            , subq_3.ds_partitioned__extract_quarter
+            , subq_3.ds_partitioned__extract_month
+            , subq_3.ds_partitioned__extract_day
+            , subq_3.ds_partitioned__extract_dow
+            , subq_3.ds_partitioned__extract_doy
+            , subq_3.paid_at__day
+            , subq_3.paid_at__week
+            , subq_3.paid_at__month
+            , subq_3.paid_at__quarter
+            , subq_3.paid_at__year
+            , subq_3.paid_at__extract_year
+            , subq_3.paid_at__extract_quarter
+            , subq_3.paid_at__extract_month
+            , subq_3.paid_at__extract_day
+            , subq_3.paid_at__extract_dow
+            , subq_3.paid_at__extract_doy
+            , subq_3.booking__ds__day
+            , subq_3.booking__ds__week
+            , subq_3.booking__ds__month
+            , subq_3.booking__ds__quarter
+            , subq_3.booking__ds__year
+            , subq_3.booking__ds__extract_year
+            , subq_3.booking__ds__extract_quarter
+            , subq_3.booking__ds__extract_month
+            , subq_3.booking__ds__extract_day
+            , subq_3.booking__ds__extract_dow
+            , subq_3.booking__ds__extract_doy
+            , subq_3.booking__ds_partitioned__day
+            , subq_3.booking__ds_partitioned__week
+            , subq_3.booking__ds_partitioned__month
+            , subq_3.booking__ds_partitioned__quarter
+            , subq_3.booking__ds_partitioned__year
+            , subq_3.booking__ds_partitioned__extract_year
+            , subq_3.booking__ds_partitioned__extract_quarter
+            , subq_3.booking__ds_partitioned__extract_month
+            , subq_3.booking__ds_partitioned__extract_day
+            , subq_3.booking__ds_partitioned__extract_dow
+            , subq_3.booking__ds_partitioned__extract_doy
+            , subq_3.booking__paid_at__day
+            , subq_3.booking__paid_at__week
+            , subq_3.booking__paid_at__month
+            , subq_3.booking__paid_at__quarter
+            , subq_3.booking__paid_at__year
+            , subq_3.booking__paid_at__extract_year
+            , subq_3.booking__paid_at__extract_quarter
+            , subq_3.booking__paid_at__extract_month
+            , subq_3.booking__paid_at__extract_day
+            , subq_3.booking__paid_at__extract_dow
+            , subq_3.booking__paid_at__extract_doy
+            , subq_3.metric_time__day
+            , subq_3.metric_time__week
+            , subq_3.metric_time__month
+            , subq_3.metric_time__quarter
+            , subq_3.metric_time__year
+            , subq_3.metric_time__extract_year
+            , subq_3.metric_time__extract_quarter
+            , subq_3.metric_time__extract_month
+            , subq_3.metric_time__extract_day
+            , subq_3.metric_time__extract_dow
+            , subq_3.metric_time__extract_doy
+            , subq_3.listing
+            , subq_3.guest
+            , subq_3.host
+            , subq_3.booking__listing
+            , subq_3.booking__guest
+            , subq_3.booking__host
+            , subq_3.is_instant
+            , subq_3.booking__is_instant
+            , subq_3.bookings
+            , subq_3.instant_bookings
+            , subq_3.booking_value
+            , subq_3.max_booking_value
+            , subq_3.min_booking_value
+            , subq_3.bookers
+            , subq_3.average_booking_value
+            , subq_3.referred_bookings
+            , subq_3.median_booking_value
+            , subq_3.booking_value_p99
+            , subq_3.discrete_booking_value_p99
+            , subq_3.approximate_continuous_booking_value_p99
+            , subq_3.approximate_discrete_booking_value_p99
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_2.ds__day
+              , subq_2.ds__week
+              , subq_2.ds__month
+              , subq_2.ds__quarter
+              , subq_2.ds__year
+              , subq_2.ds__extract_year
+              , subq_2.ds__extract_quarter
+              , subq_2.ds__extract_month
+              , subq_2.ds__extract_day
+              , subq_2.ds__extract_dow
+              , subq_2.ds__extract_doy
+              , subq_2.ds_partitioned__day
+              , subq_2.ds_partitioned__week
+              , subq_2.ds_partitioned__month
+              , subq_2.ds_partitioned__quarter
+              , subq_2.ds_partitioned__year
+              , subq_2.ds_partitioned__extract_year
+              , subq_2.ds_partitioned__extract_quarter
+              , subq_2.ds_partitioned__extract_month
+              , subq_2.ds_partitioned__extract_day
+              , subq_2.ds_partitioned__extract_dow
+              , subq_2.ds_partitioned__extract_doy
+              , subq_2.paid_at__day
+              , subq_2.paid_at__week
+              , subq_2.paid_at__month
+              , subq_2.paid_at__quarter
+              , subq_2.paid_at__year
+              , subq_2.paid_at__extract_year
+              , subq_2.paid_at__extract_quarter
+              , subq_2.paid_at__extract_month
+              , subq_2.paid_at__extract_day
+              , subq_2.paid_at__extract_dow
+              , subq_2.paid_at__extract_doy
+              , subq_2.booking__ds__day
+              , subq_2.booking__ds__week
+              , subq_2.booking__ds__month
+              , subq_2.booking__ds__quarter
+              , subq_2.booking__ds__year
+              , subq_2.booking__ds__extract_year
+              , subq_2.booking__ds__extract_quarter
+              , subq_2.booking__ds__extract_month
+              , subq_2.booking__ds__extract_day
+              , subq_2.booking__ds__extract_dow
+              , subq_2.booking__ds__extract_doy
+              , subq_2.booking__ds_partitioned__day
+              , subq_2.booking__ds_partitioned__week
+              , subq_2.booking__ds_partitioned__month
+              , subq_2.booking__ds_partitioned__quarter
+              , subq_2.booking__ds_partitioned__year
+              , subq_2.booking__ds_partitioned__extract_year
+              , subq_2.booking__ds_partitioned__extract_quarter
+              , subq_2.booking__ds_partitioned__extract_month
+              , subq_2.booking__ds_partitioned__extract_day
+              , subq_2.booking__ds_partitioned__extract_dow
+              , subq_2.booking__ds_partitioned__extract_doy
+              , subq_2.booking__paid_at__day
+              , subq_2.booking__paid_at__week
+              , subq_2.booking__paid_at__month
+              , subq_2.booking__paid_at__quarter
+              , subq_2.booking__paid_at__year
+              , subq_2.booking__paid_at__extract_year
+              , subq_2.booking__paid_at__extract_quarter
+              , subq_2.booking__paid_at__extract_month
+              , subq_2.booking__paid_at__extract_day
+              , subq_2.booking__paid_at__extract_dow
+              , subq_2.booking__paid_at__extract_doy
+              , subq_2.ds__day AS metric_time__day
+              , subq_2.ds__week AS metric_time__week
+              , subq_2.ds__month AS metric_time__month
+              , subq_2.ds__quarter AS metric_time__quarter
+              , subq_2.ds__year AS metric_time__year
+              , subq_2.ds__extract_year AS metric_time__extract_year
+              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_2.ds__extract_month AS metric_time__extract_month
+              , subq_2.ds__extract_day AS metric_time__extract_day
+              , subq_2.ds__extract_dow AS metric_time__extract_dow
+              , subq_2.ds__extract_doy AS metric_time__extract_doy
+              , subq_2.listing
+              , subq_2.guest
+              , subq_2.host
+              , subq_2.booking__listing
+              , subq_2.booking__guest
+              , subq_2.booking__host
+              , subq_2.is_instant
+              , subq_2.booking__is_instant
+              , subq_2.bookings
+              , subq_2.instant_bookings
+              , subq_2.booking_value
+              , subq_2.max_booking_value
+              , subq_2.min_booking_value
+              , subq_2.bookers
+              , subq_2.average_booking_value
+              , subq_2.referred_bookings
+              , subq_2.median_booking_value
+              , subq_2.booking_value_p99
+              , subq_2.discrete_booking_value_p99
+              , subq_2.approximate_continuous_booking_value_p99
+              , subq_2.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_2
+          ) subq_3
+          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.metric_time__day
+    ) subq_6
+    ON
+      subq_7.metric_time__day = subq_6.metric_time__day
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -1,0 +1,40 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_16.metric_time__day AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_17
+    WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+  ) subq_16
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_14
+    GROUP BY
+      metric_time__day
+  ) subq_15
+  ON
+    subq_16.metric_time__day = subq_15.metric_time__day
+  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,0 +1,311 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_5.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings',]
+    SELECT
+      subq_4.bookings
+    FROM (
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      SELECT
+        subq_3.ds__day
+        , subq_3.ds__week
+        , subq_3.ds__month
+        , subq_3.ds__quarter
+        , subq_3.ds__year
+        , subq_3.ds__extract_year
+        , subq_3.ds__extract_quarter
+        , subq_3.ds__extract_month
+        , subq_3.ds__extract_day
+        , subq_3.ds__extract_dow
+        , subq_3.ds__extract_doy
+        , subq_3.ds_partitioned__day
+        , subq_3.ds_partitioned__week
+        , subq_3.ds_partitioned__month
+        , subq_3.ds_partitioned__quarter
+        , subq_3.ds_partitioned__year
+        , subq_3.ds_partitioned__extract_year
+        , subq_3.ds_partitioned__extract_quarter
+        , subq_3.ds_partitioned__extract_month
+        , subq_3.ds_partitioned__extract_day
+        , subq_3.ds_partitioned__extract_dow
+        , subq_3.ds_partitioned__extract_doy
+        , subq_3.paid_at__day
+        , subq_3.paid_at__week
+        , subq_3.paid_at__month
+        , subq_3.paid_at__quarter
+        , subq_3.paid_at__year
+        , subq_3.paid_at__extract_year
+        , subq_3.paid_at__extract_quarter
+        , subq_3.paid_at__extract_month
+        , subq_3.paid_at__extract_day
+        , subq_3.paid_at__extract_dow
+        , subq_3.paid_at__extract_doy
+        , subq_3.booking__ds__day
+        , subq_3.booking__ds__week
+        , subq_3.booking__ds__month
+        , subq_3.booking__ds__quarter
+        , subq_3.booking__ds__year
+        , subq_3.booking__ds__extract_year
+        , subq_3.booking__ds__extract_quarter
+        , subq_3.booking__ds__extract_month
+        , subq_3.booking__ds__extract_day
+        , subq_3.booking__ds__extract_dow
+        , subq_3.booking__ds__extract_doy
+        , subq_3.booking__ds_partitioned__day
+        , subq_3.booking__ds_partitioned__week
+        , subq_3.booking__ds_partitioned__month
+        , subq_3.booking__ds_partitioned__quarter
+        , subq_3.booking__ds_partitioned__year
+        , subq_3.booking__ds_partitioned__extract_year
+        , subq_3.booking__ds_partitioned__extract_quarter
+        , subq_3.booking__ds_partitioned__extract_month
+        , subq_3.booking__ds_partitioned__extract_day
+        , subq_3.booking__ds_partitioned__extract_dow
+        , subq_3.booking__ds_partitioned__extract_doy
+        , subq_3.booking__paid_at__day
+        , subq_3.booking__paid_at__week
+        , subq_3.booking__paid_at__month
+        , subq_3.booking__paid_at__quarter
+        , subq_3.booking__paid_at__year
+        , subq_3.booking__paid_at__extract_year
+        , subq_3.booking__paid_at__extract_quarter
+        , subq_3.booking__paid_at__extract_month
+        , subq_3.booking__paid_at__extract_day
+        , subq_3.booking__paid_at__extract_dow
+        , subq_3.booking__paid_at__extract_doy
+        , subq_3.metric_time__day
+        , subq_3.metric_time__week
+        , subq_3.metric_time__month
+        , subq_3.metric_time__quarter
+        , subq_3.metric_time__year
+        , subq_3.metric_time__extract_year
+        , subq_3.metric_time__extract_quarter
+        , subq_3.metric_time__extract_month
+        , subq_3.metric_time__extract_day
+        , subq_3.metric_time__extract_dow
+        , subq_3.metric_time__extract_doy
+        , subq_3.listing
+        , subq_3.guest
+        , subq_3.host
+        , subq_3.booking__listing
+        , subq_3.booking__guest
+        , subq_3.booking__host
+        , subq_3.is_instant
+        , subq_3.booking__is_instant
+        , subq_3.bookings
+        , subq_3.instant_bookings
+        , subq_3.booking_value
+        , subq_3.max_booking_value
+        , subq_3.min_booking_value
+        , subq_3.bookers
+        , subq_3.average_booking_value
+        , subq_3.referred_bookings
+        , subq_3.median_booking_value
+        , subq_3.booking_value_p99
+        , subq_3.discrete_booking_value_p99
+        , subq_3.approximate_continuous_booking_value_p99
+        , subq_3.approximate_discrete_booking_value_p99
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_2.ds__day
+          , subq_2.ds__week
+          , subq_2.ds__month
+          , subq_2.ds__quarter
+          , subq_2.ds__year
+          , subq_2.ds__extract_year
+          , subq_2.ds__extract_quarter
+          , subq_2.ds__extract_month
+          , subq_2.ds__extract_day
+          , subq_2.ds__extract_dow
+          , subq_2.ds__extract_doy
+          , subq_2.ds_partitioned__day
+          , subq_2.ds_partitioned__week
+          , subq_2.ds_partitioned__month
+          , subq_2.ds_partitioned__quarter
+          , subq_2.ds_partitioned__year
+          , subq_2.ds_partitioned__extract_year
+          , subq_2.ds_partitioned__extract_quarter
+          , subq_2.ds_partitioned__extract_month
+          , subq_2.ds_partitioned__extract_day
+          , subq_2.ds_partitioned__extract_dow
+          , subq_2.ds_partitioned__extract_doy
+          , subq_2.paid_at__day
+          , subq_2.paid_at__week
+          , subq_2.paid_at__month
+          , subq_2.paid_at__quarter
+          , subq_2.paid_at__year
+          , subq_2.paid_at__extract_year
+          , subq_2.paid_at__extract_quarter
+          , subq_2.paid_at__extract_month
+          , subq_2.paid_at__extract_day
+          , subq_2.paid_at__extract_dow
+          , subq_2.paid_at__extract_doy
+          , subq_2.booking__ds__day
+          , subq_2.booking__ds__week
+          , subq_2.booking__ds__month
+          , subq_2.booking__ds__quarter
+          , subq_2.booking__ds__year
+          , subq_2.booking__ds__extract_year
+          , subq_2.booking__ds__extract_quarter
+          , subq_2.booking__ds__extract_month
+          , subq_2.booking__ds__extract_day
+          , subq_2.booking__ds__extract_dow
+          , subq_2.booking__ds__extract_doy
+          , subq_2.booking__ds_partitioned__day
+          , subq_2.booking__ds_partitioned__week
+          , subq_2.booking__ds_partitioned__month
+          , subq_2.booking__ds_partitioned__quarter
+          , subq_2.booking__ds_partitioned__year
+          , subq_2.booking__ds_partitioned__extract_year
+          , subq_2.booking__ds_partitioned__extract_quarter
+          , subq_2.booking__ds_partitioned__extract_month
+          , subq_2.booking__ds_partitioned__extract_day
+          , subq_2.booking__ds_partitioned__extract_dow
+          , subq_2.booking__ds_partitioned__extract_doy
+          , subq_2.booking__paid_at__day
+          , subq_2.booking__paid_at__week
+          , subq_2.booking__paid_at__month
+          , subq_2.booking__paid_at__quarter
+          , subq_2.booking__paid_at__year
+          , subq_2.booking__paid_at__extract_year
+          , subq_2.booking__paid_at__extract_quarter
+          , subq_2.booking__paid_at__extract_month
+          , subq_2.booking__paid_at__extract_day
+          , subq_2.booking__paid_at__extract_dow
+          , subq_2.booking__paid_at__extract_doy
+          , subq_2.ds__day AS metric_time__day
+          , subq_2.ds__week AS metric_time__week
+          , subq_2.ds__month AS metric_time__month
+          , subq_2.ds__quarter AS metric_time__quarter
+          , subq_2.ds__year AS metric_time__year
+          , subq_2.ds__extract_year AS metric_time__extract_year
+          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_2.ds__extract_month AS metric_time__extract_month
+          , subq_2.ds__extract_day AS metric_time__extract_day
+          , subq_2.ds__extract_dow AS metric_time__extract_dow
+          , subq_2.ds__extract_doy AS metric_time__extract_doy
+          , subq_2.listing
+          , subq_2.guest
+          , subq_2.host
+          , subq_2.booking__listing
+          , subq_2.booking__guest
+          , subq_2.booking__host
+          , subq_2.is_instant
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+          , subq_2.instant_bookings
+          , subq_2.booking_value
+          , subq_2.max_booking_value
+          , subq_2.min_booking_value
+          , subq_2.bookers
+          , subq_2.average_booking_value
+          , subq_2.referred_bookings
+          , subq_2.median_booking_value
+          , subq_2.booking_value_p99
+          , subq_2.discrete_booking_value_p99
+          , subq_2.approximate_continuous_booking_value_p99
+          , subq_2.approximate_discrete_booking_value_p99
+        FROM (
+          -- Read Elements From Semantic Model 'bookings_source'
+          SELECT
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_28000.booking_value
+            , bookings_source_src_28000.booking_value AS max_booking_value
+            , bookings_source_src_28000.booking_value AS min_booking_value
+            , bookings_source_src_28000.guest_id AS bookers
+            , bookings_source_src_28000.booking_value AS average_booking_value
+            , bookings_source_src_28000.booking_value AS booking_payments
+            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+            , bookings_source_src_28000.booking_value AS median_booking_value
+            , bookings_source_src_28000.booking_value AS booking_value_p99
+            , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+            , bookings_source_src_28000.is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+            , bookings_source_src_28000.is_instant AS booking__is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+            , bookings_source_src_28000.listing_id AS listing
+            , bookings_source_src_28000.guest_id AS guest
+            , bookings_source_src_28000.host_id AS host
+            , bookings_source_src_28000.listing_id AS booking__listing
+            , bookings_source_src_28000.guest_id AS booking__guest
+            , bookings_source_src_28000.host_id AS booking__host
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_2
+      ) subq_3
+      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_4
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  -- Pass Only Elements: ['bookings',]
+  -- Aggregate Measures
+  SELECT
+    SUM(1) AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_11

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,0 +1,242 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+    ) subq_4
+    GROUP BY
+      subq_4.metric_time__day
+  ) subq_5
+  ON
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -1,0 +1,34 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_11
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+  ) subq_14
+  ON
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -1,0 +1,45 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , booking__is_instant
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , booking__is_instant
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_11
+      WHERE booking__is_instant
+      GROUP BY
+        metric_time__day
+        , booking__is_instant
+    ) subq_13
+    ON
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
+  WHERE booking__is_instant
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,0 +1,338 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_9.metric_time__day
+    , subq_9.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_7.metric_time__day AS metric_time__day
+      , subq_6.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_8.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_8
+      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_7
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_5.metric_time__day
+        , SUM(subq_5.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          subq_4.metric_time__day
+          , subq_4.bookings
+        FROM (
+          -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+          SELECT
+            subq_3.ds__day
+            , subq_3.ds__week
+            , subq_3.ds__month
+            , subq_3.ds__quarter
+            , subq_3.ds__year
+            , subq_3.ds__extract_year
+            , subq_3.ds__extract_quarter
+            , subq_3.ds__extract_month
+            , subq_3.ds__extract_day
+            , subq_3.ds__extract_dow
+            , subq_3.ds__extract_doy
+            , subq_3.ds_partitioned__day
+            , subq_3.ds_partitioned__week
+            , subq_3.ds_partitioned__month
+            , subq_3.ds_partitioned__quarter
+            , subq_3.ds_partitioned__year
+            , subq_3.ds_partitioned__extract_year
+            , subq_3.ds_partitioned__extract_quarter
+            , subq_3.ds_partitioned__extract_month
+            , subq_3.ds_partitioned__extract_day
+            , subq_3.ds_partitioned__extract_dow
+            , subq_3.ds_partitioned__extract_doy
+            , subq_3.paid_at__day
+            , subq_3.paid_at__week
+            , subq_3.paid_at__month
+            , subq_3.paid_at__quarter
+            , subq_3.paid_at__year
+            , subq_3.paid_at__extract_year
+            , subq_3.paid_at__extract_quarter
+            , subq_3.paid_at__extract_month
+            , subq_3.paid_at__extract_day
+            , subq_3.paid_at__extract_dow
+            , subq_3.paid_at__extract_doy
+            , subq_3.booking__ds__day
+            , subq_3.booking__ds__week
+            , subq_3.booking__ds__month
+            , subq_3.booking__ds__quarter
+            , subq_3.booking__ds__year
+            , subq_3.booking__ds__extract_year
+            , subq_3.booking__ds__extract_quarter
+            , subq_3.booking__ds__extract_month
+            , subq_3.booking__ds__extract_day
+            , subq_3.booking__ds__extract_dow
+            , subq_3.booking__ds__extract_doy
+            , subq_3.booking__ds_partitioned__day
+            , subq_3.booking__ds_partitioned__week
+            , subq_3.booking__ds_partitioned__month
+            , subq_3.booking__ds_partitioned__quarter
+            , subq_3.booking__ds_partitioned__year
+            , subq_3.booking__ds_partitioned__extract_year
+            , subq_3.booking__ds_partitioned__extract_quarter
+            , subq_3.booking__ds_partitioned__extract_month
+            , subq_3.booking__ds_partitioned__extract_day
+            , subq_3.booking__ds_partitioned__extract_dow
+            , subq_3.booking__ds_partitioned__extract_doy
+            , subq_3.booking__paid_at__day
+            , subq_3.booking__paid_at__week
+            , subq_3.booking__paid_at__month
+            , subq_3.booking__paid_at__quarter
+            , subq_3.booking__paid_at__year
+            , subq_3.booking__paid_at__extract_year
+            , subq_3.booking__paid_at__extract_quarter
+            , subq_3.booking__paid_at__extract_month
+            , subq_3.booking__paid_at__extract_day
+            , subq_3.booking__paid_at__extract_dow
+            , subq_3.booking__paid_at__extract_doy
+            , subq_3.metric_time__day
+            , subq_3.metric_time__week
+            , subq_3.metric_time__month
+            , subq_3.metric_time__quarter
+            , subq_3.metric_time__year
+            , subq_3.metric_time__extract_year
+            , subq_3.metric_time__extract_quarter
+            , subq_3.metric_time__extract_month
+            , subq_3.metric_time__extract_day
+            , subq_3.metric_time__extract_dow
+            , subq_3.metric_time__extract_doy
+            , subq_3.listing
+            , subq_3.guest
+            , subq_3.host
+            , subq_3.booking__listing
+            , subq_3.booking__guest
+            , subq_3.booking__host
+            , subq_3.is_instant
+            , subq_3.booking__is_instant
+            , subq_3.bookings
+            , subq_3.instant_bookings
+            , subq_3.booking_value
+            , subq_3.max_booking_value
+            , subq_3.min_booking_value
+            , subq_3.bookers
+            , subq_3.average_booking_value
+            , subq_3.referred_bookings
+            , subq_3.median_booking_value
+            , subq_3.booking_value_p99
+            , subq_3.discrete_booking_value_p99
+            , subq_3.approximate_continuous_booking_value_p99
+            , subq_3.approximate_discrete_booking_value_p99
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_2.ds__day
+              , subq_2.ds__week
+              , subq_2.ds__month
+              , subq_2.ds__quarter
+              , subq_2.ds__year
+              , subq_2.ds__extract_year
+              , subq_2.ds__extract_quarter
+              , subq_2.ds__extract_month
+              , subq_2.ds__extract_day
+              , subq_2.ds__extract_dow
+              , subq_2.ds__extract_doy
+              , subq_2.ds_partitioned__day
+              , subq_2.ds_partitioned__week
+              , subq_2.ds_partitioned__month
+              , subq_2.ds_partitioned__quarter
+              , subq_2.ds_partitioned__year
+              , subq_2.ds_partitioned__extract_year
+              , subq_2.ds_partitioned__extract_quarter
+              , subq_2.ds_partitioned__extract_month
+              , subq_2.ds_partitioned__extract_day
+              , subq_2.ds_partitioned__extract_dow
+              , subq_2.ds_partitioned__extract_doy
+              , subq_2.paid_at__day
+              , subq_2.paid_at__week
+              , subq_2.paid_at__month
+              , subq_2.paid_at__quarter
+              , subq_2.paid_at__year
+              , subq_2.paid_at__extract_year
+              , subq_2.paid_at__extract_quarter
+              , subq_2.paid_at__extract_month
+              , subq_2.paid_at__extract_day
+              , subq_2.paid_at__extract_dow
+              , subq_2.paid_at__extract_doy
+              , subq_2.booking__ds__day
+              , subq_2.booking__ds__week
+              , subq_2.booking__ds__month
+              , subq_2.booking__ds__quarter
+              , subq_2.booking__ds__year
+              , subq_2.booking__ds__extract_year
+              , subq_2.booking__ds__extract_quarter
+              , subq_2.booking__ds__extract_month
+              , subq_2.booking__ds__extract_day
+              , subq_2.booking__ds__extract_dow
+              , subq_2.booking__ds__extract_doy
+              , subq_2.booking__ds_partitioned__day
+              , subq_2.booking__ds_partitioned__week
+              , subq_2.booking__ds_partitioned__month
+              , subq_2.booking__ds_partitioned__quarter
+              , subq_2.booking__ds_partitioned__year
+              , subq_2.booking__ds_partitioned__extract_year
+              , subq_2.booking__ds_partitioned__extract_quarter
+              , subq_2.booking__ds_partitioned__extract_month
+              , subq_2.booking__ds_partitioned__extract_day
+              , subq_2.booking__ds_partitioned__extract_dow
+              , subq_2.booking__ds_partitioned__extract_doy
+              , subq_2.booking__paid_at__day
+              , subq_2.booking__paid_at__week
+              , subq_2.booking__paid_at__month
+              , subq_2.booking__paid_at__quarter
+              , subq_2.booking__paid_at__year
+              , subq_2.booking__paid_at__extract_year
+              , subq_2.booking__paid_at__extract_quarter
+              , subq_2.booking__paid_at__extract_month
+              , subq_2.booking__paid_at__extract_day
+              , subq_2.booking__paid_at__extract_dow
+              , subq_2.booking__paid_at__extract_doy
+              , subq_2.ds__day AS metric_time__day
+              , subq_2.ds__week AS metric_time__week
+              , subq_2.ds__month AS metric_time__month
+              , subq_2.ds__quarter AS metric_time__quarter
+              , subq_2.ds__year AS metric_time__year
+              , subq_2.ds__extract_year AS metric_time__extract_year
+              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_2.ds__extract_month AS metric_time__extract_month
+              , subq_2.ds__extract_day AS metric_time__extract_day
+              , subq_2.ds__extract_dow AS metric_time__extract_dow
+              , subq_2.ds__extract_doy AS metric_time__extract_doy
+              , subq_2.listing
+              , subq_2.guest
+              , subq_2.host
+              , subq_2.booking__listing
+              , subq_2.booking__guest
+              , subq_2.booking__host
+              , subq_2.is_instant
+              , subq_2.booking__is_instant
+              , subq_2.bookings
+              , subq_2.instant_bookings
+              , subq_2.booking_value
+              , subq_2.max_booking_value
+              , subq_2.min_booking_value
+              , subq_2.bookers
+              , subq_2.average_booking_value
+              , subq_2.referred_bookings
+              , subq_2.median_booking_value
+              , subq_2.booking_value_p99
+              , subq_2.discrete_booking_value_p99
+              , subq_2.approximate_continuous_booking_value_p99
+              , subq_2.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_2
+          ) subq_3
+          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.metric_time__day
+    ) subq_6
+    ON
+      subq_7.metric_time__day = subq_6.metric_time__day
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -1,0 +1,40 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_16.metric_time__day AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_17
+    WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+  ) subq_16
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_14
+    GROUP BY
+      metric_time__day
+  ) subq_15
+  ON
+    subq_16.metric_time__day = subq_15.metric_time__day
+  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,0 +1,311 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_5.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings',]
+    SELECT
+      subq_4.bookings
+    FROM (
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      SELECT
+        subq_3.ds__day
+        , subq_3.ds__week
+        , subq_3.ds__month
+        , subq_3.ds__quarter
+        , subq_3.ds__year
+        , subq_3.ds__extract_year
+        , subq_3.ds__extract_quarter
+        , subq_3.ds__extract_month
+        , subq_3.ds__extract_day
+        , subq_3.ds__extract_dow
+        , subq_3.ds__extract_doy
+        , subq_3.ds_partitioned__day
+        , subq_3.ds_partitioned__week
+        , subq_3.ds_partitioned__month
+        , subq_3.ds_partitioned__quarter
+        , subq_3.ds_partitioned__year
+        , subq_3.ds_partitioned__extract_year
+        , subq_3.ds_partitioned__extract_quarter
+        , subq_3.ds_partitioned__extract_month
+        , subq_3.ds_partitioned__extract_day
+        , subq_3.ds_partitioned__extract_dow
+        , subq_3.ds_partitioned__extract_doy
+        , subq_3.paid_at__day
+        , subq_3.paid_at__week
+        , subq_3.paid_at__month
+        , subq_3.paid_at__quarter
+        , subq_3.paid_at__year
+        , subq_3.paid_at__extract_year
+        , subq_3.paid_at__extract_quarter
+        , subq_3.paid_at__extract_month
+        , subq_3.paid_at__extract_day
+        , subq_3.paid_at__extract_dow
+        , subq_3.paid_at__extract_doy
+        , subq_3.booking__ds__day
+        , subq_3.booking__ds__week
+        , subq_3.booking__ds__month
+        , subq_3.booking__ds__quarter
+        , subq_3.booking__ds__year
+        , subq_3.booking__ds__extract_year
+        , subq_3.booking__ds__extract_quarter
+        , subq_3.booking__ds__extract_month
+        , subq_3.booking__ds__extract_day
+        , subq_3.booking__ds__extract_dow
+        , subq_3.booking__ds__extract_doy
+        , subq_3.booking__ds_partitioned__day
+        , subq_3.booking__ds_partitioned__week
+        , subq_3.booking__ds_partitioned__month
+        , subq_3.booking__ds_partitioned__quarter
+        , subq_3.booking__ds_partitioned__year
+        , subq_3.booking__ds_partitioned__extract_year
+        , subq_3.booking__ds_partitioned__extract_quarter
+        , subq_3.booking__ds_partitioned__extract_month
+        , subq_3.booking__ds_partitioned__extract_day
+        , subq_3.booking__ds_partitioned__extract_dow
+        , subq_3.booking__ds_partitioned__extract_doy
+        , subq_3.booking__paid_at__day
+        , subq_3.booking__paid_at__week
+        , subq_3.booking__paid_at__month
+        , subq_3.booking__paid_at__quarter
+        , subq_3.booking__paid_at__year
+        , subq_3.booking__paid_at__extract_year
+        , subq_3.booking__paid_at__extract_quarter
+        , subq_3.booking__paid_at__extract_month
+        , subq_3.booking__paid_at__extract_day
+        , subq_3.booking__paid_at__extract_dow
+        , subq_3.booking__paid_at__extract_doy
+        , subq_3.metric_time__day
+        , subq_3.metric_time__week
+        , subq_3.metric_time__month
+        , subq_3.metric_time__quarter
+        , subq_3.metric_time__year
+        , subq_3.metric_time__extract_year
+        , subq_3.metric_time__extract_quarter
+        , subq_3.metric_time__extract_month
+        , subq_3.metric_time__extract_day
+        , subq_3.metric_time__extract_dow
+        , subq_3.metric_time__extract_doy
+        , subq_3.listing
+        , subq_3.guest
+        , subq_3.host
+        , subq_3.booking__listing
+        , subq_3.booking__guest
+        , subq_3.booking__host
+        , subq_3.is_instant
+        , subq_3.booking__is_instant
+        , subq_3.bookings
+        , subq_3.instant_bookings
+        , subq_3.booking_value
+        , subq_3.max_booking_value
+        , subq_3.min_booking_value
+        , subq_3.bookers
+        , subq_3.average_booking_value
+        , subq_3.referred_bookings
+        , subq_3.median_booking_value
+        , subq_3.booking_value_p99
+        , subq_3.discrete_booking_value_p99
+        , subq_3.approximate_continuous_booking_value_p99
+        , subq_3.approximate_discrete_booking_value_p99
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_2.ds__day
+          , subq_2.ds__week
+          , subq_2.ds__month
+          , subq_2.ds__quarter
+          , subq_2.ds__year
+          , subq_2.ds__extract_year
+          , subq_2.ds__extract_quarter
+          , subq_2.ds__extract_month
+          , subq_2.ds__extract_day
+          , subq_2.ds__extract_dow
+          , subq_2.ds__extract_doy
+          , subq_2.ds_partitioned__day
+          , subq_2.ds_partitioned__week
+          , subq_2.ds_partitioned__month
+          , subq_2.ds_partitioned__quarter
+          , subq_2.ds_partitioned__year
+          , subq_2.ds_partitioned__extract_year
+          , subq_2.ds_partitioned__extract_quarter
+          , subq_2.ds_partitioned__extract_month
+          , subq_2.ds_partitioned__extract_day
+          , subq_2.ds_partitioned__extract_dow
+          , subq_2.ds_partitioned__extract_doy
+          , subq_2.paid_at__day
+          , subq_2.paid_at__week
+          , subq_2.paid_at__month
+          , subq_2.paid_at__quarter
+          , subq_2.paid_at__year
+          , subq_2.paid_at__extract_year
+          , subq_2.paid_at__extract_quarter
+          , subq_2.paid_at__extract_month
+          , subq_2.paid_at__extract_day
+          , subq_2.paid_at__extract_dow
+          , subq_2.paid_at__extract_doy
+          , subq_2.booking__ds__day
+          , subq_2.booking__ds__week
+          , subq_2.booking__ds__month
+          , subq_2.booking__ds__quarter
+          , subq_2.booking__ds__year
+          , subq_2.booking__ds__extract_year
+          , subq_2.booking__ds__extract_quarter
+          , subq_2.booking__ds__extract_month
+          , subq_2.booking__ds__extract_day
+          , subq_2.booking__ds__extract_dow
+          , subq_2.booking__ds__extract_doy
+          , subq_2.booking__ds_partitioned__day
+          , subq_2.booking__ds_partitioned__week
+          , subq_2.booking__ds_partitioned__month
+          , subq_2.booking__ds_partitioned__quarter
+          , subq_2.booking__ds_partitioned__year
+          , subq_2.booking__ds_partitioned__extract_year
+          , subq_2.booking__ds_partitioned__extract_quarter
+          , subq_2.booking__ds_partitioned__extract_month
+          , subq_2.booking__ds_partitioned__extract_day
+          , subq_2.booking__ds_partitioned__extract_dow
+          , subq_2.booking__ds_partitioned__extract_doy
+          , subq_2.booking__paid_at__day
+          , subq_2.booking__paid_at__week
+          , subq_2.booking__paid_at__month
+          , subq_2.booking__paid_at__quarter
+          , subq_2.booking__paid_at__year
+          , subq_2.booking__paid_at__extract_year
+          , subq_2.booking__paid_at__extract_quarter
+          , subq_2.booking__paid_at__extract_month
+          , subq_2.booking__paid_at__extract_day
+          , subq_2.booking__paid_at__extract_dow
+          , subq_2.booking__paid_at__extract_doy
+          , subq_2.ds__day AS metric_time__day
+          , subq_2.ds__week AS metric_time__week
+          , subq_2.ds__month AS metric_time__month
+          , subq_2.ds__quarter AS metric_time__quarter
+          , subq_2.ds__year AS metric_time__year
+          , subq_2.ds__extract_year AS metric_time__extract_year
+          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_2.ds__extract_month AS metric_time__extract_month
+          , subq_2.ds__extract_day AS metric_time__extract_day
+          , subq_2.ds__extract_dow AS metric_time__extract_dow
+          , subq_2.ds__extract_doy AS metric_time__extract_doy
+          , subq_2.listing
+          , subq_2.guest
+          , subq_2.host
+          , subq_2.booking__listing
+          , subq_2.booking__guest
+          , subq_2.booking__host
+          , subq_2.is_instant
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+          , subq_2.instant_bookings
+          , subq_2.booking_value
+          , subq_2.max_booking_value
+          , subq_2.min_booking_value
+          , subq_2.bookers
+          , subq_2.average_booking_value
+          , subq_2.referred_bookings
+          , subq_2.median_booking_value
+          , subq_2.booking_value_p99
+          , subq_2.discrete_booking_value_p99
+          , subq_2.approximate_continuous_booking_value_p99
+          , subq_2.approximate_discrete_booking_value_p99
+        FROM (
+          -- Read Elements From Semantic Model 'bookings_source'
+          SELECT
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_28000.booking_value
+            , bookings_source_src_28000.booking_value AS max_booking_value
+            , bookings_source_src_28000.booking_value AS min_booking_value
+            , bookings_source_src_28000.guest_id AS bookers
+            , bookings_source_src_28000.booking_value AS average_booking_value
+            , bookings_source_src_28000.booking_value AS booking_payments
+            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+            , bookings_source_src_28000.booking_value AS median_booking_value
+            , bookings_source_src_28000.booking_value AS booking_value_p99
+            , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+            , bookings_source_src_28000.is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+            , bookings_source_src_28000.is_instant AS booking__is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+            , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+            , bookings_source_src_28000.listing_id AS listing
+            , bookings_source_src_28000.guest_id AS guest
+            , bookings_source_src_28000.host_id AS host
+            , bookings_source_src_28000.listing_id AS booking__listing
+            , bookings_source_src_28000.guest_id AS booking__guest
+            , bookings_source_src_28000.host_id AS booking__host
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_2
+      ) subq_3
+      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_4
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  -- Pass Only Elements: ['bookings',]
+  -- Aggregate Measures
+  SELECT
+    SUM(1) AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_11

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,0 +1,242 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+    ) subq_4
+    GROUP BY
+      subq_4.metric_time__day
+  ) subq_5
+  ON
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -1,0 +1,34 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_11
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+  ) subq_14
+  ON
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -1,0 +1,45 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , booking__is_instant
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , booking__is_instant
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_11
+      WHERE booking__is_instant
+      GROUP BY
+        metric_time__day
+        , booking__is_instant
+    ) subq_13
+    ON
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
+  WHERE booking__is_instant
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,0 +1,338 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_9.metric_time__day
+    , subq_9.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_7.metric_time__day AS metric_time__day
+      , subq_6.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_8.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_8
+      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_7
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_5.metric_time__day
+        , SUM(subq_5.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          subq_4.metric_time__day
+          , subq_4.bookings
+        FROM (
+          -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+          SELECT
+            subq_3.ds__day
+            , subq_3.ds__week
+            , subq_3.ds__month
+            , subq_3.ds__quarter
+            , subq_3.ds__year
+            , subq_3.ds__extract_year
+            , subq_3.ds__extract_quarter
+            , subq_3.ds__extract_month
+            , subq_3.ds__extract_day
+            , subq_3.ds__extract_dow
+            , subq_3.ds__extract_doy
+            , subq_3.ds_partitioned__day
+            , subq_3.ds_partitioned__week
+            , subq_3.ds_partitioned__month
+            , subq_3.ds_partitioned__quarter
+            , subq_3.ds_partitioned__year
+            , subq_3.ds_partitioned__extract_year
+            , subq_3.ds_partitioned__extract_quarter
+            , subq_3.ds_partitioned__extract_month
+            , subq_3.ds_partitioned__extract_day
+            , subq_3.ds_partitioned__extract_dow
+            , subq_3.ds_partitioned__extract_doy
+            , subq_3.paid_at__day
+            , subq_3.paid_at__week
+            , subq_3.paid_at__month
+            , subq_3.paid_at__quarter
+            , subq_3.paid_at__year
+            , subq_3.paid_at__extract_year
+            , subq_3.paid_at__extract_quarter
+            , subq_3.paid_at__extract_month
+            , subq_3.paid_at__extract_day
+            , subq_3.paid_at__extract_dow
+            , subq_3.paid_at__extract_doy
+            , subq_3.booking__ds__day
+            , subq_3.booking__ds__week
+            , subq_3.booking__ds__month
+            , subq_3.booking__ds__quarter
+            , subq_3.booking__ds__year
+            , subq_3.booking__ds__extract_year
+            , subq_3.booking__ds__extract_quarter
+            , subq_3.booking__ds__extract_month
+            , subq_3.booking__ds__extract_day
+            , subq_3.booking__ds__extract_dow
+            , subq_3.booking__ds__extract_doy
+            , subq_3.booking__ds_partitioned__day
+            , subq_3.booking__ds_partitioned__week
+            , subq_3.booking__ds_partitioned__month
+            , subq_3.booking__ds_partitioned__quarter
+            , subq_3.booking__ds_partitioned__year
+            , subq_3.booking__ds_partitioned__extract_year
+            , subq_3.booking__ds_partitioned__extract_quarter
+            , subq_3.booking__ds_partitioned__extract_month
+            , subq_3.booking__ds_partitioned__extract_day
+            , subq_3.booking__ds_partitioned__extract_dow
+            , subq_3.booking__ds_partitioned__extract_doy
+            , subq_3.booking__paid_at__day
+            , subq_3.booking__paid_at__week
+            , subq_3.booking__paid_at__month
+            , subq_3.booking__paid_at__quarter
+            , subq_3.booking__paid_at__year
+            , subq_3.booking__paid_at__extract_year
+            , subq_3.booking__paid_at__extract_quarter
+            , subq_3.booking__paid_at__extract_month
+            , subq_3.booking__paid_at__extract_day
+            , subq_3.booking__paid_at__extract_dow
+            , subq_3.booking__paid_at__extract_doy
+            , subq_3.metric_time__day
+            , subq_3.metric_time__week
+            , subq_3.metric_time__month
+            , subq_3.metric_time__quarter
+            , subq_3.metric_time__year
+            , subq_3.metric_time__extract_year
+            , subq_3.metric_time__extract_quarter
+            , subq_3.metric_time__extract_month
+            , subq_3.metric_time__extract_day
+            , subq_3.metric_time__extract_dow
+            , subq_3.metric_time__extract_doy
+            , subq_3.listing
+            , subq_3.guest
+            , subq_3.host
+            , subq_3.booking__listing
+            , subq_3.booking__guest
+            , subq_3.booking__host
+            , subq_3.is_instant
+            , subq_3.booking__is_instant
+            , subq_3.bookings
+            , subq_3.instant_bookings
+            , subq_3.booking_value
+            , subq_3.max_booking_value
+            , subq_3.min_booking_value
+            , subq_3.bookers
+            , subq_3.average_booking_value
+            , subq_3.referred_bookings
+            , subq_3.median_booking_value
+            , subq_3.booking_value_p99
+            , subq_3.discrete_booking_value_p99
+            , subq_3.approximate_continuous_booking_value_p99
+            , subq_3.approximate_discrete_booking_value_p99
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_2.ds__day
+              , subq_2.ds__week
+              , subq_2.ds__month
+              , subq_2.ds__quarter
+              , subq_2.ds__year
+              , subq_2.ds__extract_year
+              , subq_2.ds__extract_quarter
+              , subq_2.ds__extract_month
+              , subq_2.ds__extract_day
+              , subq_2.ds__extract_dow
+              , subq_2.ds__extract_doy
+              , subq_2.ds_partitioned__day
+              , subq_2.ds_partitioned__week
+              , subq_2.ds_partitioned__month
+              , subq_2.ds_partitioned__quarter
+              , subq_2.ds_partitioned__year
+              , subq_2.ds_partitioned__extract_year
+              , subq_2.ds_partitioned__extract_quarter
+              , subq_2.ds_partitioned__extract_month
+              , subq_2.ds_partitioned__extract_day
+              , subq_2.ds_partitioned__extract_dow
+              , subq_2.ds_partitioned__extract_doy
+              , subq_2.paid_at__day
+              , subq_2.paid_at__week
+              , subq_2.paid_at__month
+              , subq_2.paid_at__quarter
+              , subq_2.paid_at__year
+              , subq_2.paid_at__extract_year
+              , subq_2.paid_at__extract_quarter
+              , subq_2.paid_at__extract_month
+              , subq_2.paid_at__extract_day
+              , subq_2.paid_at__extract_dow
+              , subq_2.paid_at__extract_doy
+              , subq_2.booking__ds__day
+              , subq_2.booking__ds__week
+              , subq_2.booking__ds__month
+              , subq_2.booking__ds__quarter
+              , subq_2.booking__ds__year
+              , subq_2.booking__ds__extract_year
+              , subq_2.booking__ds__extract_quarter
+              , subq_2.booking__ds__extract_month
+              , subq_2.booking__ds__extract_day
+              , subq_2.booking__ds__extract_dow
+              , subq_2.booking__ds__extract_doy
+              , subq_2.booking__ds_partitioned__day
+              , subq_2.booking__ds_partitioned__week
+              , subq_2.booking__ds_partitioned__month
+              , subq_2.booking__ds_partitioned__quarter
+              , subq_2.booking__ds_partitioned__year
+              , subq_2.booking__ds_partitioned__extract_year
+              , subq_2.booking__ds_partitioned__extract_quarter
+              , subq_2.booking__ds_partitioned__extract_month
+              , subq_2.booking__ds_partitioned__extract_day
+              , subq_2.booking__ds_partitioned__extract_dow
+              , subq_2.booking__ds_partitioned__extract_doy
+              , subq_2.booking__paid_at__day
+              , subq_2.booking__paid_at__week
+              , subq_2.booking__paid_at__month
+              , subq_2.booking__paid_at__quarter
+              , subq_2.booking__paid_at__year
+              , subq_2.booking__paid_at__extract_year
+              , subq_2.booking__paid_at__extract_quarter
+              , subq_2.booking__paid_at__extract_month
+              , subq_2.booking__paid_at__extract_day
+              , subq_2.booking__paid_at__extract_dow
+              , subq_2.booking__paid_at__extract_doy
+              , subq_2.ds__day AS metric_time__day
+              , subq_2.ds__week AS metric_time__week
+              , subq_2.ds__month AS metric_time__month
+              , subq_2.ds__quarter AS metric_time__quarter
+              , subq_2.ds__year AS metric_time__year
+              , subq_2.ds__extract_year AS metric_time__extract_year
+              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_2.ds__extract_month AS metric_time__extract_month
+              , subq_2.ds__extract_day AS metric_time__extract_day
+              , subq_2.ds__extract_dow AS metric_time__extract_dow
+              , subq_2.ds__extract_doy AS metric_time__extract_doy
+              , subq_2.listing
+              , subq_2.guest
+              , subq_2.host
+              , subq_2.booking__listing
+              , subq_2.booking__guest
+              , subq_2.booking__host
+              , subq_2.is_instant
+              , subq_2.booking__is_instant
+              , subq_2.bookings
+              , subq_2.instant_bookings
+              , subq_2.booking_value
+              , subq_2.max_booking_value
+              , subq_2.min_booking_value
+              , subq_2.bookers
+              , subq_2.average_booking_value
+              , subq_2.referred_bookings
+              , subq_2.median_booking_value
+              , subq_2.booking_value_p99
+              , subq_2.discrete_booking_value_p99
+              , subq_2.approximate_continuous_booking_value_p99
+              , subq_2.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_2
+          ) subq_3
+          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.metric_time__day
+    ) subq_6
+    ON
+      subq_7.metric_time__day = subq_6.metric_time__day
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -1,0 +1,40 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_16.metric_time__day AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_17
+    WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+  ) subq_16
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_14
+    GROUP BY
+      metric_time__day
+  ) subq_15
+  ON
+    subq_16.metric_time__day = subq_15.metric_time__day
+  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,0 +1,311 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_5.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings',]
+    SELECT
+      subq_4.bookings
+    FROM (
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      SELECT
+        subq_3.ds__day
+        , subq_3.ds__week
+        , subq_3.ds__month
+        , subq_3.ds__quarter
+        , subq_3.ds__year
+        , subq_3.ds__extract_year
+        , subq_3.ds__extract_quarter
+        , subq_3.ds__extract_month
+        , subq_3.ds__extract_day
+        , subq_3.ds__extract_dow
+        , subq_3.ds__extract_doy
+        , subq_3.ds_partitioned__day
+        , subq_3.ds_partitioned__week
+        , subq_3.ds_partitioned__month
+        , subq_3.ds_partitioned__quarter
+        , subq_3.ds_partitioned__year
+        , subq_3.ds_partitioned__extract_year
+        , subq_3.ds_partitioned__extract_quarter
+        , subq_3.ds_partitioned__extract_month
+        , subq_3.ds_partitioned__extract_day
+        , subq_3.ds_partitioned__extract_dow
+        , subq_3.ds_partitioned__extract_doy
+        , subq_3.paid_at__day
+        , subq_3.paid_at__week
+        , subq_3.paid_at__month
+        , subq_3.paid_at__quarter
+        , subq_3.paid_at__year
+        , subq_3.paid_at__extract_year
+        , subq_3.paid_at__extract_quarter
+        , subq_3.paid_at__extract_month
+        , subq_3.paid_at__extract_day
+        , subq_3.paid_at__extract_dow
+        , subq_3.paid_at__extract_doy
+        , subq_3.booking__ds__day
+        , subq_3.booking__ds__week
+        , subq_3.booking__ds__month
+        , subq_3.booking__ds__quarter
+        , subq_3.booking__ds__year
+        , subq_3.booking__ds__extract_year
+        , subq_3.booking__ds__extract_quarter
+        , subq_3.booking__ds__extract_month
+        , subq_3.booking__ds__extract_day
+        , subq_3.booking__ds__extract_dow
+        , subq_3.booking__ds__extract_doy
+        , subq_3.booking__ds_partitioned__day
+        , subq_3.booking__ds_partitioned__week
+        , subq_3.booking__ds_partitioned__month
+        , subq_3.booking__ds_partitioned__quarter
+        , subq_3.booking__ds_partitioned__year
+        , subq_3.booking__ds_partitioned__extract_year
+        , subq_3.booking__ds_partitioned__extract_quarter
+        , subq_3.booking__ds_partitioned__extract_month
+        , subq_3.booking__ds_partitioned__extract_day
+        , subq_3.booking__ds_partitioned__extract_dow
+        , subq_3.booking__ds_partitioned__extract_doy
+        , subq_3.booking__paid_at__day
+        , subq_3.booking__paid_at__week
+        , subq_3.booking__paid_at__month
+        , subq_3.booking__paid_at__quarter
+        , subq_3.booking__paid_at__year
+        , subq_3.booking__paid_at__extract_year
+        , subq_3.booking__paid_at__extract_quarter
+        , subq_3.booking__paid_at__extract_month
+        , subq_3.booking__paid_at__extract_day
+        , subq_3.booking__paid_at__extract_dow
+        , subq_3.booking__paid_at__extract_doy
+        , subq_3.metric_time__day
+        , subq_3.metric_time__week
+        , subq_3.metric_time__month
+        , subq_3.metric_time__quarter
+        , subq_3.metric_time__year
+        , subq_3.metric_time__extract_year
+        , subq_3.metric_time__extract_quarter
+        , subq_3.metric_time__extract_month
+        , subq_3.metric_time__extract_day
+        , subq_3.metric_time__extract_dow
+        , subq_3.metric_time__extract_doy
+        , subq_3.listing
+        , subq_3.guest
+        , subq_3.host
+        , subq_3.booking__listing
+        , subq_3.booking__guest
+        , subq_3.booking__host
+        , subq_3.is_instant
+        , subq_3.booking__is_instant
+        , subq_3.bookings
+        , subq_3.instant_bookings
+        , subq_3.booking_value
+        , subq_3.max_booking_value
+        , subq_3.min_booking_value
+        , subq_3.bookers
+        , subq_3.average_booking_value
+        , subq_3.referred_bookings
+        , subq_3.median_booking_value
+        , subq_3.booking_value_p99
+        , subq_3.discrete_booking_value_p99
+        , subq_3.approximate_continuous_booking_value_p99
+        , subq_3.approximate_discrete_booking_value_p99
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_2.ds__day
+          , subq_2.ds__week
+          , subq_2.ds__month
+          , subq_2.ds__quarter
+          , subq_2.ds__year
+          , subq_2.ds__extract_year
+          , subq_2.ds__extract_quarter
+          , subq_2.ds__extract_month
+          , subq_2.ds__extract_day
+          , subq_2.ds__extract_dow
+          , subq_2.ds__extract_doy
+          , subq_2.ds_partitioned__day
+          , subq_2.ds_partitioned__week
+          , subq_2.ds_partitioned__month
+          , subq_2.ds_partitioned__quarter
+          , subq_2.ds_partitioned__year
+          , subq_2.ds_partitioned__extract_year
+          , subq_2.ds_partitioned__extract_quarter
+          , subq_2.ds_partitioned__extract_month
+          , subq_2.ds_partitioned__extract_day
+          , subq_2.ds_partitioned__extract_dow
+          , subq_2.ds_partitioned__extract_doy
+          , subq_2.paid_at__day
+          , subq_2.paid_at__week
+          , subq_2.paid_at__month
+          , subq_2.paid_at__quarter
+          , subq_2.paid_at__year
+          , subq_2.paid_at__extract_year
+          , subq_2.paid_at__extract_quarter
+          , subq_2.paid_at__extract_month
+          , subq_2.paid_at__extract_day
+          , subq_2.paid_at__extract_dow
+          , subq_2.paid_at__extract_doy
+          , subq_2.booking__ds__day
+          , subq_2.booking__ds__week
+          , subq_2.booking__ds__month
+          , subq_2.booking__ds__quarter
+          , subq_2.booking__ds__year
+          , subq_2.booking__ds__extract_year
+          , subq_2.booking__ds__extract_quarter
+          , subq_2.booking__ds__extract_month
+          , subq_2.booking__ds__extract_day
+          , subq_2.booking__ds__extract_dow
+          , subq_2.booking__ds__extract_doy
+          , subq_2.booking__ds_partitioned__day
+          , subq_2.booking__ds_partitioned__week
+          , subq_2.booking__ds_partitioned__month
+          , subq_2.booking__ds_partitioned__quarter
+          , subq_2.booking__ds_partitioned__year
+          , subq_2.booking__ds_partitioned__extract_year
+          , subq_2.booking__ds_partitioned__extract_quarter
+          , subq_2.booking__ds_partitioned__extract_month
+          , subq_2.booking__ds_partitioned__extract_day
+          , subq_2.booking__ds_partitioned__extract_dow
+          , subq_2.booking__ds_partitioned__extract_doy
+          , subq_2.booking__paid_at__day
+          , subq_2.booking__paid_at__week
+          , subq_2.booking__paid_at__month
+          , subq_2.booking__paid_at__quarter
+          , subq_2.booking__paid_at__year
+          , subq_2.booking__paid_at__extract_year
+          , subq_2.booking__paid_at__extract_quarter
+          , subq_2.booking__paid_at__extract_month
+          , subq_2.booking__paid_at__extract_day
+          , subq_2.booking__paid_at__extract_dow
+          , subq_2.booking__paid_at__extract_doy
+          , subq_2.ds__day AS metric_time__day
+          , subq_2.ds__week AS metric_time__week
+          , subq_2.ds__month AS metric_time__month
+          , subq_2.ds__quarter AS metric_time__quarter
+          , subq_2.ds__year AS metric_time__year
+          , subq_2.ds__extract_year AS metric_time__extract_year
+          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_2.ds__extract_month AS metric_time__extract_month
+          , subq_2.ds__extract_day AS metric_time__extract_day
+          , subq_2.ds__extract_dow AS metric_time__extract_dow
+          , subq_2.ds__extract_doy AS metric_time__extract_doy
+          , subq_2.listing
+          , subq_2.guest
+          , subq_2.host
+          , subq_2.booking__listing
+          , subq_2.booking__guest
+          , subq_2.booking__host
+          , subq_2.is_instant
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+          , subq_2.instant_bookings
+          , subq_2.booking_value
+          , subq_2.max_booking_value
+          , subq_2.min_booking_value
+          , subq_2.bookers
+          , subq_2.average_booking_value
+          , subq_2.referred_bookings
+          , subq_2.median_booking_value
+          , subq_2.booking_value_p99
+          , subq_2.discrete_booking_value_p99
+          , subq_2.approximate_continuous_booking_value_p99
+          , subq_2.approximate_discrete_booking_value_p99
+        FROM (
+          -- Read Elements From Semantic Model 'bookings_source'
+          SELECT
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_28000.booking_value
+            , bookings_source_src_28000.booking_value AS max_booking_value
+            , bookings_source_src_28000.booking_value AS min_booking_value
+            , bookings_source_src_28000.guest_id AS bookers
+            , bookings_source_src_28000.booking_value AS average_booking_value
+            , bookings_source_src_28000.booking_value AS booking_payments
+            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+            , bookings_source_src_28000.booking_value AS median_booking_value
+            , bookings_source_src_28000.booking_value AS booking_value_p99
+            , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+            , bookings_source_src_28000.is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+            , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+            , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+            , bookings_source_src_28000.is_instant AS booking__is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+            , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+            , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+            , bookings_source_src_28000.listing_id AS listing
+            , bookings_source_src_28000.guest_id AS guest
+            , bookings_source_src_28000.host_id AS host
+            , bookings_source_src_28000.listing_id AS booking__listing
+            , bookings_source_src_28000.guest_id AS booking__guest
+            , bookings_source_src_28000.host_id AS booking__host
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_2
+      ) subq_3
+      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_4
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  -- Pass Only Elements: ['bookings',]
+  -- Aggregate Measures
+  SELECT
+    SUM(1) AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_11

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,0 +1,242 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+    ) subq_4
+    GROUP BY
+      subq_4.metric_time__day
+  ) subq_5
+  ON
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -1,0 +1,34 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_11
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+  ) subq_14
+  ON
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -1,0 +1,45 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , booking__is_instant
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , booking__is_instant
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_11
+      WHERE booking__is_instant
+      GROUP BY
+        metric_time__day
+        , booking__is_instant
+    ) subq_13
+    ON
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
+  WHERE booking__is_instant
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,0 +1,338 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_9.metric_time__day
+    , subq_9.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_7.metric_time__day AS metric_time__day
+      , subq_6.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_8.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_8
+      WHERE subq_8.ds BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_7
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_5.metric_time__day
+        , SUM(subq_5.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          subq_4.metric_time__day
+          , subq_4.bookings
+        FROM (
+          -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+          SELECT
+            subq_3.ds__day
+            , subq_3.ds__week
+            , subq_3.ds__month
+            , subq_3.ds__quarter
+            , subq_3.ds__year
+            , subq_3.ds__extract_year
+            , subq_3.ds__extract_quarter
+            , subq_3.ds__extract_month
+            , subq_3.ds__extract_day
+            , subq_3.ds__extract_dow
+            , subq_3.ds__extract_doy
+            , subq_3.ds_partitioned__day
+            , subq_3.ds_partitioned__week
+            , subq_3.ds_partitioned__month
+            , subq_3.ds_partitioned__quarter
+            , subq_3.ds_partitioned__year
+            , subq_3.ds_partitioned__extract_year
+            , subq_3.ds_partitioned__extract_quarter
+            , subq_3.ds_partitioned__extract_month
+            , subq_3.ds_partitioned__extract_day
+            , subq_3.ds_partitioned__extract_dow
+            , subq_3.ds_partitioned__extract_doy
+            , subq_3.paid_at__day
+            , subq_3.paid_at__week
+            , subq_3.paid_at__month
+            , subq_3.paid_at__quarter
+            , subq_3.paid_at__year
+            , subq_3.paid_at__extract_year
+            , subq_3.paid_at__extract_quarter
+            , subq_3.paid_at__extract_month
+            , subq_3.paid_at__extract_day
+            , subq_3.paid_at__extract_dow
+            , subq_3.paid_at__extract_doy
+            , subq_3.booking__ds__day
+            , subq_3.booking__ds__week
+            , subq_3.booking__ds__month
+            , subq_3.booking__ds__quarter
+            , subq_3.booking__ds__year
+            , subq_3.booking__ds__extract_year
+            , subq_3.booking__ds__extract_quarter
+            , subq_3.booking__ds__extract_month
+            , subq_3.booking__ds__extract_day
+            , subq_3.booking__ds__extract_dow
+            , subq_3.booking__ds__extract_doy
+            , subq_3.booking__ds_partitioned__day
+            , subq_3.booking__ds_partitioned__week
+            , subq_3.booking__ds_partitioned__month
+            , subq_3.booking__ds_partitioned__quarter
+            , subq_3.booking__ds_partitioned__year
+            , subq_3.booking__ds_partitioned__extract_year
+            , subq_3.booking__ds_partitioned__extract_quarter
+            , subq_3.booking__ds_partitioned__extract_month
+            , subq_3.booking__ds_partitioned__extract_day
+            , subq_3.booking__ds_partitioned__extract_dow
+            , subq_3.booking__ds_partitioned__extract_doy
+            , subq_3.booking__paid_at__day
+            , subq_3.booking__paid_at__week
+            , subq_3.booking__paid_at__month
+            , subq_3.booking__paid_at__quarter
+            , subq_3.booking__paid_at__year
+            , subq_3.booking__paid_at__extract_year
+            , subq_3.booking__paid_at__extract_quarter
+            , subq_3.booking__paid_at__extract_month
+            , subq_3.booking__paid_at__extract_day
+            , subq_3.booking__paid_at__extract_dow
+            , subq_3.booking__paid_at__extract_doy
+            , subq_3.metric_time__day
+            , subq_3.metric_time__week
+            , subq_3.metric_time__month
+            , subq_3.metric_time__quarter
+            , subq_3.metric_time__year
+            , subq_3.metric_time__extract_year
+            , subq_3.metric_time__extract_quarter
+            , subq_3.metric_time__extract_month
+            , subq_3.metric_time__extract_day
+            , subq_3.metric_time__extract_dow
+            , subq_3.metric_time__extract_doy
+            , subq_3.listing
+            , subq_3.guest
+            , subq_3.host
+            , subq_3.booking__listing
+            , subq_3.booking__guest
+            , subq_3.booking__host
+            , subq_3.is_instant
+            , subq_3.booking__is_instant
+            , subq_3.bookings
+            , subq_3.instant_bookings
+            , subq_3.booking_value
+            , subq_3.max_booking_value
+            , subq_3.min_booking_value
+            , subq_3.bookers
+            , subq_3.average_booking_value
+            , subq_3.referred_bookings
+            , subq_3.median_booking_value
+            , subq_3.booking_value_p99
+            , subq_3.discrete_booking_value_p99
+            , subq_3.approximate_continuous_booking_value_p99
+            , subq_3.approximate_discrete_booking_value_p99
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_2.ds__day
+              , subq_2.ds__week
+              , subq_2.ds__month
+              , subq_2.ds__quarter
+              , subq_2.ds__year
+              , subq_2.ds__extract_year
+              , subq_2.ds__extract_quarter
+              , subq_2.ds__extract_month
+              , subq_2.ds__extract_day
+              , subq_2.ds__extract_dow
+              , subq_2.ds__extract_doy
+              , subq_2.ds_partitioned__day
+              , subq_2.ds_partitioned__week
+              , subq_2.ds_partitioned__month
+              , subq_2.ds_partitioned__quarter
+              , subq_2.ds_partitioned__year
+              , subq_2.ds_partitioned__extract_year
+              , subq_2.ds_partitioned__extract_quarter
+              , subq_2.ds_partitioned__extract_month
+              , subq_2.ds_partitioned__extract_day
+              , subq_2.ds_partitioned__extract_dow
+              , subq_2.ds_partitioned__extract_doy
+              , subq_2.paid_at__day
+              , subq_2.paid_at__week
+              , subq_2.paid_at__month
+              , subq_2.paid_at__quarter
+              , subq_2.paid_at__year
+              , subq_2.paid_at__extract_year
+              , subq_2.paid_at__extract_quarter
+              , subq_2.paid_at__extract_month
+              , subq_2.paid_at__extract_day
+              , subq_2.paid_at__extract_dow
+              , subq_2.paid_at__extract_doy
+              , subq_2.booking__ds__day
+              , subq_2.booking__ds__week
+              , subq_2.booking__ds__month
+              , subq_2.booking__ds__quarter
+              , subq_2.booking__ds__year
+              , subq_2.booking__ds__extract_year
+              , subq_2.booking__ds__extract_quarter
+              , subq_2.booking__ds__extract_month
+              , subq_2.booking__ds__extract_day
+              , subq_2.booking__ds__extract_dow
+              , subq_2.booking__ds__extract_doy
+              , subq_2.booking__ds_partitioned__day
+              , subq_2.booking__ds_partitioned__week
+              , subq_2.booking__ds_partitioned__month
+              , subq_2.booking__ds_partitioned__quarter
+              , subq_2.booking__ds_partitioned__year
+              , subq_2.booking__ds_partitioned__extract_year
+              , subq_2.booking__ds_partitioned__extract_quarter
+              , subq_2.booking__ds_partitioned__extract_month
+              , subq_2.booking__ds_partitioned__extract_day
+              , subq_2.booking__ds_partitioned__extract_dow
+              , subq_2.booking__ds_partitioned__extract_doy
+              , subq_2.booking__paid_at__day
+              , subq_2.booking__paid_at__week
+              , subq_2.booking__paid_at__month
+              , subq_2.booking__paid_at__quarter
+              , subq_2.booking__paid_at__year
+              , subq_2.booking__paid_at__extract_year
+              , subq_2.booking__paid_at__extract_quarter
+              , subq_2.booking__paid_at__extract_month
+              , subq_2.booking__paid_at__extract_day
+              , subq_2.booking__paid_at__extract_dow
+              , subq_2.booking__paid_at__extract_doy
+              , subq_2.ds__day AS metric_time__day
+              , subq_2.ds__week AS metric_time__week
+              , subq_2.ds__month AS metric_time__month
+              , subq_2.ds__quarter AS metric_time__quarter
+              , subq_2.ds__year AS metric_time__year
+              , subq_2.ds__extract_year AS metric_time__extract_year
+              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_2.ds__extract_month AS metric_time__extract_month
+              , subq_2.ds__extract_day AS metric_time__extract_day
+              , subq_2.ds__extract_dow AS metric_time__extract_dow
+              , subq_2.ds__extract_doy AS metric_time__extract_doy
+              , subq_2.listing
+              , subq_2.guest
+              , subq_2.host
+              , subq_2.booking__listing
+              , subq_2.booking__guest
+              , subq_2.booking__host
+              , subq_2.is_instant
+              , subq_2.booking__is_instant
+              , subq_2.bookings
+              , subq_2.instant_bookings
+              , subq_2.booking_value
+              , subq_2.max_booking_value
+              , subq_2.min_booking_value
+              , subq_2.bookers
+              , subq_2.average_booking_value
+              , subq_2.referred_bookings
+              , subq_2.median_booking_value
+              , subq_2.booking_value_p99
+              , subq_2.discrete_booking_value_p99
+              , subq_2.approximate_continuous_booking_value_p99
+              , subq_2.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_2
+          ) subq_3
+          WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.metric_time__day
+    ) subq_6
+    ON
+      subq_7.metric_time__day = subq_6.metric_time__day
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -1,0 +1,40 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_16.metric_time__day AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_17
+    WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
+  ) subq_16
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_14
+    GROUP BY
+      metric_time__day
+  ) subq_15
+  ON
+    subq_16.metric_time__day = subq_15.metric_time__day
+  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,0 +1,311 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_5.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings',]
+    SELECT
+      subq_4.bookings
+    FROM (
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      SELECT
+        subq_3.ds__day
+        , subq_3.ds__week
+        , subq_3.ds__month
+        , subq_3.ds__quarter
+        , subq_3.ds__year
+        , subq_3.ds__extract_year
+        , subq_3.ds__extract_quarter
+        , subq_3.ds__extract_month
+        , subq_3.ds__extract_day
+        , subq_3.ds__extract_dow
+        , subq_3.ds__extract_doy
+        , subq_3.ds_partitioned__day
+        , subq_3.ds_partitioned__week
+        , subq_3.ds_partitioned__month
+        , subq_3.ds_partitioned__quarter
+        , subq_3.ds_partitioned__year
+        , subq_3.ds_partitioned__extract_year
+        , subq_3.ds_partitioned__extract_quarter
+        , subq_3.ds_partitioned__extract_month
+        , subq_3.ds_partitioned__extract_day
+        , subq_3.ds_partitioned__extract_dow
+        , subq_3.ds_partitioned__extract_doy
+        , subq_3.paid_at__day
+        , subq_3.paid_at__week
+        , subq_3.paid_at__month
+        , subq_3.paid_at__quarter
+        , subq_3.paid_at__year
+        , subq_3.paid_at__extract_year
+        , subq_3.paid_at__extract_quarter
+        , subq_3.paid_at__extract_month
+        , subq_3.paid_at__extract_day
+        , subq_3.paid_at__extract_dow
+        , subq_3.paid_at__extract_doy
+        , subq_3.booking__ds__day
+        , subq_3.booking__ds__week
+        , subq_3.booking__ds__month
+        , subq_3.booking__ds__quarter
+        , subq_3.booking__ds__year
+        , subq_3.booking__ds__extract_year
+        , subq_3.booking__ds__extract_quarter
+        , subq_3.booking__ds__extract_month
+        , subq_3.booking__ds__extract_day
+        , subq_3.booking__ds__extract_dow
+        , subq_3.booking__ds__extract_doy
+        , subq_3.booking__ds_partitioned__day
+        , subq_3.booking__ds_partitioned__week
+        , subq_3.booking__ds_partitioned__month
+        , subq_3.booking__ds_partitioned__quarter
+        , subq_3.booking__ds_partitioned__year
+        , subq_3.booking__ds_partitioned__extract_year
+        , subq_3.booking__ds_partitioned__extract_quarter
+        , subq_3.booking__ds_partitioned__extract_month
+        , subq_3.booking__ds_partitioned__extract_day
+        , subq_3.booking__ds_partitioned__extract_dow
+        , subq_3.booking__ds_partitioned__extract_doy
+        , subq_3.booking__paid_at__day
+        , subq_3.booking__paid_at__week
+        , subq_3.booking__paid_at__month
+        , subq_3.booking__paid_at__quarter
+        , subq_3.booking__paid_at__year
+        , subq_3.booking__paid_at__extract_year
+        , subq_3.booking__paid_at__extract_quarter
+        , subq_3.booking__paid_at__extract_month
+        , subq_3.booking__paid_at__extract_day
+        , subq_3.booking__paid_at__extract_dow
+        , subq_3.booking__paid_at__extract_doy
+        , subq_3.metric_time__day
+        , subq_3.metric_time__week
+        , subq_3.metric_time__month
+        , subq_3.metric_time__quarter
+        , subq_3.metric_time__year
+        , subq_3.metric_time__extract_year
+        , subq_3.metric_time__extract_quarter
+        , subq_3.metric_time__extract_month
+        , subq_3.metric_time__extract_day
+        , subq_3.metric_time__extract_dow
+        , subq_3.metric_time__extract_doy
+        , subq_3.listing
+        , subq_3.guest
+        , subq_3.host
+        , subq_3.booking__listing
+        , subq_3.booking__guest
+        , subq_3.booking__host
+        , subq_3.is_instant
+        , subq_3.booking__is_instant
+        , subq_3.bookings
+        , subq_3.instant_bookings
+        , subq_3.booking_value
+        , subq_3.max_booking_value
+        , subq_3.min_booking_value
+        , subq_3.bookers
+        , subq_3.average_booking_value
+        , subq_3.referred_bookings
+        , subq_3.median_booking_value
+        , subq_3.booking_value_p99
+        , subq_3.discrete_booking_value_p99
+        , subq_3.approximate_continuous_booking_value_p99
+        , subq_3.approximate_discrete_booking_value_p99
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_2.ds__day
+          , subq_2.ds__week
+          , subq_2.ds__month
+          , subq_2.ds__quarter
+          , subq_2.ds__year
+          , subq_2.ds__extract_year
+          , subq_2.ds__extract_quarter
+          , subq_2.ds__extract_month
+          , subq_2.ds__extract_day
+          , subq_2.ds__extract_dow
+          , subq_2.ds__extract_doy
+          , subq_2.ds_partitioned__day
+          , subq_2.ds_partitioned__week
+          , subq_2.ds_partitioned__month
+          , subq_2.ds_partitioned__quarter
+          , subq_2.ds_partitioned__year
+          , subq_2.ds_partitioned__extract_year
+          , subq_2.ds_partitioned__extract_quarter
+          , subq_2.ds_partitioned__extract_month
+          , subq_2.ds_partitioned__extract_day
+          , subq_2.ds_partitioned__extract_dow
+          , subq_2.ds_partitioned__extract_doy
+          , subq_2.paid_at__day
+          , subq_2.paid_at__week
+          , subq_2.paid_at__month
+          , subq_2.paid_at__quarter
+          , subq_2.paid_at__year
+          , subq_2.paid_at__extract_year
+          , subq_2.paid_at__extract_quarter
+          , subq_2.paid_at__extract_month
+          , subq_2.paid_at__extract_day
+          , subq_2.paid_at__extract_dow
+          , subq_2.paid_at__extract_doy
+          , subq_2.booking__ds__day
+          , subq_2.booking__ds__week
+          , subq_2.booking__ds__month
+          , subq_2.booking__ds__quarter
+          , subq_2.booking__ds__year
+          , subq_2.booking__ds__extract_year
+          , subq_2.booking__ds__extract_quarter
+          , subq_2.booking__ds__extract_month
+          , subq_2.booking__ds__extract_day
+          , subq_2.booking__ds__extract_dow
+          , subq_2.booking__ds__extract_doy
+          , subq_2.booking__ds_partitioned__day
+          , subq_2.booking__ds_partitioned__week
+          , subq_2.booking__ds_partitioned__month
+          , subq_2.booking__ds_partitioned__quarter
+          , subq_2.booking__ds_partitioned__year
+          , subq_2.booking__ds_partitioned__extract_year
+          , subq_2.booking__ds_partitioned__extract_quarter
+          , subq_2.booking__ds_partitioned__extract_month
+          , subq_2.booking__ds_partitioned__extract_day
+          , subq_2.booking__ds_partitioned__extract_dow
+          , subq_2.booking__ds_partitioned__extract_doy
+          , subq_2.booking__paid_at__day
+          , subq_2.booking__paid_at__week
+          , subq_2.booking__paid_at__month
+          , subq_2.booking__paid_at__quarter
+          , subq_2.booking__paid_at__year
+          , subq_2.booking__paid_at__extract_year
+          , subq_2.booking__paid_at__extract_quarter
+          , subq_2.booking__paid_at__extract_month
+          , subq_2.booking__paid_at__extract_day
+          , subq_2.booking__paid_at__extract_dow
+          , subq_2.booking__paid_at__extract_doy
+          , subq_2.ds__day AS metric_time__day
+          , subq_2.ds__week AS metric_time__week
+          , subq_2.ds__month AS metric_time__month
+          , subq_2.ds__quarter AS metric_time__quarter
+          , subq_2.ds__year AS metric_time__year
+          , subq_2.ds__extract_year AS metric_time__extract_year
+          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_2.ds__extract_month AS metric_time__extract_month
+          , subq_2.ds__extract_day AS metric_time__extract_day
+          , subq_2.ds__extract_dow AS metric_time__extract_dow
+          , subq_2.ds__extract_doy AS metric_time__extract_doy
+          , subq_2.listing
+          , subq_2.guest
+          , subq_2.host
+          , subq_2.booking__listing
+          , subq_2.booking__guest
+          , subq_2.booking__host
+          , subq_2.is_instant
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+          , subq_2.instant_bookings
+          , subq_2.booking_value
+          , subq_2.max_booking_value
+          , subq_2.min_booking_value
+          , subq_2.bookers
+          , subq_2.average_booking_value
+          , subq_2.referred_bookings
+          , subq_2.median_booking_value
+          , subq_2.booking_value_p99
+          , subq_2.discrete_booking_value_p99
+          , subq_2.approximate_continuous_booking_value_p99
+          , subq_2.approximate_discrete_booking_value_p99
+        FROM (
+          -- Read Elements From Semantic Model 'bookings_source'
+          SELECT
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_28000.booking_value
+            , bookings_source_src_28000.booking_value AS max_booking_value
+            , bookings_source_src_28000.booking_value AS min_booking_value
+            , bookings_source_src_28000.guest_id AS bookers
+            , bookings_source_src_28000.booking_value AS average_booking_value
+            , bookings_source_src_28000.booking_value AS booking_payments
+            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+            , bookings_source_src_28000.booking_value AS median_booking_value
+            , bookings_source_src_28000.booking_value AS booking_value_p99
+            , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+            , bookings_source_src_28000.is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+            , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+            , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+            , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+            , bookings_source_src_28000.is_instant AS booking__is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+            , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+            , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+            , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+            , bookings_source_src_28000.listing_id AS listing
+            , bookings_source_src_28000.guest_id AS guest
+            , bookings_source_src_28000.host_id AS host
+            , bookings_source_src_28000.listing_id AS booking__listing
+            , bookings_source_src_28000.guest_id AS booking__guest
+            , bookings_source_src_28000.host_id AS booking__host
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_2
+      ) subq_3
+      WHERE subq_3.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+    ) subq_4
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  -- Pass Only Elements: ['bookings',]
+  -- Aggregate Measures
+  SELECT
+    SUM(1) AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_11

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,0 +1,242 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+    ) subq_4
+    GROUP BY
+      subq_4.metric_time__day
+  ) subq_5
+  ON
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -1,0 +1,34 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_11
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+  ) subq_14
+  ON
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -1,0 +1,45 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , booking__is_instant
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , booking__is_instant
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_11
+      WHERE booking__is_instant
+      GROUP BY
+        metric_time__day
+        , booking__is_instant
+    ) subq_13
+    ON
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
+  WHERE booking__is_instant
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0.sql
@@ -1,0 +1,338 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.metric_time__day
+  , COALESCE(subq_10.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_9.metric_time__day
+    , subq_9.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_7.metric_time__day AS metric_time__day
+      , subq_6.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_8.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_8
+      WHERE subq_8.ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+    ) subq_7
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_5.metric_time__day
+        , SUM(subq_5.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'metric_time__day']
+        SELECT
+          subq_4.metric_time__day
+          , subq_4.bookings
+        FROM (
+          -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+          SELECT
+            subq_3.ds__day
+            , subq_3.ds__week
+            , subq_3.ds__month
+            , subq_3.ds__quarter
+            , subq_3.ds__year
+            , subq_3.ds__extract_year
+            , subq_3.ds__extract_quarter
+            , subq_3.ds__extract_month
+            , subq_3.ds__extract_day
+            , subq_3.ds__extract_dow
+            , subq_3.ds__extract_doy
+            , subq_3.ds_partitioned__day
+            , subq_3.ds_partitioned__week
+            , subq_3.ds_partitioned__month
+            , subq_3.ds_partitioned__quarter
+            , subq_3.ds_partitioned__year
+            , subq_3.ds_partitioned__extract_year
+            , subq_3.ds_partitioned__extract_quarter
+            , subq_3.ds_partitioned__extract_month
+            , subq_3.ds_partitioned__extract_day
+            , subq_3.ds_partitioned__extract_dow
+            , subq_3.ds_partitioned__extract_doy
+            , subq_3.paid_at__day
+            , subq_3.paid_at__week
+            , subq_3.paid_at__month
+            , subq_3.paid_at__quarter
+            , subq_3.paid_at__year
+            , subq_3.paid_at__extract_year
+            , subq_3.paid_at__extract_quarter
+            , subq_3.paid_at__extract_month
+            , subq_3.paid_at__extract_day
+            , subq_3.paid_at__extract_dow
+            , subq_3.paid_at__extract_doy
+            , subq_3.booking__ds__day
+            , subq_3.booking__ds__week
+            , subq_3.booking__ds__month
+            , subq_3.booking__ds__quarter
+            , subq_3.booking__ds__year
+            , subq_3.booking__ds__extract_year
+            , subq_3.booking__ds__extract_quarter
+            , subq_3.booking__ds__extract_month
+            , subq_3.booking__ds__extract_day
+            , subq_3.booking__ds__extract_dow
+            , subq_3.booking__ds__extract_doy
+            , subq_3.booking__ds_partitioned__day
+            , subq_3.booking__ds_partitioned__week
+            , subq_3.booking__ds_partitioned__month
+            , subq_3.booking__ds_partitioned__quarter
+            , subq_3.booking__ds_partitioned__year
+            , subq_3.booking__ds_partitioned__extract_year
+            , subq_3.booking__ds_partitioned__extract_quarter
+            , subq_3.booking__ds_partitioned__extract_month
+            , subq_3.booking__ds_partitioned__extract_day
+            , subq_3.booking__ds_partitioned__extract_dow
+            , subq_3.booking__ds_partitioned__extract_doy
+            , subq_3.booking__paid_at__day
+            , subq_3.booking__paid_at__week
+            , subq_3.booking__paid_at__month
+            , subq_3.booking__paid_at__quarter
+            , subq_3.booking__paid_at__year
+            , subq_3.booking__paid_at__extract_year
+            , subq_3.booking__paid_at__extract_quarter
+            , subq_3.booking__paid_at__extract_month
+            , subq_3.booking__paid_at__extract_day
+            , subq_3.booking__paid_at__extract_dow
+            , subq_3.booking__paid_at__extract_doy
+            , subq_3.metric_time__day
+            , subq_3.metric_time__week
+            , subq_3.metric_time__month
+            , subq_3.metric_time__quarter
+            , subq_3.metric_time__year
+            , subq_3.metric_time__extract_year
+            , subq_3.metric_time__extract_quarter
+            , subq_3.metric_time__extract_month
+            , subq_3.metric_time__extract_day
+            , subq_3.metric_time__extract_dow
+            , subq_3.metric_time__extract_doy
+            , subq_3.listing
+            , subq_3.guest
+            , subq_3.host
+            , subq_3.booking__listing
+            , subq_3.booking__guest
+            , subq_3.booking__host
+            , subq_3.is_instant
+            , subq_3.booking__is_instant
+            , subq_3.bookings
+            , subq_3.instant_bookings
+            , subq_3.booking_value
+            , subq_3.max_booking_value
+            , subq_3.min_booking_value
+            , subq_3.bookers
+            , subq_3.average_booking_value
+            , subq_3.referred_bookings
+            , subq_3.median_booking_value
+            , subq_3.booking_value_p99
+            , subq_3.discrete_booking_value_p99
+            , subq_3.approximate_continuous_booking_value_p99
+            , subq_3.approximate_discrete_booking_value_p99
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_2.ds__day
+              , subq_2.ds__week
+              , subq_2.ds__month
+              , subq_2.ds__quarter
+              , subq_2.ds__year
+              , subq_2.ds__extract_year
+              , subq_2.ds__extract_quarter
+              , subq_2.ds__extract_month
+              , subq_2.ds__extract_day
+              , subq_2.ds__extract_dow
+              , subq_2.ds__extract_doy
+              , subq_2.ds_partitioned__day
+              , subq_2.ds_partitioned__week
+              , subq_2.ds_partitioned__month
+              , subq_2.ds_partitioned__quarter
+              , subq_2.ds_partitioned__year
+              , subq_2.ds_partitioned__extract_year
+              , subq_2.ds_partitioned__extract_quarter
+              , subq_2.ds_partitioned__extract_month
+              , subq_2.ds_partitioned__extract_day
+              , subq_2.ds_partitioned__extract_dow
+              , subq_2.ds_partitioned__extract_doy
+              , subq_2.paid_at__day
+              , subq_2.paid_at__week
+              , subq_2.paid_at__month
+              , subq_2.paid_at__quarter
+              , subq_2.paid_at__year
+              , subq_2.paid_at__extract_year
+              , subq_2.paid_at__extract_quarter
+              , subq_2.paid_at__extract_month
+              , subq_2.paid_at__extract_day
+              , subq_2.paid_at__extract_dow
+              , subq_2.paid_at__extract_doy
+              , subq_2.booking__ds__day
+              , subq_2.booking__ds__week
+              , subq_2.booking__ds__month
+              , subq_2.booking__ds__quarter
+              , subq_2.booking__ds__year
+              , subq_2.booking__ds__extract_year
+              , subq_2.booking__ds__extract_quarter
+              , subq_2.booking__ds__extract_month
+              , subq_2.booking__ds__extract_day
+              , subq_2.booking__ds__extract_dow
+              , subq_2.booking__ds__extract_doy
+              , subq_2.booking__ds_partitioned__day
+              , subq_2.booking__ds_partitioned__week
+              , subq_2.booking__ds_partitioned__month
+              , subq_2.booking__ds_partitioned__quarter
+              , subq_2.booking__ds_partitioned__year
+              , subq_2.booking__ds_partitioned__extract_year
+              , subq_2.booking__ds_partitioned__extract_quarter
+              , subq_2.booking__ds_partitioned__extract_month
+              , subq_2.booking__ds_partitioned__extract_day
+              , subq_2.booking__ds_partitioned__extract_dow
+              , subq_2.booking__ds_partitioned__extract_doy
+              , subq_2.booking__paid_at__day
+              , subq_2.booking__paid_at__week
+              , subq_2.booking__paid_at__month
+              , subq_2.booking__paid_at__quarter
+              , subq_2.booking__paid_at__year
+              , subq_2.booking__paid_at__extract_year
+              , subq_2.booking__paid_at__extract_quarter
+              , subq_2.booking__paid_at__extract_month
+              , subq_2.booking__paid_at__extract_day
+              , subq_2.booking__paid_at__extract_dow
+              , subq_2.booking__paid_at__extract_doy
+              , subq_2.ds__day AS metric_time__day
+              , subq_2.ds__week AS metric_time__week
+              , subq_2.ds__month AS metric_time__month
+              , subq_2.ds__quarter AS metric_time__quarter
+              , subq_2.ds__year AS metric_time__year
+              , subq_2.ds__extract_year AS metric_time__extract_year
+              , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_2.ds__extract_month AS metric_time__extract_month
+              , subq_2.ds__extract_day AS metric_time__extract_day
+              , subq_2.ds__extract_dow AS metric_time__extract_dow
+              , subq_2.ds__extract_doy AS metric_time__extract_doy
+              , subq_2.listing
+              , subq_2.guest
+              , subq_2.host
+              , subq_2.booking__listing
+              , subq_2.booking__guest
+              , subq_2.booking__host
+              , subq_2.is_instant
+              , subq_2.booking__is_instant
+              , subq_2.bookings
+              , subq_2.instant_bookings
+              , subq_2.booking_value
+              , subq_2.max_booking_value
+              , subq_2.min_booking_value
+              , subq_2.bookers
+              , subq_2.average_booking_value
+              , subq_2.referred_bookings
+              , subq_2.median_booking_value
+              , subq_2.booking_value_p99
+              , subq_2.discrete_booking_value_p99
+              , subq_2.approximate_continuous_booking_value_p99
+              , subq_2.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_2
+          ) subq_3
+          WHERE subq_3.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+        ) subq_4
+      ) subq_5
+      GROUP BY
+        subq_5.metric_time__day
+    ) subq_6
+    ON
+      subq_7.metric_time__day = subq_6.metric_time__day
+  ) subq_9
+  WHERE subq_9.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+) subq_10

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -1,0 +1,40 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  SELECT
+    subq_16.metric_time__day AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_17
+    WHERE ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+  ) subq_16
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+      WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+    ) subq_14
+    GROUP BY
+      metric_time__day
+  ) subq_15
+  ON
+    subq_16.metric_time__day = subq_15.metric_time__day
+  WHERE subq_16.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+) subq_19

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_time_constraint__plan0.sql
@@ -1,0 +1,311 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(subq_6.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Aggregate Measures
+  SELECT
+    SUM(subq_5.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings',]
+    SELECT
+      subq_4.bookings
+    FROM (
+      -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+      SELECT
+        subq_3.ds__day
+        , subq_3.ds__week
+        , subq_3.ds__month
+        , subq_3.ds__quarter
+        , subq_3.ds__year
+        , subq_3.ds__extract_year
+        , subq_3.ds__extract_quarter
+        , subq_3.ds__extract_month
+        , subq_3.ds__extract_day
+        , subq_3.ds__extract_dow
+        , subq_3.ds__extract_doy
+        , subq_3.ds_partitioned__day
+        , subq_3.ds_partitioned__week
+        , subq_3.ds_partitioned__month
+        , subq_3.ds_partitioned__quarter
+        , subq_3.ds_partitioned__year
+        , subq_3.ds_partitioned__extract_year
+        , subq_3.ds_partitioned__extract_quarter
+        , subq_3.ds_partitioned__extract_month
+        , subq_3.ds_partitioned__extract_day
+        , subq_3.ds_partitioned__extract_dow
+        , subq_3.ds_partitioned__extract_doy
+        , subq_3.paid_at__day
+        , subq_3.paid_at__week
+        , subq_3.paid_at__month
+        , subq_3.paid_at__quarter
+        , subq_3.paid_at__year
+        , subq_3.paid_at__extract_year
+        , subq_3.paid_at__extract_quarter
+        , subq_3.paid_at__extract_month
+        , subq_3.paid_at__extract_day
+        , subq_3.paid_at__extract_dow
+        , subq_3.paid_at__extract_doy
+        , subq_3.booking__ds__day
+        , subq_3.booking__ds__week
+        , subq_3.booking__ds__month
+        , subq_3.booking__ds__quarter
+        , subq_3.booking__ds__year
+        , subq_3.booking__ds__extract_year
+        , subq_3.booking__ds__extract_quarter
+        , subq_3.booking__ds__extract_month
+        , subq_3.booking__ds__extract_day
+        , subq_3.booking__ds__extract_dow
+        , subq_3.booking__ds__extract_doy
+        , subq_3.booking__ds_partitioned__day
+        , subq_3.booking__ds_partitioned__week
+        , subq_3.booking__ds_partitioned__month
+        , subq_3.booking__ds_partitioned__quarter
+        , subq_3.booking__ds_partitioned__year
+        , subq_3.booking__ds_partitioned__extract_year
+        , subq_3.booking__ds_partitioned__extract_quarter
+        , subq_3.booking__ds_partitioned__extract_month
+        , subq_3.booking__ds_partitioned__extract_day
+        , subq_3.booking__ds_partitioned__extract_dow
+        , subq_3.booking__ds_partitioned__extract_doy
+        , subq_3.booking__paid_at__day
+        , subq_3.booking__paid_at__week
+        , subq_3.booking__paid_at__month
+        , subq_3.booking__paid_at__quarter
+        , subq_3.booking__paid_at__year
+        , subq_3.booking__paid_at__extract_year
+        , subq_3.booking__paid_at__extract_quarter
+        , subq_3.booking__paid_at__extract_month
+        , subq_3.booking__paid_at__extract_day
+        , subq_3.booking__paid_at__extract_dow
+        , subq_3.booking__paid_at__extract_doy
+        , subq_3.metric_time__day
+        , subq_3.metric_time__week
+        , subq_3.metric_time__month
+        , subq_3.metric_time__quarter
+        , subq_3.metric_time__year
+        , subq_3.metric_time__extract_year
+        , subq_3.metric_time__extract_quarter
+        , subq_3.metric_time__extract_month
+        , subq_3.metric_time__extract_day
+        , subq_3.metric_time__extract_dow
+        , subq_3.metric_time__extract_doy
+        , subq_3.listing
+        , subq_3.guest
+        , subq_3.host
+        , subq_3.booking__listing
+        , subq_3.booking__guest
+        , subq_3.booking__host
+        , subq_3.is_instant
+        , subq_3.booking__is_instant
+        , subq_3.bookings
+        , subq_3.instant_bookings
+        , subq_3.booking_value
+        , subq_3.max_booking_value
+        , subq_3.min_booking_value
+        , subq_3.bookers
+        , subq_3.average_booking_value
+        , subq_3.referred_bookings
+        , subq_3.median_booking_value
+        , subq_3.booking_value_p99
+        , subq_3.discrete_booking_value_p99
+        , subq_3.approximate_continuous_booking_value_p99
+        , subq_3.approximate_discrete_booking_value_p99
+      FROM (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_2.ds__day
+          , subq_2.ds__week
+          , subq_2.ds__month
+          , subq_2.ds__quarter
+          , subq_2.ds__year
+          , subq_2.ds__extract_year
+          , subq_2.ds__extract_quarter
+          , subq_2.ds__extract_month
+          , subq_2.ds__extract_day
+          , subq_2.ds__extract_dow
+          , subq_2.ds__extract_doy
+          , subq_2.ds_partitioned__day
+          , subq_2.ds_partitioned__week
+          , subq_2.ds_partitioned__month
+          , subq_2.ds_partitioned__quarter
+          , subq_2.ds_partitioned__year
+          , subq_2.ds_partitioned__extract_year
+          , subq_2.ds_partitioned__extract_quarter
+          , subq_2.ds_partitioned__extract_month
+          , subq_2.ds_partitioned__extract_day
+          , subq_2.ds_partitioned__extract_dow
+          , subq_2.ds_partitioned__extract_doy
+          , subq_2.paid_at__day
+          , subq_2.paid_at__week
+          , subq_2.paid_at__month
+          , subq_2.paid_at__quarter
+          , subq_2.paid_at__year
+          , subq_2.paid_at__extract_year
+          , subq_2.paid_at__extract_quarter
+          , subq_2.paid_at__extract_month
+          , subq_2.paid_at__extract_day
+          , subq_2.paid_at__extract_dow
+          , subq_2.paid_at__extract_doy
+          , subq_2.booking__ds__day
+          , subq_2.booking__ds__week
+          , subq_2.booking__ds__month
+          , subq_2.booking__ds__quarter
+          , subq_2.booking__ds__year
+          , subq_2.booking__ds__extract_year
+          , subq_2.booking__ds__extract_quarter
+          , subq_2.booking__ds__extract_month
+          , subq_2.booking__ds__extract_day
+          , subq_2.booking__ds__extract_dow
+          , subq_2.booking__ds__extract_doy
+          , subq_2.booking__ds_partitioned__day
+          , subq_2.booking__ds_partitioned__week
+          , subq_2.booking__ds_partitioned__month
+          , subq_2.booking__ds_partitioned__quarter
+          , subq_2.booking__ds_partitioned__year
+          , subq_2.booking__ds_partitioned__extract_year
+          , subq_2.booking__ds_partitioned__extract_quarter
+          , subq_2.booking__ds_partitioned__extract_month
+          , subq_2.booking__ds_partitioned__extract_day
+          , subq_2.booking__ds_partitioned__extract_dow
+          , subq_2.booking__ds_partitioned__extract_doy
+          , subq_2.booking__paid_at__day
+          , subq_2.booking__paid_at__week
+          , subq_2.booking__paid_at__month
+          , subq_2.booking__paid_at__quarter
+          , subq_2.booking__paid_at__year
+          , subq_2.booking__paid_at__extract_year
+          , subq_2.booking__paid_at__extract_quarter
+          , subq_2.booking__paid_at__extract_month
+          , subq_2.booking__paid_at__extract_day
+          , subq_2.booking__paid_at__extract_dow
+          , subq_2.booking__paid_at__extract_doy
+          , subq_2.ds__day AS metric_time__day
+          , subq_2.ds__week AS metric_time__week
+          , subq_2.ds__month AS metric_time__month
+          , subq_2.ds__quarter AS metric_time__quarter
+          , subq_2.ds__year AS metric_time__year
+          , subq_2.ds__extract_year AS metric_time__extract_year
+          , subq_2.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_2.ds__extract_month AS metric_time__extract_month
+          , subq_2.ds__extract_day AS metric_time__extract_day
+          , subq_2.ds__extract_dow AS metric_time__extract_dow
+          , subq_2.ds__extract_doy AS metric_time__extract_doy
+          , subq_2.listing
+          , subq_2.guest
+          , subq_2.host
+          , subq_2.booking__listing
+          , subq_2.booking__guest
+          , subq_2.booking__host
+          , subq_2.is_instant
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+          , subq_2.instant_bookings
+          , subq_2.booking_value
+          , subq_2.max_booking_value
+          , subq_2.min_booking_value
+          , subq_2.bookers
+          , subq_2.average_booking_value
+          , subq_2.referred_bookings
+          , subq_2.median_booking_value
+          , subq_2.booking_value_p99
+          , subq_2.discrete_booking_value_p99
+          , subq_2.approximate_continuous_booking_value_p99
+          , subq_2.approximate_discrete_booking_value_p99
+        FROM (
+          -- Read Elements From Semantic Model 'bookings_source'
+          SELECT
+            1 AS bookings
+            , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+            , bookings_source_src_28000.booking_value
+            , bookings_source_src_28000.booking_value AS max_booking_value
+            , bookings_source_src_28000.booking_value AS min_booking_value
+            , bookings_source_src_28000.guest_id AS bookers
+            , bookings_source_src_28000.booking_value AS average_booking_value
+            , bookings_source_src_28000.booking_value AS booking_payments
+            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+            , bookings_source_src_28000.booking_value AS median_booking_value
+            , bookings_source_src_28000.booking_value AS booking_value_p99
+            , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+            , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+            , bookings_source_src_28000.is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+            , bookings_source_src_28000.is_instant AS booking__is_instant
+            , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+            , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+            , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+            , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+            , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+            , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+            , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+            , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+            , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+            , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+            , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+            , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+            , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+            , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+            , bookings_source_src_28000.listing_id AS listing
+            , bookings_source_src_28000.guest_id AS guest
+            , bookings_source_src_28000.host_id AS host
+            , bookings_source_src_28000.listing_id AS booking__listing
+            , bookings_source_src_28000.guest_id AS booking__guest
+            , bookings_source_src_28000.host_id AS booking__host
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_2
+      ) subq_3
+      WHERE subq_3.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+    ) subq_4
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -1,0 +1,14 @@
+-- Compute Metrics via Expressions
+SELECT
+  COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Read Elements From Semantic Model 'bookings_source'
+  -- Metric Time Dimension 'ds'
+  -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
+  -- Pass Only Elements: ['bookings',]
+  -- Aggregate Measures
+  SELECT
+    SUM(1) AS bookings
+  FROM ***************************.fct_bookings bookings_source_src_28000
+  WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+) subq_11

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,0 +1,242 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
+  FROM (
+    -- Time Spine
+    SELECT
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
+  LEFT OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
+    FROM (
+      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+    ) subq_4
+    GROUP BY
+      subq_4.metric_time__day
+  ) subq_5
+  ON
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -1,0 +1,34 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_11
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+  ) subq_14
+  ON
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -1,0 +1,45 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    metric_time__day
+    , booking__is_instant
+    , bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
+    LEFT OUTER JOIN (
+      -- Constrain Output with WHERE
+      -- Aggregate Measures
+      SELECT
+        metric_time__day
+        , booking__is_instant
+        , SUM(bookings) AS bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_11
+      WHERE booking__is_instant
+      GROUP BY
+        metric_time__day
+        , booking__is_instant
+    ) subq_13
+    ON
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
+  WHERE booking__is_instant
+) subq_17


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->
Resolves SL-1987


### Description
When an input metric specifies `join_to_timespine: true` in its YAML definition, we apply special behavior for filters. Before this PR, we were applying all filters twice - before and after the time spine join. This is because you might end up with new rows after the time spine join that should be filtered out. This resulted in a bug sometimes if you filtered by a spec that was not in the group by, since the filter column no longer existed at that level of the query.
This fixes that bug by only applying the post-join filter if the filtered spec is also in the group by. The specs in the group by should be the only ones changed after the time spine join, anyway.