### PR TITLE
Rename node visitor method to match typical pattern

### DIFF
--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -127,7 +127,7 @@ class DataflowPlanNodeVisitor(Generic[VisitorOutputT], ABC):
         pass
 
     @abstractmethod
-    def visit_pass_elements_filter_node(self, node: FilterElementsNode) -> VisitorOutputT:  # noqa: D102
+    def visit_filter_elements_node(self, node: FilterElementsNode) -> VisitorOutputT:  # noqa: D102
         pass
 
     @abstractmethod

--- a/metricflow/dataflow/nodes/filter_elements.py
+++ b/metricflow/dataflow/nodes/filter_elements.py
@@ -41,7 +41,7 @@ class FilterElementsNode(BaseOutput):
         return self._distinct
 
     def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
-        return visitor.visit_pass_elements_filter_node(self)
+        return visitor.visit_filter_elements_node(self)
 
     @property
     def description(self) -> str:  # noqa: D102

--- a/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
+++ b/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
@@ -338,7 +338,7 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         self._log_visit_node_type(node)
         return self._handle_unsupported_node(node)
 
-    def visit_pass_elements_filter_node(  # noqa: D102
+    def visit_filter_elements_node(  # noqa: D102
         self, node: FilterElementsNode
     ) -> ComputeMetricsBranchCombinerResult:  # noqa: D102
         self._log_visit_node_type(node)

--- a/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
+++ b/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
@@ -194,7 +194,7 @@ class SourceScanOptimizer(
         self._log_visit_node_type(node)
         return self._default_sink_node_handler(node)
 
-    def visit_pass_elements_filter_node(self, node: FilterElementsNode) -> OptimizeBranchResult:  # noqa: D102
+    def visit_filter_elements_node(self, node: FilterElementsNode) -> OptimizeBranchResult:  # noqa: D102
         self._log_visit_node_type(node)
         return self._default_base_output_handler(node)
 

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -828,7 +828,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             ),
         )
 
-    def visit_pass_elements_filter_node(self, node: FilterElementsNode) -> SqlDataSet:
+    def visit_filter_elements_node(self, node: FilterElementsNode) -> SqlDataSet:
         """Generates the query that realizes the behavior of FilterElementsNode."""
         from_data_set: SqlDataSet = node.parent_node.accept(self)
         output_instance_set = from_data_set.instance_set.transform(FilterElements(node.include_specs))

--- a/tests/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
+++ b/tests/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
@@ -78,7 +78,7 @@ class ReadSqlSourceNodeCounter(DataflowPlanNodeVisitor[int]):
     def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
-    def visit_pass_elements_filter_node(self, node: FilterElementsNode) -> int:  # noqa: D102
+    def visit_filter_elements_node(self, node: FilterElementsNode) -> int:  # noqa: D102
         return self._sum_parents(node)
 
     def visit_combine_aggregated_outputs_node(self, node: CombineAggregatedOutputsNode) -> int:  # noqa: D102


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Just a quick rename! This has been bothering me for a while because it's so hard to remember the name of this method. So I've updated it to match our typical pattern, which is just snake-casing the node class name.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
