### PR TITLE
Use query parser to build group by metric source node

### DIFF
--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -33,6 +33,7 @@ from metricflow_semantics.protocols.query_parameter import (
 )
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_pattern_factory import (
     DefaultWhereFilterPatternFactory,
+    WhereFilterPatternFactory,
 )
 from metricflow_semantics.query.group_by_item.group_by_item_resolver import GroupByItemResolver
 from metricflow_semantics.query.group_by_item.resolution_dag.dag import GroupByItemResolutionDag
@@ -82,14 +83,18 @@ class MetricFlowQueryParser:
     TODO: Add fuzzy match results.
     """
 
-    def __init__(self, semantic_manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
+    def __init__(  # noqa: D107
+        self,
+        semantic_manifest_lookup: SemanticManifestLookup,
+        where_filter_pattern_factory: WhereFilterPatternFactory = DefaultWhereFilterPatternFactory(),
+    ) -> None:
         self._manifest_lookup = semantic_manifest_lookup
         self._metric_naming_schemes = (MetricNamingScheme(),)
         self._group_by_item_naming_schemes = (
             ObjectBuilderNamingScheme(),
             DunderNamingScheme(),
         )
-        self._where_filter_pattern_factory = DefaultWhereFilterPatternFactory()
+        self._where_filter_pattern_factory = where_filter_pattern_factory
 
     def parse_and_validate_saved_query(
         self,
@@ -524,7 +529,7 @@ class MetricFlowQueryParser:
     def build_query_spec_for_group_by_metric_source_node(
         self, group_by_metric_spec: GroupByMetricSpec
     ) -> MetricFlowQuerySpec:
-        """Query spec that can be used to build a source node for this spec in the DFP."""
+        """Query spec that can be used to build a source node for this spec in the DataflowPlanBuilder."""
         return self.parse_and_validate_query(
             metrics=(MetricParameter(group_by_metric_spec.reference.element_name),),
             group_by=(DimensionOrEntityParameter(group_by_metric_spec.entity_spec.qualified_name),),

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -55,8 +55,10 @@ from metricflow_semantics.query.resolver_inputs.query_resolver_inputs import (
 from metricflow_semantics.specs.patterns.base_time_grain import BaseTimeGrainPattern
 from metricflow_semantics.specs.patterns.metric_time_pattern import MetricTimePattern
 from metricflow_semantics.specs.patterns.none_date_part import NoneDatePartPattern
+from metricflow_semantics.specs.query_param_implementations import DimensionOrEntityParameter, MetricParameter
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.specs.spec_classes import (
+    GroupByMetricSpec,
     InstanceSpec,
     TimeDimensionSpec,
 )
@@ -517,6 +519,15 @@ class MetricFlowQueryParser:
         return ParseQueryResult(
             query_spec=query_spec,
             queried_semantic_models=query_resolution.queried_semantic_models,
+        )
+
+    def build_query_spec_for_group_by_metric_source_node(
+        self, group_by_metric_spec: GroupByMetricSpec
+    ) -> MetricFlowQuerySpec:
+        """Query spec that can be used to build a source node for this spec in the DFP."""
+        return self.parse_and_validate_query(
+            metrics=(MetricParameter(group_by_metric_spec.reference.element_name),),
+            group_by=(DimensionOrEntityParameter(group_by_metric_spec.entity_spec.qualified_name),),
         )
 
 

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -33,7 +33,6 @@ from metricflow_semantics.protocols.query_parameter import (
 )
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_pattern_factory import (
     DefaultWhereFilterPatternFactory,
-    WhereFilterPatternFactory,
 )
 from metricflow_semantics.query.group_by_item.group_by_item_resolver import GroupByItemResolver
 from metricflow_semantics.query.group_by_item.resolution_dag.dag import GroupByItemResolutionDag
@@ -81,18 +80,14 @@ class MetricFlowQueryParser:
     TODO: Add fuzzy match results.
     """
 
