### PR TITLE
Types cleanup: `defined_from` -> `semantic_model_element_reference`

### DIFF
--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -233,17 +233,10 @@ class NodeEvaluatorForLinkableInstances:
                 if entity_instance_in_right_node is None:
                     raise RuntimeError(f"Could not find entity instance with name ({entity_spec_in_right_node})")
 
-                assert (
-                    len(entity_instance_in_right_node.defined_from) == 1
-                ), f"Did not get exactly 1 defined_from in {entity_instance_in_right_node}"
-
-                entity_in_right_node = self._semantic_model_lookup.get_entity_in_semantic_model(
-                    entity_instance_in_right_node.defined_from[0]
-                )
+                element_reference = entity_instance_in_right_node.checked_origin_semantic_model_reference
+                entity_in_right_node = self._semantic_model_lookup.get_entity_in_semantic_model(element_reference)
                 if entity_in_right_node is None:
-                    raise RuntimeError(
-                        f"Invalid SemanticModelElementReference {entity_instance_in_right_node.defined_from[0]}"
-                    )
+                    raise RuntimeError(f"Invalid SemanticModelElementReference {element_reference}")
 
                 entity_instance_in_left_node = None
                 for instance in left_node_instance_set.entity_instances:
@@ -255,14 +248,9 @@ class NodeEvaluatorForLinkableInstances:
                     # The right node can have a superset of entities.
                     continue
 
-                assert len(entity_instance_in_left_node.defined_from) == 1
-                assert len(entity_instance_in_right_node.defined_from) == 1
-
                 if not self._join_evaluator.is_valid_semantic_model_join(
-                    left_semantic_model_reference=entity_instance_in_left_node.defined_from[0].semantic_model_reference,
-                    right_semantic_model_reference=entity_instance_in_right_node.defined_from[
-                        0
-                    ].semantic_model_reference,
+                    left_semantic_model_reference=entity_instance_in_left_node.checked_origin_semantic_model_reference.semantic_model_reference,
+                    right_semantic_model_reference=entity_instance_in_right_node.checked_origin_semantic_model_reference.semantic_model_reference,
                     on_entity_reference=entity_spec_in_right_node.reference,
                 ):
                     # If joining to ComputeMetricsNode, the right node is pre-aggregated.

--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -233,7 +233,7 @@ class NodeEvaluatorForLinkableInstances:
                 if entity_instance_in_right_node is None:
                     raise RuntimeError(f"Could not find entity instance with name ({entity_spec_in_right_node})")
 
-                element_reference = entity_instance_in_right_node.checked_origin_semantic_model_reference
+                element_reference = entity_instance_in_right_node.checked_semantic_model_element_reference
                 entity_in_right_node = self._semantic_model_lookup.get_entity_in_semantic_model(element_reference)
                 if entity_in_right_node is None:
                     raise RuntimeError(f"Invalid SemanticModelElementReference {element_reference}")
@@ -249,8 +249,8 @@ class NodeEvaluatorForLinkableInstances:
                     continue
 
                 if not self._join_evaluator.is_valid_semantic_model_join(
-                    left_semantic_model_reference=entity_instance_in_left_node.checked_origin_semantic_model_reference.semantic_model_reference,
-                    right_semantic_model_reference=entity_instance_in_right_node.checked_origin_semantic_model_reference.semantic_model_reference,
+                    left_semantic_model_reference=entity_instance_in_left_node.checked_semantic_model_element_reference.semantic_model_reference,
+                    right_semantic_model_reference=entity_instance_in_right_node.checked_semantic_model_element_reference.semantic_model_reference,
                     on_entity_reference=entity_spec_in_right_node.reference,
                 ):
                     # If joining to ComputeMetricsNode, the right node is pre-aggregated.

