### PR TITLE
Give enums singular names

### DIFF
--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -34,7 +34,7 @@ from metricflow.mf_logging.formatting import indent
 from metricflow.mf_logging.pretty_print import mf_pformat
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow.model.semantics.linkable_element_properties import (
-    LinkableElementProperties,
+    LinkableElementProperty,
 )
 from metricflow.model.semantics.linkable_spec_resolver import LinkableDimension
 from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
@@ -228,7 +228,7 @@ class AbstractMetricFlowEngine(ABC):
 
     @abstractmethod
     def simple_dimensions_for_metrics(
-        self, metric_names: List[str], without_any_property: Sequence[LinkableElementProperties]
+        self, metric_names: List[str], without_any_property: Sequence[LinkableElementProperty]
     ) -> List[Dimension]:
         """Retrieves a list of all common dimensions for metric_names.
 
@@ -546,10 +546,10 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
     def simple_dimensions_for_metrics(  # noqa: D102
         self,
         metric_names: List[str],
-        without_any_property: Sequence[LinkableElementProperties] = (
-            LinkableElementProperties.ENTITY,
-            LinkableElementProperties.DERIVED_TIME_GRANULARITY,
-            LinkableElementProperties.LOCAL_LINKED,
+        without_any_property: Sequence[LinkableElementProperty] = (
+            LinkableElementProperty.ENTITY,
+            LinkableElementProperty.DERIVED_TIME_GRANULARITY,
+            LinkableElementProperty.LOCAL_LINKED,
         ),
     ) -> List[Dimension]:
         path_key_to_linkable_dimensions = (
@@ -570,10 +570,10 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 if linkable_dimension.date_part is not None:
                     continue
 
-                if LinkableElementProperties.METRIC_TIME in linkable_dimension.properties:
+                if LinkableElementProperty.METRIC_TIME in linkable_dimension.properties:
                     metric_time_name = DataSet.metric_time_dimension_name()
                     assert linkable_dimension.element_name == metric_time_name, (
-                        f"{linkable_dimension} has the {LinkableElementProperties.METRIC_TIME}, but the name does not"
+                        f"{linkable_dimension} has the {LinkableElementProperty.METRIC_TIME}, but the name does not"
                         f"match."
                     )
 
@@ -623,7 +623,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 metric_references=[MetricReference(element_name=mname) for mname in metric_names],
                 with_any_property=frozenset(
                     {
-                        LinkableElementProperties.ENTITY,
+                        LinkableElementProperty.ENTITY,
                     }
                 ),
             )

--- a/metricflow/model/semantics/linkable_element_properties.py
+++ b/metricflow/model/semantics/linkable_element_properties.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import FrozenSet
 
 
-class LinkableElementProperties(Enum):
+class LinkableElementProperty(Enum):
     """The properties associated with a valid linkable element.
 
     Local means an element that is defined within the same semantic model as the measure. This definition is used
@@ -29,15 +29,15 @@ class LinkableElementProperties(Enum):
     METRIC = "metric"
 
     @staticmethod
-    def all_properties() -> FrozenSet[LinkableElementProperties]:  # noqa: D102
+    def all_properties() -> FrozenSet[LinkableElementProperty]:  # noqa: D102
         return frozenset(
             {
-                LinkableElementProperties.LOCAL,
-                LinkableElementProperties.LOCAL_LINKED,
-                LinkableElementProperties.JOINED,
-                LinkableElementProperties.MULTI_HOP,
-                LinkableElementProperties.DERIVED_TIME_GRANULARITY,
-                LinkableElementProperties.METRIC_TIME,
-                LinkableElementProperties.METRIC,
+                LinkableElementProperty.LOCAL,
+                LinkableElementProperty.LOCAL_LINKED,
+                LinkableElementProperty.JOINED,
+                LinkableElementProperty.MULTI_HOP,
+                LinkableElementProperty.DERIVED_TIME_GRANULARITY,
+                LinkableElementProperty.METRIC_TIME,
+                LinkableElementProperty.METRIC,
             }
         )

--- a/metricflow/model/semantics/metric_lookup.py
+++ b/metricflow/model/semantics/metric_lookup.py
@@ -9,7 +9,7 @@ from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference, TimeDimensionReference
 
 from metricflow.errors.errors import DuplicateMetricError, MetricNotFoundError, NonExistentMeasureError