-    def __init__(  # noqa: D107
-        self,
-        semantic_manifest_lookup: SemanticManifestLookup,
-        where_filter_pattern_factory: WhereFilterPatternFactory = DefaultWhereFilterPatternFactory(),
-    ) -> None:
+    def __init__(self, semantic_manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
         self._manifest_lookup = semantic_manifest_lookup
         self._metric_naming_schemes = (MetricNamingScheme(),)
         self._group_by_item_naming_schemes = (
             ObjectBuilderNamingScheme(),
             DunderNamingScheme(),
         )
-        self._where_filter_pattern_factory = where_filter_pattern_factory
+        self._where_filter_pattern_factory = DefaultWhereFilterPatternFactory()
 
     def parse_and_validate_saved_query(
         self,

--- a/metricflow-semantics/metricflow_semantics/specs/spec_classes.py
+++ b/metricflow-semantics/metricflow_semantics/specs/spec_classes.py
@@ -692,6 +692,16 @@ class GroupByMetricSpec(LinkableInstanceSpec, SerializableDataclass):
     def without_entity_links(self) -> GroupByMetricSpec:  # noqa: D102
         return GroupByMetricSpec(element_name=self.element_name, entity_links=())
 
+    @property
+    def last_entity_link(self) -> EntityReference:  # noqa: D102
+        assert len(self.entity_links) > 0, f"Spec does not have any entity links: {self}"
+        return self.entity_links[-1]
+
+    @property
+    def entity_spec(self) -> EntitySpec:
+        """Entity that the metric will be grouped by on aggregation."""
+        return EntitySpec(element_name=self.last_entity_link.element_name, entity_links=self.entity_links[:-1])
+
     @staticmethod
     def from_name(name: str) -> GroupByMetricSpec:  # noqa: D102
         structured_name = StructuredLinkableSpecName.from_name(name)

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_ambiguous_entity_path.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_ambiguous_entity_path.py
@@ -5,9 +5,6 @@ import logging
 import pytest
 from _pytest.fixtures import FixtureRequest
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_pattern_factory import (
-    DefaultWhereFilterPatternFactory,
-)
 from metricflow_semantics.query.query_exceptions import InvalidQueryException
 from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_ambiguous_entity_path.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_ambiguous_entity_path.py
@@ -20,10 +20,7 @@ logger = logging.getLogger(__name__)
 def multi_hop_query_parser(  # noqa: D103
     simple_multi_hop_join_manifest_lookup: SemanticManifestLookup,
 ) -> MetricFlowQueryParser:
-    return MetricFlowQueryParser(
-        semantic_manifest_lookup=simple_multi_hop_join_manifest_lookup,
-        where_filter_pattern_factory=DefaultWhereFilterPatternFactory(),
-    )
+    return MetricFlowQueryParser(semantic_manifest_lookup=simple_multi_hop_join_manifest_lookup)
 
 
 def test_resolvable_ambiguous_entity_path(  # noqa: D103

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -829,7 +829,7 @@ class DataflowPlanBuilder:
         # MetricGroupBy source nodes could be extremely large (and potentially slow).
         candidate_nodes_for_right_side_of_join += [
             self._build_query_output_node(
-                query_spec=self._source_node_builder.build_source_node_for_group_by_metric(group_by_metric_spec),
+                query_spec=self._source_node_builder.build_source_node_inputs_for_group_by_metric(group_by_metric_spec),
                 for_group_by_source_node=True,
             )
             for group_by_metric_spec in linkable_spec_set.group_by_metric_specs

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -40,7 +40,6 @@ from metricflow_semantics.specs.spec_classes import (
     ConstantPropertySpec,
     CumulativeMeasureDescription,
     EntitySpec,
-    GroupByMetricSpec,
     JoinToTimeSpineDescription,
     LinkableInstanceSpec,
     LinklessEntitySpec,
@@ -63,7 +62,7 @@ from metricflow.dataflow.builder.node_evaluator import (
     LinkableInstanceSatisfiabilityEvaluation,
     NodeEvaluatorForLinkableInstances,
 )
-from metricflow.dataflow.builder.source_node import SourceNodeSet
+from metricflow.dataflow.builder.source_node import SourceNodeBuilder, SourceNodeSet
 from metricflow.dataflow.dataflow_plan import (
     BaseOutput,
     DataflowPlan,
@@ -126,6 +125,7 @@ class DataflowPlanBuilder:
         semantic_manifest_lookup: SemanticManifestLookup,
         node_output_resolver: DataflowPlanNodeOutputDataSetResolver,
         column_association_resolver: ColumnAssociationResolver,
+        source_node_builder: SourceNodeBuilder,
     ) -> None:
         self._semantic_model_lookup = semantic_manifest_lookup.semantic_model_lookup
         self._metric_lookup = semantic_manifest_lookup.metric_lookup
@@ -133,6 +133,7 @@ class DataflowPlanBuilder:
         self._source_node_set = source_node_set
         self._column_association_resolver = column_association_resolver
         self._node_data_set_resolver = node_output_resolver
+        self._source_node_builder = source_node_builder
 
     def build_plan(
         self,
@@ -813,14 +814,6 @@ class DataflowPlanBuilder:
             non_additive_dimension_spec=non_additive_dimension_spec,
         )
 
-    def _query_spec_for_source_node(self, group_by_metric_spec: GroupByMetricSpec) -> MetricFlowQuerySpec:
-        return MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name=group_by_metric_spec.element_name),),
-            entity_specs=tuple(
-                EntitySpec.from_name(entity_link.element_name) for entity_link in group_by_metric_spec.entity_links
-            ),
-        )
-
     def _find_dataflow_recipe(
         self,
         linkable_spec_set: LinkableSpecSet,
@@ -836,7 +829,8 @@ class DataflowPlanBuilder:
         # MetricGroupBy source nodes could be extremely large (and potentially slow).
         candidate_nodes_for_right_side_of_join += [
             self._build_query_output_node(
-                query_spec=self._query_spec_for_source_node(group_by_metric_spec), for_group_by_source_node=True
+                query_spec=self._source_node_builder.build_source_node_for_group_by_metric(group_by_metric_spec),
+                for_group_by_source_node=True,
             )
             for group_by_metric_spec in linkable_spec_set.group_by_metric_specs
         ]

--- a/metricflow/dataflow/builder/source_node.py
+++ b/metricflow/dataflow/builder/source_node.py
@@ -5,11 +5,12 @@ from typing import List, Sequence, Tuple
 
 from dbt_semantic_interfaces.references import TimeDimensionReference
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
+from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
+from metricflow_semantics.specs.spec_classes import GroupByMetricSpec
 
-from metricflow.dataflow.dataflow_plan import (
-    BaseOutput,
-)
+from metricflow.dataflow.dataflow_plan import BaseOutput
 from metricflow.dataflow.nodes.metric_time_transform import MetricTimeDimensionTransformNode
 from metricflow.dataflow.nodes.read_sql_source import ReadSqlSourceNode
 from metricflow.dataset.convert_semantic_model import SemanticModelToDataSetConverter
@@ -62,6 +63,7 @@ class SourceNodeBuilder:
             parent_node=ReadSqlSourceNode(data_set=time_spine_data_set),
             aggregation_time_dimension_reference=time_dim_reference,
         )
+        self._query_parser = MetricFlowQueryParser(semantic_manifest_lookup)
 
     def create_from_data_sets(self, data_sets: Sequence[SemanticModelDataSet]) -> SourceNodeSet:
         """Creates a `SourceNodeSet` from SemanticModelDataSets."""
@@ -95,3 +97,11 @@ class SourceNodeBuilder:
             source_nodes_for_group_by_item_queries=tuple(group_by_item_source_nodes) + (self._time_spine_source_node,),
             source_nodes_for_metric_queries=tuple(source_nodes_for_metric_queries),
         )
+
+    def build_source_node_for_group_by_metric(self, group_by_metric_spec: GroupByMetricSpec) -> MetricFlowQuerySpec:
+        """Build source node used to satisfy requested group by metrics.
+
+        This is just a wrapper around the query parser method, stored here to limit the scope of the DataFlowPlanBuilder's
+        dependency on the query parser to only source nodes.
+        """
+        return self._query_parser.build_query_spec_for_group_by_metric_source_node(group_by_metric_spec)

--- a/metricflow/dataflow/builder/source_node.py
+++ b/metricflow/dataflow/builder/source_node.py
@@ -98,8 +98,13 @@ class SourceNodeBuilder:
             source_nodes_for_metric_queries=tuple(source_nodes_for_metric_queries),
         )
 