--- a/metricflow/dataset/convert_semantic_model.py
+++ b/metricflow/dataset/convert_semantic_model.py
@@ -95,11 +95,9 @@ class SemanticModelToDataSetConverter:
         return DimensionInstance(
             associated_columns=(self._column_association_resolver.resolve_spec(dimension_spec),),
             spec=dimension_spec,
-            defined_from=(
-                SemanticModelElementReference(
-                    semantic_model_name=semantic_model_name,
-                    element_name=dimension.reference.element_name,
-                ),
+            origin_semantic_model_reference=SemanticModelElementReference(
+                semantic_model_name=semantic_model_name,
+                element_name=dimension.reference.element_name,
             ),
         )
 
@@ -122,15 +120,10 @@ class SemanticModelToDataSetConverter:
         return TimeDimensionInstance(
             associated_columns=(self._column_association_resolver.resolve_spec(time_dimension_spec),),
             spec=time_dimension_spec,
-            defined_from=(
-                (
-                    SemanticModelElementReference(
-                        semantic_model_name=semantic_model_name,
-                        element_name=element_name,
-                    ),
-                )
+            origin_semantic_model_reference=(
+                SemanticModelElementReference(semantic_model_name=semantic_model_name, element_name=element_name)
                 if semantic_model_name
-                else ()
+                else None
             ),
         )
 
@@ -148,11 +141,8 @@ class SemanticModelToDataSetConverter:
         return EntityInstance(
             associated_columns=(self._column_association_resolver.resolve_spec(entity_spec),),
             spec=entity_spec,
-            defined_from=(
-                SemanticModelElementReference(
-                    semantic_model_name=semantic_model_name,
-                    element_name=entity.reference.element_name,
-                ),
+            origin_semantic_model_reference=SemanticModelElementReference(
+                semantic_model_name=semantic_model_name, element_name=entity.reference.element_name
             ),
         )
 
@@ -198,11 +188,8 @@ class SemanticModelToDataSetConverter:
             measure_instance = MeasureInstance(
                 associated_columns=(self._column_association_resolver.resolve_spec(measure_spec),),
                 spec=measure_spec,
-                defined_from=(
-                    SemanticModelElementReference(
-                        semantic_model_name=semantic_model_name,
-                        element_name=measure.reference.element_name,
-                    ),
+                origin_semantic_model_reference=SemanticModelElementReference(
+                    semantic_model_name=semantic_model_name, element_name=measure.reference.element_name
                 ),
                 aggregation_state=AggregationState.NON_AGGREGATED,
             )

--- a/metricflow/dataset/convert_semantic_model.py
+++ b/metricflow/dataset/convert_semantic_model.py
@@ -95,7 +95,7 @@ class SemanticModelToDataSetConverter:
         return DimensionInstance(
             associated_columns=(self._column_association_resolver.resolve_spec(dimension_spec),),
             spec=dimension_spec,
-            origin_semantic_model_reference=SemanticModelElementReference(
+            semantic_model_element_reference=SemanticModelElementReference(
                 semantic_model_name=semantic_model_name,
                 element_name=dimension.reference.element_name,
             ),
@@ -120,7 +120,7 @@ class SemanticModelToDataSetConverter:
         return TimeDimensionInstance(
             associated_columns=(self._column_association_resolver.resolve_spec(time_dimension_spec),),
             spec=time_dimension_spec,
-            origin_semantic_model_reference=(
+            semantic_model_element_reference=(
                 SemanticModelElementReference(semantic_model_name=semantic_model_name, element_name=element_name)
                 if semantic_model_name
                 else None
@@ -141,7 +141,7 @@ class SemanticModelToDataSetConverter:
         return EntityInstance(
             associated_columns=(self._column_association_resolver.resolve_spec(entity_spec),),
             spec=entity_spec,
-            origin_semantic_model_reference=SemanticModelElementReference(
+            semantic_model_element_reference=SemanticModelElementReference(
                 semantic_model_name=semantic_model_name, element_name=entity.reference.element_name
             ),
         )
@@ -188,7 +188,7 @@ class SemanticModelToDataSetConverter:
             measure_instance = MeasureInstance(
                 associated_columns=(self._column_association_resolver.resolve_spec(measure_spec),),
                 spec=measure_spec,
-                origin_semantic_model_reference=SemanticModelElementReference(
+                semantic_model_element_reference=SemanticModelElementReference(
                     semantic_model_name=semantic_model_name, element_name=measure.reference.element_name
                 ),
                 aggregation_state=AggregationState.NON_AGGREGATED,

--- a/metricflow/instances.py
+++ b/metricflow/instances.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generic, List, Tuple, TypeVar
+from typing import Generic, List, Optional, Tuple, TypeVar
 
 from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 from dbt_semantic_interfaces.references import MetricModelReference, SemanticModelElementReference
@@ -56,26 +56,19 @@ class MdoInstance(ABC, Generic[SpecT]):
 
 @dataclass(frozen=True)
 class SemanticModelElementInstance(SerializableDataclass):  # noqa: D101
-    # This instance is derived from something defined in a semantic model.
-    defined_from: Tuple[SemanticModelElementReference, ...]
+    origin_semantic_model_reference: Optional[SemanticModelElementReference]
 
     @property
-    def origin_semantic_model_reference(self) -> SemanticModelElementReference:
-        """Property to grab the element reference pointing to the origin semantic model for this element instance.
+    def checked_origin_semantic_model_reference(self) -> SemanticModelElementReference:
+        """Get origin_semantic_model_reference, error if it doesn't exist.
 
-        By convention this is the zeroth element in the Tuple. At this time these tuples are always of exactly
-        length 1, so the simple assertions here work.
-
-        TODO: make this a required input value, rather than a derived property on these objects
+        Mostly used for type-checking simplification.
         """
-        if len(self.defined_from) != 1:
+        if self.origin_semantic_model_reference is None:
             raise ValueError(
-                f"SemanticModelElementInstances should have exactly one entry in the `defined_from` property, because "
-                f"otherwise there is no way to ensure that the first element is always the origin semantic model! Found "
-                f"{len(self.defined_from)} elements in this particular instance: {self.defined_from}."
+                f"Expected origin_semantic_model_reference for SemanticModelElementInstance, but found none. Instance: {self}"
             )
-
-        return self.defined_from[0]
+        return self.origin_semantic_model_reference
 
 
 @dataclass(frozen=True)

--- a/metricflow/instances.py
+++ b/metricflow/instances.py
@@ -56,19 +56,19 @@ class MdoInstance(ABC, Generic[SpecT]):
 
 @dataclass(frozen=True)
 class SemanticModelElementInstance(SerializableDataclass):  # noqa: D101
-    origin_semantic_model_reference: Optional[SemanticModelElementReference]
+    semantic_model_element_reference: Optional[SemanticModelElementReference]
 
     @property
-    def checked_origin_semantic_model_reference(self) -> SemanticModelElementReference:
-        """Get origin_semantic_model_reference, error if it doesn't exist.
+    def checked_semantic_model_element_reference(self) -> SemanticModelElementReference:
+        """Get semantic_model_element_reference, error if it doesn't exist.
 
         Mostly used for type-checking simplification.
         """
-        if self.origin_semantic_model_reference is None:
+        if self.semantic_model_element_reference is None:
             raise ValueError(
-                f"Expected origin_semantic_model_reference for SemanticModelElementInstance, but found none. Instance: {self}"
+                f"Expected semantic_model_element_reference for SemanticModelElementInstance, but found none. Instance: {self}"
             )
-        return self.origin_semantic_model_reference
+        return self.semantic_model_element_reference
 
 
 @dataclass(frozen=True)

--- a/metricflow/model/semantics/semantic_model_join_evaluator.py
+++ b/metricflow/model/semantics/semantic_model_join_evaluator.py
@@ -235,7 +235,7 @@ class SemanticModelJoinEvaluator:
             f"Not exactly 1 matching entity instances found: {matching_entity_instances} for {entity_reference} in "
             f"{mf_pformat(instance_set)}"
         )
-        return matching_entity_instances[0].checked_origin_semantic_model_reference.semantic_model_reference
+        return matching_entity_instances[0].checked_semantic_model_element_reference.semantic_model_reference
 
     def is_valid_instance_set_join(
         self,

--- a/metricflow/model/semantics/semantic_model_join_evaluator.py
+++ b/metricflow/model/semantics/semantic_model_join_evaluator.py
@@ -226,17 +226,16 @@ class SemanticModelJoinEvaluator:
         entity_reference: EntityReference,
     ) -> SemanticModelReference:
         """Return the semantic model where the entity was defined in the instance set."""
-        matching_instances: List[EntityInstance] = []
+        matching_entity_instances: List[EntityInstance] = []
         for entity_instance in instance_set.entity_instances:
-            assert len(entity_instance.defined_from) == 1
             if len(entity_instance.spec.entity_links) == 0 and entity_instance.spec.reference == entity_reference:
-                matching_instances.append(entity_instance)
+                matching_entity_instances.append(entity_instance)
 
-        assert len(matching_instances) == 1, (
-            f"Not exactly 1 matching entity instances found: {matching_instances} for {entity_reference} in "
+        assert len(matching_entity_instances) == 1, (
+            f"Not exactly 1 matching entity instances found: {matching_entity_instances} for {entity_reference} in "
             f"{mf_pformat(instance_set)}"
         )
-        return matching_instances[0].origin_semantic_model_reference.semantic_model_reference
+        return matching_entity_instances[0].checked_origin_semantic_model_reference.semantic_model_reference
 
     def is_valid_instance_set_join(
         self,

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -230,7 +230,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         day.
         """
         time_spine_instance = TimeDimensionInstance(
-            defined_from=agg_time_dimension_instance.defined_from,
+            origin_semantic_model_reference=agg_time_dimension_instance.origin_semantic_model_reference,
             associated_columns=(
                 ColumnAssociation(
                     column_name=agg_time_dimension_column_name,
@@ -1077,11 +1077,11 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         output_measure_instances = []
         for measure_instance in input_data_set.instance_set.measure_instances:
             semantic_model = self._semantic_model_lookup.get_by_reference(
-                semantic_model_reference=measure_instance.origin_semantic_model_reference.semantic_model_reference
+                semantic_model_reference=measure_instance.checked_origin_semantic_model_reference.semantic_model_reference
             )
             assert semantic_model is not None, (
                 f"{measure_instance} was defined from "
-                f"{measure_instance.origin_semantic_model_reference.semantic_model_reference}, but that can't be found"
+                f"{measure_instance.checked_origin_semantic_model_reference.semantic_model_reference}, but that can't be found"
             )
             aggregation_time_dimension_for_measure = semantic_model.checked_agg_time_dimension_for_measure(
                 measure_reference=measure_instance.spec.reference
@@ -1090,7 +1090,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                 output_measure_instances.append(measure_instance)
 
         # Find time dimension instances that refer to the same dimension as the one specified in the node.
-        matching_time_dimension_instances = []
+        matching_time_dimension_instances: List[TimeDimensionInstance] = []
         for time_dimension_instance in input_data_set.instance_set.time_dimension_instances:
             # The specification for the time dimension to use for aggregation is the local one.
             if (
@@ -1114,7 +1114,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             )
             output_time_dimension_instances.append(
                 TimeDimensionInstance(
-                    defined_from=matching_time_dimension_instance.defined_from,
+                    origin_semantic_model_reference=matching_time_dimension_instance.origin_semantic_model_reference,
                     associated_columns=(self._column_association_resolver.resolve_spec(metric_time_dimension_spec),),
                     spec=metric_time_dimension_spec,
                 )
@@ -1430,7 +1430,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                 aggregation_state=original_time_spine_dim_instance.spec.aggregation_state,
             )
             time_spine_dim_instance = TimeDimensionInstance(
-                defined_from=original_time_spine_dim_instance.defined_from,
+                origin_semantic_model_reference=original_time_spine_dim_instance.origin_semantic_model_reference,
                 associated_columns=(self._column_association_resolver.resolve_spec(time_dim_spec),),
                 spec=time_dim_spec,
             )

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -230,7 +230,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         day.
         """
         time_spine_instance = TimeDimensionInstance(
-            origin_semantic_model_reference=agg_time_dimension_instance.origin_semantic_model_reference,
+            semantic_model_element_reference=agg_time_dimension_instance.semantic_model_element_reference,
             associated_columns=(
                 ColumnAssociation(
                     column_name=agg_time_dimension_column_name,
@@ -1077,11 +1077,11 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         output_measure_instances = []
         for measure_instance in input_data_set.instance_set.measure_instances:
             semantic_model = self._semantic_model_lookup.get_by_reference(
-                semantic_model_reference=measure_instance.checked_origin_semantic_model_reference.semantic_model_reference
+                semantic_model_reference=measure_instance.checked_semantic_model_element_reference.semantic_model_reference
             )
             assert semantic_model is not None, (
                 f"{measure_instance} was defined from "
-                f"{measure_instance.checked_origin_semantic_model_reference.semantic_model_reference}, but that can't be found"
+                f"{measure_instance.checked_semantic_model_element_reference.semantic_model_reference}, but that can't be found"
             )
             aggregation_time_dimension_for_measure = semantic_model.checked_agg_time_dimension_for_measure(
                 measure_reference=measure_instance.spec.reference
@@ -1114,7 +1114,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             )
             output_time_dimension_instances.append(
                 TimeDimensionInstance(
-                    origin_semantic_model_reference=matching_time_dimension_instance.origin_semantic_model_reference,
+                    semantic_model_element_reference=matching_time_dimension_instance.semantic_model_element_reference,
                     associated_columns=(self._column_association_resolver.resolve_spec(metric_time_dimension_spec),),
                     spec=metric_time_dimension_spec,
                 )
@@ -1430,7 +1430,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                 aggregation_state=original_time_spine_dim_instance.spec.aggregation_state,
             )
             time_spine_dim_instance = TimeDimensionInstance(
-                origin_semantic_model_reference=original_time_spine_dim_instance.origin_semantic_model_reference,
+                semantic_model_element_reference=original_time_spine_dim_instance.semantic_model_element_reference,
                 associated_columns=(self._column_association_resolver.resolve_spec(time_dim_spec),),
                 spec=time_dim_spec,
             )

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -333,7 +333,7 @@ class CreateValidityWindowJoinDescription(InstanceSetTransform[Optional[Validity
         semantic_model_to_window: Dict[SemanticModelReference, ValidityWindowJoinDescription] = {}
         instances_by_semantic_model = bucket(
             instance_set.time_dimension_instances,
-            lambda x: x.checked_origin_semantic_model_reference.semantic_model_reference,
+            lambda x: x.checked_semantic_model_element_reference.semantic_model_reference,
         )
         for semantic_model_reference in instances_by_semantic_model:
             validity_dims = self._get_validity_window_dimensions_for_semantic_model(semantic_model_reference)
@@ -410,7 +410,7 @@ class AddLinkToLinkableElements(InstanceSetTransform[InstanceSet]):
             dimension_instances_with_additional_link.append(
                 DimensionInstance(
                     associated_columns=dimension_instance.associated_columns,
-                    origin_semantic_model_reference=dimension_instance.origin_semantic_model_reference,
+                    semantic_model_element_reference=dimension_instance.semantic_model_element_reference,
                     spec=transformed_dimension_spec_from_right,
                 )
             )
@@ -431,7 +431,7 @@ class AddLinkToLinkableElements(InstanceSetTransform[InstanceSet]):
             time_dimension_instances_with_additional_link.append(
                 TimeDimensionInstance(
                     associated_columns=time_dimension_instance.associated_columns,
-                    origin_semantic_model_reference=time_dimension_instance.origin_semantic_model_reference,
+                    semantic_model_element_reference=time_dimension_instance.semantic_model_element_reference,
                     spec=transformed_time_dimension_spec_from_right,
                 )
             )
@@ -451,7 +451,7 @@ class AddLinkToLinkableElements(InstanceSetTransform[InstanceSet]):
             entity_instances_with_additional_link.append(
                 EntityInstance(
                     associated_columns=entity_instance.associated_columns,
-                    origin_semantic_model_reference=entity_instance.origin_semantic_model_reference,
+                    semantic_model_element_reference=entity_instance.semantic_model_element_reference,
                     spec=transformed_entity_spec_from_right,
                 )
             )
@@ -613,7 +613,7 @@ class ChangeMeasureAggregationState(InstanceSetTransform[InstanceSet]):
         measure_instances = tuple(
             MeasureInstance(
                 associated_columns=x.associated_columns,
-                origin_semantic_model_reference=x.origin_semantic_model_reference,
+                semantic_model_element_reference=x.semantic_model_element_reference,
                 aggregation_state=self._aggregation_state_changes[x.aggregation_state],
                 spec=x.spec,
             )
@@ -654,7 +654,7 @@ class UpdateMeasureFillNullsWith(InstanceSetTransform[InstanceSet]):
                     associated_columns=instance.associated_columns,
                     spec=measure_spec,
                     aggregation_state=instance.aggregation_state,
-                    origin_semantic_model_reference=instance.origin_semantic_model_reference,
+                    semantic_model_element_reference=instance.semantic_model_element_reference,
                 )
             )
 
@@ -709,7 +709,7 @@ class AliasAggregatedMeasures(InstanceSetTransform[InstanceSet]):
                     associated_columns=instance.associated_columns,
                     spec=measure_spec,
                     aggregation_state=instance.aggregation_state,
-                    origin_semantic_model_reference=instance.origin_semantic_model_reference,
+                    semantic_model_element_reference=instance.semantic_model_element_reference,
                 )
             )
 
@@ -942,7 +942,7 @@ class ChangeAssociatedColumns(InstanceSetTransform[InstanceSet]):
                 MeasureInstance(
                     associated_columns=(self._column_association_resolver.resolve_spec(input_measure_instance.spec),),
                     spec=input_measure_instance.spec,
-                    origin_semantic_model_reference=input_measure_instance.origin_semantic_model_reference,
+                    semantic_model_element_reference=input_measure_instance.semantic_model_element_reference,
                     aggregation_state=input_measure_instance.aggregation_state,
                 )
             )
@@ -953,7 +953,7 @@ class ChangeAssociatedColumns(InstanceSetTransform[InstanceSet]):
                 DimensionInstance(
                     associated_columns=(self._column_association_resolver.resolve_spec(input_dimension_instance.spec),),
                     spec=input_dimension_instance.spec,
-                    origin_semantic_model_reference=input_dimension_instance.origin_semantic_model_reference,
+                    semantic_model_element_reference=input_dimension_instance.semantic_model_element_reference,
                 )
             )
 
@@ -965,7 +965,7 @@ class ChangeAssociatedColumns(InstanceSetTransform[InstanceSet]):
                         self._column_association_resolver.resolve_spec(input_time_dimension_instance.spec),
                     ),
                     spec=input_time_dimension_instance.spec,
-                    origin_semantic_model_reference=input_time_dimension_instance.origin_semantic_model_reference,
+                    semantic_model_element_reference=input_time_dimension_instance.semantic_model_element_reference,
                 )
             )
 
@@ -975,7 +975,7 @@ class ChangeAssociatedColumns(InstanceSetTransform[InstanceSet]):
                 EntityInstance(
                     associated_columns=(self._column_association_resolver.resolve_spec(input_entity_instance.spec),),
                     spec=input_entity_instance.spec,
-                    origin_semantic_model_reference=input_entity_instance.origin_semantic_model_reference,
+                    semantic_model_element_reference=input_entity_instance.semantic_model_element_reference,
                 )
             )
 

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -332,7 +332,8 @@ class CreateValidityWindowJoinDescription(InstanceSetTransform[Optional[Validity
         """
         semantic_model_to_window: Dict[SemanticModelReference, ValidityWindowJoinDescription] = {}
         instances_by_semantic_model = bucket(
-            instance_set.time_dimension_instances, lambda x: x.origin_semantic_model_reference.semantic_model_reference
+            instance_set.time_dimension_instances,
+            lambda x: x.checked_origin_semantic_model_reference.semantic_model_reference,
         )
         for semantic_model_reference in instances_by_semantic_model:
             validity_dims = self._get_validity_window_dimensions_for_semantic_model(semantic_model_reference)
@@ -409,7 +410,7 @@ class AddLinkToLinkableElements(InstanceSetTransform[InstanceSet]):
             dimension_instances_with_additional_link.append(
                 DimensionInstance(
                     associated_columns=dimension_instance.associated_columns,
-                    defined_from=dimension_instance.defined_from,
+                    origin_semantic_model_reference=dimension_instance.origin_semantic_model_reference,
                     spec=transformed_dimension_spec_from_right,
                 )
             )
@@ -430,7 +431,7 @@ class AddLinkToLinkableElements(InstanceSetTransform[InstanceSet]):
             time_dimension_instances_with_additional_link.append(
                 TimeDimensionInstance(
                     associated_columns=time_dimension_instance.associated_columns,
-                    defined_from=time_dimension_instance.defined_from,
+                    origin_semantic_model_reference=time_dimension_instance.origin_semantic_model_reference,
                     spec=transformed_time_dimension_spec_from_right,
                 )
             )
@@ -450,7 +451,7 @@ class AddLinkToLinkableElements(InstanceSetTransform[InstanceSet]):
             entity_instances_with_additional_link.append(
                 EntityInstance(
                     associated_columns=entity_instance.associated_columns,
-                    defined_from=entity_instance.defined_from,
+                    origin_semantic_model_reference=entity_instance.origin_semantic_model_reference,
                     spec=transformed_entity_spec_from_right,
                 )
             )
@@ -612,7 +613,7 @@ class ChangeMeasureAggregationState(InstanceSetTransform[InstanceSet]):
         measure_instances = tuple(
             MeasureInstance(
                 associated_columns=x.associated_columns,
-                defined_from=x.defined_from,
+                origin_semantic_model_reference=x.origin_semantic_model_reference,
                 aggregation_state=self._aggregation_state_changes[x.aggregation_state],
                 spec=x.spec,
             )
@@ -653,7 +654,7 @@ class UpdateMeasureFillNullsWith(InstanceSetTransform[InstanceSet]):
                     associated_columns=instance.associated_columns,
                     spec=measure_spec,
                     aggregation_state=instance.aggregation_state,
-                    defined_from=instance.defined_from,
+                    origin_semantic_model_reference=instance.origin_semantic_model_reference,
                 )
             )
 
@@ -708,7 +709,7 @@ class AliasAggregatedMeasures(InstanceSetTransform[InstanceSet]):
                     associated_columns=instance.associated_columns,
                     spec=measure_spec,
                     aggregation_state=instance.aggregation_state,
-                    defined_from=instance.defined_from,
+                    origin_semantic_model_reference=instance.origin_semantic_model_reference,
                 )
             )
 
@@ -941,7 +942,7 @@ class ChangeAssociatedColumns(InstanceSetTransform[InstanceSet]):
                 MeasureInstance(
                     associated_columns=(self._column_association_resolver.resolve_spec(input_measure_instance.spec),),
                     spec=input_measure_instance.spec,
-                    defined_from=input_measure_instance.defined_from,
+                    origin_semantic_model_reference=input_measure_instance.origin_semantic_model_reference,
                     aggregation_state=input_measure_instance.aggregation_state,
                 )
             )
@@ -952,7 +953,7 @@ class ChangeAssociatedColumns(InstanceSetTransform[InstanceSet]):
                 DimensionInstance(
                     associated_columns=(self._column_association_resolver.resolve_spec(input_dimension_instance.spec),),
                     spec=input_dimension_instance.spec,
-                    defined_from=input_dimension_instance.defined_from,
+                    origin_semantic_model_reference=input_dimension_instance.origin_semantic_model_reference,
                 )
             )
 
@@ -964,7 +965,7 @@ class ChangeAssociatedColumns(InstanceSetTransform[InstanceSet]):
                         self._column_association_resolver.resolve_spec(input_time_dimension_instance.spec),
                     ),
                     spec=input_time_dimension_instance.spec,
-                    defined_from=input_time_dimension_instance.defined_from,
+                    origin_semantic_model_reference=input_time_dimension_instance.origin_semantic_model_reference,
                 )
             )
 
@@ -974,7 +975,7 @@ class ChangeAssociatedColumns(InstanceSetTransform[InstanceSet]):
                 EntityInstance(
                     associated_columns=(self._column_association_resolver.resolve_spec(input_entity_instance.spec),),
                     spec=input_entity_instance.spec,
-                    defined_from=input_entity_instance.defined_from,
+                    origin_semantic_model_reference=input_entity_instance.origin_semantic_model_reference,
                 )
             )
 

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -133,7 +133,7 @@ class PreJoinNodeProcessor:
             if len(entity_spec_in_first_node.entity_links) > 0:
                 continue
 
-            element_reference = entity_instance_in_first_node.checked_origin_semantic_model_reference
+            element_reference = entity_instance_in_first_node.checked_semantic_model_element_reference
             entity = self._semantic_model_lookup.get_entity_in_semantic_model(element_reference)
             if entity is None:
                 raise RuntimeError(f"Invalid SemanticModelElementReference {element_reference}")

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -133,17 +133,10 @@ class PreJoinNodeProcessor:
             if len(entity_spec_in_first_node.entity_links) > 0:
                 continue
 
-            assert (
-                len(entity_instance_in_first_node.defined_from) == 1
-            ), "Multiple items in defined_from not yet supported"
-
-            entity = self._semantic_model_lookup.get_entity_in_semantic_model(
-                entity_instance_in_first_node.defined_from[0]
-            )
+            element_reference = entity_instance_in_first_node.checked_origin_semantic_model_reference
+            entity = self._semantic_model_lookup.get_entity_in_semantic_model(element_reference)
             if entity is None:
-                raise RuntimeError(
-                    f"Invalid SemanticModelElementReference {entity_instance_in_first_node.defined_from[0]}"
-                )
+                raise RuntimeError(f"Invalid SemanticModelElementReference {element_reference}")
 
             return True
 

--- a/tests/dataflow/builder/test_node_data_set.py
+++ b/tests/dataflow/builder/test_node_data_set.py
@@ -52,7 +52,7 @@ def test_no_parent_node_data_set(
                             column_name="bookings", single_column_correlation_key=SingleColumnCorrelationKey()
                         ),
                     ),
-                    origin_semantic_model_reference=SemanticModelElementReference(
+                    semantic_model_element_reference=SemanticModelElementReference(
                         semantic_model_name="fct_bookings_semantic_model", element_name="bookings"
                     ),
                     spec=MeasureSpec(

--- a/tests/dataflow/builder/test_node_data_set.py
+++ b/tests/dataflow/builder/test_node_data_set.py
@@ -52,10 +52,8 @@ def test_no_parent_node_data_set(
                             column_name="bookings", single_column_correlation_key=SingleColumnCorrelationKey()
                         ),
                     ),
-                    defined_from=(
-                        SemanticModelElementReference(
-                            semantic_model_name="fct_bookings_semantic_model", element_name="bookings"
-                        ),
+                    origin_semantic_model_reference=SemanticModelElementReference(
+                        semantic_model_name="fct_bookings_semantic_model", element_name="bookings"
                     ),
                     spec=MeasureSpec(
                         element_name="bookings",


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Removes `SemanticModelElementInstance.defined_from` property in favor of `SemanticModelElementInstance.semantic_model_element_reference` made these changes:
1. There could never be multiple items in the tuple. It either contained one `SemanticModelElementReference` or was empty. This resulted in a lot of unnecessary type checking boilerplate code scattered throughout the codebase. Instead, I updated the type to be one optional `SemanticModelElementReference`.
2. This still left a lot of type assertions to make sure it wasn't `None`, so I added the `checked_semantic_model_element_reference` property to use wherever that assertion would be needed.
3. There was a TODO on the `origin_semantic_model_reference` property stating: `TODO: make this a required input value, rather than a derived property on these objects` so i went ahead and did that, replacing `defined_from` with `origin_semantic_model_reference` as a dataclass attribute.
4. Then I realized that `origin_semantic_model_reference` is not actually a `SemanticModelReference` as the name suggests. It's a `SemanticModelElementReference`. So I changed the name to be `origin_semantic_model_element_reference`. That was really long. So I removed the `origin_` prefix, shortening it to `semantic_model_element_reference`.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  5. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  6. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