-from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperty
 from metricflow.model.semantics.linkable_spec_resolver import (
     ElementPathKey,
     LinkableElementSet,
@@ -48,13 +48,11 @@ class MetricLookup(MetricAccessor):
     def linkable_elements_for_measure(
         self,
         measure_reference: MeasureReference,
-        with_any_of: Optional[Set[LinkableElementProperties]] = None,
-        without_any_of: Optional[Set[LinkableElementProperties]] = None,
+        with_any_of: Optional[Set[LinkableElementProperty]] = None,
+        without_any_of: Optional[Set[LinkableElementProperty]] = None,
     ) -> LinkableElementSet:
         """Return the set of linkable elements reachable from a given measure."""
-        frozen_with_any_of = (
-            LinkableElementProperties.all_properties() if with_any_of is None else frozenset(with_any_of)
-        )
+        frozen_with_any_of = LinkableElementProperty.all_properties() if with_any_of is None else frozenset(with_any_of)
         frozen_without_any_of = frozenset() if without_any_of is None else frozenset(without_any_of)
 
         return self._linkable_spec_resolver.get_linkable_element_set_for_measure(
@@ -65,13 +63,11 @@ class MetricLookup(MetricAccessor):
 
     def linkable_elements_for_no_metrics_query(
         self,
-        with_any_of: Optional[Set[LinkableElementProperties]] = None,
-        without_any_of: Optional[Set[LinkableElementProperties]] = None,
+        with_any_of: Optional[Set[LinkableElementProperty]] = None,
+        without_any_of: Optional[Set[LinkableElementProperty]] = None,
     ) -> LinkableElementSet:
         """Return the reachable linkable elements for a dimension values query with no metrics."""
-        frozen_with_any_of = (
-            LinkableElementProperties.all_properties() if with_any_of is None else frozenset(with_any_of)
-        )
+        frozen_with_any_of = LinkableElementProperty.all_properties() if with_any_of is None else frozenset(with_any_of)
         frozen_without_any_of = frozenset() if without_any_of is None else frozenset(without_any_of)
 
         return self._linkable_spec_resolver.get_linkable_elements_for_distinct_values_query(
@@ -82,8 +78,8 @@ class MetricLookup(MetricAccessor):
     def linkable_elements_for_metrics(
         self,
         metric_references: Sequence[MetricReference],
-        with_any_property: FrozenSet[LinkableElementProperties] = LinkableElementProperties.all_properties(),
-        without_any_property: FrozenSet[LinkableElementProperties] = frozenset(),
+        with_any_property: FrozenSet[LinkableElementProperty] = LinkableElementProperty.all_properties(),
+        without_any_property: FrozenSet[LinkableElementProperty] = frozenset(),
     ) -> LinkableElementSet:
         """Retrieve the matching set of linkable elements common to all metrics requested (intersection)."""
         return self._linkable_spec_resolver.get_linkable_elements_for_metrics(

--- a/metricflow/protocols/semantics.py
+++ b/metricflow/protocols/semantics.py
@@ -27,7 +27,7 @@ from dbt_semantic_interfaces.references import (
 )
 
 from metricflow.model.semantics.element_group import ElementGrouper
-from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperty
 from metricflow.specs.specs import LinkableInstanceSpec, MeasureSpec, NonAdditiveDimensionSpec, TimeDimensionSpec
 
 if TYPE_CHECKING:
@@ -157,8 +157,8 @@ class MetricAccessor(ABC):
     def linkable_elements_for_metrics(
         self,
         metric_references: Sequence[MetricReference],
-        with_any_property: FrozenSet[LinkableElementProperties] = LinkableElementProperties.all_properties(),
-        without_any_property: FrozenSet[LinkableElementProperties] = frozenset(),
+        with_any_property: FrozenSet[LinkableElementProperty] = LinkableElementProperty.all_properties(),
+        without_any_property: FrozenSet[LinkableElementProperty] = frozenset(),
     ) -> LinkableElementSet:
         """Retrieve the matching set of linkable elements common to all metrics requested (intersection)."""
         raise NotImplementedError
@@ -198,8 +198,8 @@ class MetricAccessor(ABC):
     def linkable_elements_for_measure(
         self,
         measure_reference: MeasureReference,
-        with_any_of: Optional[Set[LinkableElementProperties]] = None,
-        without_any_of: Optional[Set[LinkableElementProperties]] = None,
+        with_any_of: Optional[Set[LinkableElementProperty]] = None,
+        without_any_of: Optional[Set[LinkableElementProperty]] = None,
     ) -> LinkableElementSet:
         """Return the set of linkable elements reachable from a given measure."""
         raise NotImplementedError
@@ -207,8 +207,8 @@ class MetricAccessor(ABC):
     @abstractmethod
     def linkable_elements_for_no_metrics_query(
         self,
-        with_any_of: Optional[Set[LinkableElementProperties]] = None,
-        without_any_of: Optional[Set[LinkableElementProperties]] = None,
+        with_any_of: Optional[Set[LinkableElementProperty]] = None,
+        without_any_of: Optional[Set[LinkableElementProperty]] = None,
     ) -> LinkableElementSet:
         """Return the possible linkable elements for a dimension values query with no metrics."""
         raise NotImplementedError

--- a/metricflow/query/group_by_item/candidate_push_down/push_down_visitor.py
+++ b/metricflow/query/group_by_item/candidate_push_down/push_down_visitor.py
@@ -12,7 +12,7 @@ from typing_extensions import override
 from metricflow.mf_logging.formatting import indent
 from metricflow.mf_logging.pretty_print import mf_pformat, mf_pformat_many
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperty
 from metricflow.query.group_by_item.candidate_push_down.group_by_item_candidate import GroupByItemCandidateSet
 from metricflow.query.group_by_item.resolution_dag.resolution_nodes.base_node import (
     GroupByItemResolutionNode,
@@ -126,8 +126,8 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
         manifest_lookup: SemanticManifestLookup,
         suggestion_generator: Optional[QueryItemSuggestionGenerator],
         source_spec_patterns: Sequence[SpecPattern] = (),
-        with_any_property: Optional[Set[LinkableElementProperties]] = None,
-        without_any_property: Optional[Set[LinkableElementProperties]] = None,
+        with_any_property: Optional[Set[LinkableElementProperty]] = None,
+        without_any_property: Optional[Set[LinkableElementProperty]] = None,
     ) -> None:
         """Initializer.
 
@@ -138,7 +138,7 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
             source_spec_patterns: The patterns to apply to the specs available at the measure nodes.
             with_any_property: Only consider group-by-items with these properties from the measure nodes.
             without_any_property:  Only consider group-by-items without any of these properties (see
-            LinkableElementProperties).
+            LinkableElementProperty).
         """
         self._semantic_manifest_lookup = manifest_lookup
         self._source_spec_patterns = tuple(source_spec_patterns)

--- a/tests/integration/configured_test_case.py
+++ b/tests/integration/configured_test_case.py
@@ -25,7 +25,7 @@ class IntegrationTestModel(Enum):
     SCD_MODEL = "SCD_MODEL"
 
 
-class RequiredDwEngineFeatures(Enum):
+class RequiredDwEngineFeature(Enum):
     """Required features that are needed in the DW engine for the test to run."""
 
     CONTINUOUS_PERCENTILE_AGGREGATION = "CONTINUOUS_PERCENTILE_AGGREGATION"
@@ -56,7 +56,7 @@ class ConfiguredIntegrationTestCase(FrozenBaseModel):
     group_by_objs: Tuple[Dict, ...] = ()
     order_bys: Tuple[str, ...] = ()
     # The required features in the DW engine for the test to complete.
-    required_features: Tuple[RequiredDwEngineFeatures, ...] = ()
+    required_features: Tuple[RequiredDwEngineFeature, ...] = ()
     # Whether to check the order of the rows / columns.
     check_order: bool = False
     allow_empty: bool = False

--- a/tests/integration/test_configured_cases.py
+++ b/tests/integration/test_configured_cases.py
@@ -43,7 +43,7 @@ from tests.fixtures.setup_fixtures import MetricFlowTestConfiguration
 from tests.integration.configured_test_case import (
     CONFIGURED_INTEGRATION_TESTS_REPOSITORY,
     IntegrationTestModel,
-    RequiredDwEngineFeatures,
+    RequiredDwEngineFeature,
 )
 
 logger = logging.getLogger(__name__)
@@ -202,27 +202,27 @@ class CheckQueryHelpers:
 
 
 def filter_not_supported_features(
-    sql_client: SqlClient, required_features: Tuple[RequiredDwEngineFeatures, ...]
-) -> Sequence[RequiredDwEngineFeatures]:
+    sql_client: SqlClient, required_features: Tuple[RequiredDwEngineFeature, ...]
+) -> Sequence[RequiredDwEngineFeature]:
     """Given a list of required features, return a list of features not supported by the given SQLClient."""
-    not_supported_features: List[RequiredDwEngineFeatures] = []
+    not_supported_features: List[RequiredDwEngineFeature] = []
     for required_feature in required_features:
-        if required_feature is RequiredDwEngineFeatures.CONTINUOUS_PERCENTILE_AGGREGATION:
+        if required_feature is RequiredDwEngineFeature.CONTINUOUS_PERCENTILE_AGGREGATION:
             if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.CONTINUOUS
             ):
                 not_supported_features.append(required_feature)
-        elif required_feature is RequiredDwEngineFeatures.DISCRETE_PERCENTILE_AGGREGATION:
+        elif required_feature is RequiredDwEngineFeature.DISCRETE_PERCENTILE_AGGREGATION:
             if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.DISCRETE
             ):
                 not_supported_features.append(required_feature)
-        elif required_feature is RequiredDwEngineFeatures.APPROXIMATE_CONTINUOUS_PERCENTILE_AGGREGATION:
+        elif required_feature is RequiredDwEngineFeature.APPROXIMATE_CONTINUOUS_PERCENTILE_AGGREGATION:
             if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS
             ):
                 not_supported_features.append(required_feature)