-    def build_source_node_for_group_by_metric(self, group_by_metric_spec: GroupByMetricSpec) -> MetricFlowQuerySpec:
-        """Build source node used to satisfy requested group by metrics.
+    def build_source_node_inputs_for_group_by_metric(
+        self, group_by_metric_spec: GroupByMetricSpec
+    ) -> MetricFlowQuerySpec:
+        """Build source node inputs used to satisfy requested group by metrics.
+
+        Group by metrics are essentially metric subqueries that operate as source nodes in the DataflowPlanBuilder. We
+        provide the inputs here because they require an entire DataFlowPlan generation step.
 
         This is just a wrapper around the query parser method, stored here to limit the scope of the DataFlowPlanBuilder's
         dependency on the query parser to only source nodes.

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -394,6 +394,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             semantic_manifest_lookup=self._semantic_manifest_lookup,
             column_association_resolver=self._column_association_resolver,
             node_output_resolver=node_output_resolver,
+            source_node_builder=source_node_builder,
         )
         self._to_sql_query_plan_converter = DataflowToSqlQueryPlanConverter(
             column_association_resolver=self._column_association_resolver,

--- a/scripts/ci_tests/metricflow_package_test.py
+++ b/scripts/ci_tests/metricflow_package_test.py
@@ -154,6 +154,7 @@ def log_dataflow_plan() -> None:  # noqa: D103
         semantic_manifest_lookup=semantic_manifest_lookup,
         node_output_resolver=node_output_resolver,
         column_association_resolver=column_association_resolver,
+        source_node_builder=source_node_builder,
     )
 
     dataflow_plan = dataflow_plan_builder.build_plan(

--- a/tests_metricflow/fixtures/manifest_fixtures.py
+++ b/tests_metricflow/fixtures/manifest_fixtures.py
@@ -105,6 +105,7 @@ class MetricFlowEngineTestFixture:
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter
     query_parser: MetricFlowQueryParser
     metricflow_engine: MetricFlowEngine
+    source_node_builder: SourceNodeBuilder
 
     _node_output_resolver: DataflowPlanNodeOutputDataSetResolver
 
@@ -116,9 +117,8 @@ class MetricFlowEngineTestFixture:
         data_set_mapping = MetricFlowEngineTestFixture._create_data_sets(semantic_manifest_lookup)
         read_node_mapping = MetricFlowEngineTestFixture._data_set_to_read_nodes(data_set_mapping)
         column_association_resolver = DunderColumnAssociationResolver(semantic_manifest_lookup)
-        source_node_set = MetricFlowEngineTestFixture._data_set_to_source_node_set(
-            column_association_resolver, semantic_manifest_lookup, data_set_mapping
-        )
+        source_node_builder = SourceNodeBuilder(column_association_resolver, semantic_manifest_lookup)
+        source_node_set = source_node_builder.create_from_data_sets(list(data_set_mapping.values()))
         node_output_resolver = DataflowPlanNodeOutputDataSetResolver(
             column_association_resolver=column_association_resolver,
             semantic_manifest_lookup=semantic_manifest_lookup,
@@ -145,6 +145,7 @@ class MetricFlowEngineTestFixture:
                 query_parser=query_parser,
                 column_association_resolver=column_association_resolver,
             ),
+            source_node_builder=source_node_builder,
         )
 
     @property
