### PR TITLE
Make LinkableElementSet.only_unique_path_keys consider distinct values

### DIFF
--- a/tests/model/semantics/test_linkable_element_set.py
+++ b/tests/model/semantics/test_linkable_element_set.py
@@ -469,7 +469,8 @@ def test_only_unique_path_keys() -> None:
     unique_path_keys = base_set.only_unique_path_keys
 
     assert unique_path_keys.path_key_to_linkable_dimensions == {
-        _time_dimension.path_key: (_time_dimension,)
+        _categorical_dimension.path_key: (_categorical_dimension,),
+        _time_dimension.path_key: (_time_dimension,),
     }, "Got an unexpected value for unique dimensions sets!"
     assert unique_path_keys.path_key_to_linkable_entities == {
         _base_entity.path_key: (_base_entity,)


### PR DESCRIPTION
The only_unique_path_keys property in LinkableElementSet previously
did a simple length check on the value tuple for each element type,
meaning that a path key pointing to a tuple containing a lot of
duplicate elements would not be included.

This is almost certainly counter to expectation - indeed the only callsite
for this property clearly expects consolidation to a unique value.
The issue with this is some, but not all, of our LinkableElementSet
operations do distinct value filtering. For example, the merge_by_path_key
does not do such filtering, while the intersection_by_path_key does.

Furthermore, there is nothing stopping a callsite from creating a
set with duplicate elements, so this should probably apply the deduplication
on each call regardless.

This change adjusts the behavior to be more in line with end user
expectations. If we decide that the intersect and merge methods should
both be brought in line with allowing duplicates we can factor the
deduplication logic out later.