-        elif required_feature is RequiredDwEngineFeatures.APPROXIMATE_DISCRETE_PERCENTILE_AGGREGATION:
+        elif required_feature is RequiredDwEngineFeature.APPROXIMATE_DISCRETE_PERCENTILE_AGGREGATION:
             if not sql_client.sql_query_plan_renderer.expr_renderer.can_render_percentile_function(
                 SqlPercentileFunctionType.APPROXIMATE_DISCRETE
             ):

--- a/tests/model/semantics/test_linkable_spec_resolver.py
+++ b/tests/model/semantics/test_linkable_spec_resolver.py
@@ -12,7 +12,7 @@ from dbt_semantic_interfaces.references import (
 )
 
 from metricflow.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperty
 from metricflow.model.semantics.linkable_spec_resolver import (
     SemanticModelJoinPath,
     SemanticModelJoinPathElement,
@@ -58,7 +58,7 @@ def test_all_properties(  # noqa: D103
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="views")],
-            with_any_of=LinkableElementProperties.all_properties(),
+            with_any_of=LinkableElementProperty.all_properties(),
             without_any_of=frozenset({}),
         ),
     )
@@ -75,7 +75,7 @@ def test_one_property(  # noqa: D103
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="views")],
-            with_any_of=frozenset({LinkableElementProperties.LOCAL}),
+            with_any_of=frozenset({LinkableElementProperty.LOCAL}),
             without_any_of=frozenset(),
         ),
     )