@@ -158,6 +159,7 @@ class MetricFlowEngineTestFixture:
             semantic_manifest_lookup=self.semantic_manifest_lookup,
             node_output_resolver=self._node_output_resolver.copy(),
             column_association_resolver=self.column_association_resolver,
+            source_node_builder=self.source_node_builder,
         )
 
     @staticmethod
@@ -174,16 +176,6 @@ class MetricFlowEngineTestFixture:
             )
 
         return return_dict
-
-    @staticmethod
-    def _data_set_to_source_node_set(
-        column_association_resolver: ColumnAssociationResolver,
-        semantic_manifest_lookup: SemanticManifestLookup,
-        data_sets: OrderedDict[str, SemanticModelDataSet],
-    ) -> SourceNodeSet:
-        # Moved from model_fixtures.py.
-        source_node_builder = SourceNodeBuilder(column_association_resolver, semantic_manifest_lookup)
-        return source_node_builder.create_from_data_sets(list(data_sets.values()))
 
     @staticmethod
     def _create_data_sets(


### PR DESCRIPTION
Needed to resolve the appropriate join path for multi-hop joins. Moved source node-building logic to query parser class to avoid cirular import errors. This change also required adding the query parser as a dependency for the dataflow plan builder.

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
This is needed to resolve the appropriate join path for multi-hop joins. Currently users won't be able to pass a join path for those, so we need to build it ourselves.
Moved source node-building logic to query parser class to avoid circular import errors. This change also required adding the query parser as a dependency for the dataflow plan builder.
This doesn't change the output of any existing tests, but I have some relevant tests coming in future PRs.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
