### PR TITLE
Update `get_semantic_models_for_measure` to return just one semantic model

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -720,12 +720,9 @@ class DataflowPlanBuilder:
 
         This is a temporary method for use in assertion boundaries while we implement support for multiple semantic models
         """
-        semantic_model_names: Set[str] = set()
-        for measure in measures:
-            semantic_model_names = semantic_model_names.union(
-                {d.name for d in self._semantic_model_lookup.get_semantic_models_for_measure(measure.reference)}
-            )
-        return semantic_model_names
+        return {
+            self._semantic_model_lookup.get_semantic_model_for_measure(measure.reference).name for measure in measures
+        }
 
     def _sort_by_suitability(self, nodes: Sequence[BaseOutput]) -> Sequence[BaseOutput]:
         """Sort nodes by the number of linkable specs.

--- a/tests/model/test_semantic_model_container.py
+++ b/tests/model/test_semantic_model_container.py
@@ -58,18 +58,15 @@ def test_get_elements(semantic_model_lookup: SemanticModelLookup) -> None:  # no
         assert semantic_model_lookup.get_measure(measure_reference=measure_reference).reference == measure_reference
 
 
-def test_get_semantic_models_for_measure(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D103
-    bookings_sources = semantic_model_lookup.get_semantic_models_for_measure(MeasureReference(element_name="bookings"))
-    assert len(bookings_sources) == 1
-    assert bookings_sources[0].name == "bookings_source"
+def test_get_semantic_model_for_measure(semantic_model_lookup: SemanticModelLookup) -> None:  # noqa: D103
+    bookings_source = semantic_model_lookup.get_semantic_model_for_measure(MeasureReference(element_name="bookings"))
+    assert bookings_source.name == "bookings_source"
 
-    views_sources = semantic_model_lookup.get_semantic_models_for_measure(MeasureReference(element_name="views"))
-    assert len(views_sources) == 1
-    assert views_sources[0].name == "views_source"
+    views_source = semantic_model_lookup.get_semantic_model_for_measure(MeasureReference(element_name="views"))
+    assert views_source.name == "views_source"
 
-    listings_sources = semantic_model_lookup.get_semantic_models_for_measure(MeasureReference(element_name="listings"))
-    assert len(listings_sources) == 1
-    assert listings_sources[0].name == "listings_latest"
+    listings_source = semantic_model_lookup.get_semantic_model_for_measure(MeasureReference(element_name="listings"))
+    assert listings_source.name == "listings_latest"
 
 
 def test_local_linked_elements_for_metric(  # noqa: D103


### PR DESCRIPTION
### Description
Measure names are required to be unique across semantic models, so we can safely assume that `get_semantic_models_for_measure()` should return one semantic model per measure. 