@@ -92,7 +92,7 @@ def test_metric_time_property_for_cumulative_metric(  # noqa: D103
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="trailing_2_months_revenue")],
-            with_any_of=frozenset({LinkableElementProperties.METRIC_TIME}),
+            with_any_of=frozenset({LinkableElementProperty.METRIC_TIME}),
             without_any_of=frozenset(),
         ),
     )
@@ -109,7 +109,7 @@ def test_metric_time_property_for_derived_metrics(  # noqa: D103
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings_per_view")],
-            with_any_of=frozenset({LinkableElementProperties.METRIC_TIME}),
+            with_any_of=frozenset({LinkableElementProperty.METRIC_TIME}),
             without_any_of=frozenset(),
         ),
     )
@@ -126,7 +126,7 @@ def test_cyclic_join_manifest(  # noqa: D103
         set_id="result0",
         linkable_element_set=cyclic_join_manifest_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="listings")],
-            with_any_of=LinkableElementProperties.all_properties(),
+            with_any_of=LinkableElementProperty.all_properties(),
             without_any_of=frozenset(),
         ),
     )
@@ -150,7 +150,7 @@ def test_create_linkable_element_set_from_join_path(  # noqa: D103
                     ),
                 )
             ),
-            with_properties=frozenset({LinkableElementProperties.JOINED}),
+            with_properties=frozenset({LinkableElementProperty.JOINED}),
         ),
     )
 
@@ -173,7 +173,7 @@ def test_create_linkable_element_set_from_join_path_multi_hop(  # noqa: D103
                     ),
                 )
             ),
-            with_properties=frozenset({LinkableElementProperties.JOINED, LinkableElementProperties.MULTI_HOP}),
+            with_properties=frozenset({LinkableElementProperty.JOINED, LinkableElementProperty.MULTI_HOP}),
         ),
     )
 
@@ -191,7 +191,7 @@ def test_linkable_element_set_as_spec_set(
     """
     linkable_spec_set = simple_model_spec_resolver.get_linkable_element_set_for_measure(
         MeasureReference(element_name="listings"),
-        with_any_of=LinkableElementProperties.all_properties(),
+        with_any_of=LinkableElementProperty.all_properties(),
         without_any_of=frozenset({}),
     ).as_spec_set
 

--- a/tests/model/test_semantic_model_container.py
+++ b/tests/model/test_semantic_model_container.py
@@ -7,7 +7,7 @@ from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import EntityReference, MeasureReference, MetricReference
 
-from metricflow.model.semantics.linkable_element_properties import LinkableElementProperties
+from metricflow.model.semantics.linkable_element_properties import LinkableElementProperty
 from metricflow.model.semantics.metric_lookup import MetricLookup
 from metricflow.model.semantics.semantic_model_lookup import SemanticModelLookup
 from tests.fixtures.setup_fixtures import MetricFlowTestConfiguration
@@ -77,8 +77,8 @@ def test_local_linked_elements_for_metric(  # noqa: D103
 ) -> None:
     linkable_elements = metric_lookup.linkable_elements_for_metrics(
         [MetricReference(element_name="listings")],
-        with_any_property=frozenset({LinkableElementProperties.LOCAL_LINKED}),
-        without_any_property=frozenset({LinkableElementProperties.DERIVED_TIME_GRANULARITY}),
+        with_any_property=frozenset({LinkableElementProperty.LOCAL_LINKED}),
+        without_any_property=frozenset({LinkableElementProperty.DERIVED_TIME_GRANULARITY}),
     )
     sorted_specs = sorted(linkable_elements.as_spec_set.as_tuple, key=lambda x: x.qualified_name)
     assert_object_snapshot_equal(
@@ -106,8 +106,8 @@ def test_linkable_elements_for_metrics(  # noqa: D103
             (MetricReference(element_name="views"),),
             without_any_property=frozenset(
                 {
-                    LinkableElementProperties.DERIVED_TIME_GRANULARITY,
-                    LinkableElementProperties.METRIC_TIME,
+                    LinkableElementProperty.DERIVED_TIME_GRANULARITY,
+                    LinkableElementProperty.METRIC_TIME,
                 }
             ),
         ),
@@ -138,7 +138,7 @@ def test_linkable_elements_for_no_metrics_query(
     """Tests extracting linkable elements for a dimension values query with no metrics."""
     linkable_elements = metric_lookup.linkable_elements_for_no_metrics_query(
         without_any_of={
-            LinkableElementProperties.DERIVED_TIME_GRANULARITY,
+            LinkableElementProperty.DERIVED_TIME_GRANULARITY,
         }
     )
     sorted_specs = sorted(linkable_elements.as_spec_set.as_tuple, key=lambda x: x.qualified_name)
@@ -165,7 +165,7 @@ def test_linkable_set_for_common_dimensions_in_different_models(
             (MetricReference(element_name="bookings_per_view"),),
             without_any_property=frozenset(
                 {
-                    LinkableElementProperties.DERIVED_TIME_GRANULARITY,
+                    LinkableElementProperty.DERIVED_TIME_GRANULARITY,
                 }
             ),
         ),


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Updates two enums to have singular names, as is conventional (and as we do with all our other enums).
`LinkableElementProperties` -> `LinkableElementProperty`
`RequiredDwEngineFeatures` -> `RequiredDwEngineFeature`
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
