### PR TITLE
Update DFP join logic to account for group by metric source nodes

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/linkable_spec_set.py
+++ b/metricflow-semantics/metricflow_semantics/specs/linkable_spec_set.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import itertools
 import typing
 from dataclasses import dataclass
-from typing import Dict, List, Sequence, Tuple
+from typing import Dict, List, Sequence, Set, Tuple
 
 from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
-from dbt_semantic_interfaces.references import MeasureReference, MetricReference
+from dbt_semantic_interfaces.references import LinkableElementReference, MeasureReference, MetricReference
 from typing_extensions import override
 
 from metricflow_semantics.collection_helpers.merger import Mergeable
@@ -83,6 +83,10 @@ class LinkableSpecSet(Mergeable, SerializableDataclass):
                 self.dimension_specs, self.time_dimension_specs, self.entity_specs, self.group_by_metric_specs
             )
         )
+
+    @property
+    def as_reference_set(self) -> Set[LinkableElementReference]:  # noqa: D102
+        return {spec.reference for spec in self.as_tuple}
 
     @override
     def merge(self, other: LinkableSpecSet) -> LinkableSpecSet:

--- a/metricflow-semantics/metricflow_semantics/specs/spec_classes.py
+++ b/metricflow-semantics/metricflow_semantics/specs/spec_classes.py
@@ -25,6 +25,7 @@ from dbt_semantic_interfaces.protocols import MetricTimeWindow
 from dbt_semantic_interfaces.references import (
     DimensionReference,
     EntityReference,
+    LinkableElementReference,
     MeasureReference,
     MetricReference,
     TimeDimensionReference,
@@ -175,6 +176,11 @@ class LinkableInstanceSpec(InstanceSpec, ABC):
         return StructuredLinkableSpecName(
             entity_link_names=tuple(x.element_name for x in self.entity_links), element_name=self.element_name
         ).qualified_name
+
+    @property
+    @abstractmethod
+    def reference(self) -> LinkableElementReference:  # noqa: D102
+        pass
 
 
 @dataclass(frozen=True)
@@ -679,6 +685,17 @@ class JoinToTimeSpineDescription:
     offset_to_grain: Optional[TimeGranularity]
 
 
+# TODO: add to DSI
+@dataclass(frozen=True)
+class GroupByMetricReference(LinkableElementReference):
+    """Represents a group by metric.
+
+    Different from MetricReference because it inherits linkable element attributes.
+    """
+
+    pass
+
+
 @dataclass(frozen=True)
 class GroupByMetricSpec(LinkableInstanceSpec, SerializableDataclass):
     """Metric used in group by or where filter.
@@ -747,8 +764,8 @@ class GroupByMetricSpec(LinkableInstanceSpec, SerializableDataclass):
         return hash((self.element_name, self.entity_links, self.metric_subquery_entity_links))
 
     @property
-    def reference(self) -> MetricReference:  # noqa: D102
-        return MetricReference(element_name=self.element_name)
+    def reference(self) -> GroupByMetricReference:  # noqa: D102
+        return GroupByMetricReference(element_name=self.element_name)
 
     def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_group_by_metric_spec(self)

--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -223,11 +223,6 @@ class NodeEvaluatorForLinkableInstances:
             # then produce the linkable spec. See comments further below for more details.
 
             for entity_spec_in_right_node in entity_specs_in_right_node:
-                # If an entity has links, what that means and whether it can be used is unclear at the moment,
-                # so skip it.
-                if len(entity_spec_in_right_node.entity_links) > 0:
-                    continue
-
                 entity_instance_in_right_node = None
                 for instance in data_set_in_right_node.instance_set.entity_instances:
                     if instance.spec == entity_spec_in_right_node:

--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -40,7 +40,6 @@ from metricflow.dataflow.builder.partitions import (
     PartitionTimeDimensionJoinDescription,
 )
 from metricflow.dataflow.dataflow_plan import BaseOutput
-from metricflow.dataflow.nodes.compute_metrics import ComputeMetricsNode
 from metricflow.dataflow.nodes.filter_elements import FilterElementsNode
 from metricflow.dataflow.nodes.join_to_base import JoinDescription, ValidityWindowJoinDescription
 from metricflow.dataflow.nodes.metric_time_transform import MetricTimeDimensionTransformNode
@@ -257,17 +256,19 @@ class NodeEvaluatorForLinkableInstances:
                 assert len(entity_instance_in_left_node.defined_from) == 1
                 assert len(entity_instance_in_right_node.defined_from) == 1
 
-                if not self._join_evaluator.is_valid_semantic_model_join(
-                    left_semantic_model_reference=entity_instance_in_left_node.defined_from[0].semantic_model_reference,
-                    right_semantic_model_reference=entity_instance_in_right_node.defined_from[
-                        0
-                    ].semantic_model_reference,
-                    on_entity_reference=entity_spec_in_right_node.reference,
+                if not (
+                    self._join_evaluator.is_valid_semantic_model_join(
+                        left_semantic_model_reference=entity_instance_in_left_node.defined_from[
+                            0
+                        ].semantic_model_reference,
+                        right_semantic_model_reference=entity_instance_in_right_node.defined_from[
+                            0
+                        ].semantic_model_reference,
+                        on_entity_reference=entity_spec_in_right_node.reference,
+                    )
+                    or right_node.is_aggregated_to_elements == {entity_spec_in_right_node.reference}
                 ):
-                    # If joining to ComputeMetricsNode, the right node is pre-aggregated.
-                    # Since we currently only allow one entity on GroupByMetric, this won't fan out.
-                    if not isinstance(right_node, ComputeMetricsNode):
-                        continue
+                    continue
 
                 linkless_entity_spec_in_node = LinklessEntitySpec.from_element_name(
                     entity_spec_in_right_node.element_name

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import logging
 import typing
 from abc import ABC, abstractmethod
-from typing import Generic, Optional, Sequence, Type, TypeVar
+from typing import Generic, Optional, Sequence, Set, Type, TypeVar
 
 from metricflow_semantics.dag.id_prefix import StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DagId, DagNode, MetricFlowDag, NodeId
 from metricflow_semantics.visitor import Visitable, VisitorOutputT
 
 if typing.TYPE_CHECKING:
+    from dbt_semantic_interfaces.references import LinkableElementReference
+
     from metricflow.dataflow.nodes.add_generated_uuid import AddGeneratedUuidColumnNode
     from metricflow.dataflow.nodes.aggregate_measures import AggregateMeasuresNode
     from metricflow.dataflow.nodes.combine_aggregated_outputs import CombineAggregatedOutputsNode
@@ -175,7 +177,10 @@ class BaseOutput(DataflowPlanNode, ABC):
     The base format is where the columns represent un-aggregated measures, dimensions, and entities.
     """
 
-    pass
+    @property
+    def is_aggregated_to_elements(self) -> Set[LinkableElementReference]:
+        """Indicates that the node has been aggregated to these specs, guaranteeing uniqueness in each combination of them."""
+        return set()
 
 
 class AggregatedMeasuresOutput(BaseOutput, ABC):

--- a/metricflow/dataflow/nodes/compute_metrics.py
+++ b/metricflow/dataflow/nodes/compute_metrics.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Sequence, Set
 
+from dbt_semantic_interfaces.references import LinkableElementReference
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DisplayedProperty
 from metricflow_semantics.specs.spec_classes import MetricSpec
@@ -19,7 +20,11 @@ class ComputeMetricsNode(ComputedMetricsOutput):
     """A node that computes metrics from input measures. Dimensions / entities are passed through."""
 
     def __init__(
-        self, parent_node: BaseOutput, metric_specs: Sequence[MetricSpec], for_group_by_source_node: bool = False
+        self,
+        parent_node: BaseOutput,
+        metric_specs: Sequence[MetricSpec],
+        is_aggregated_to_elements: Set[LinkableElementReference],
+        for_group_by_source_node: bool = False,
     ) -> None:
         """Constructor.
 
@@ -31,6 +36,7 @@ class ComputeMetricsNode(ComputedMetricsOutput):
         self._parent_node = parent_node
         self._metric_specs = tuple(metric_specs)
         self._for_group_by_source_node = for_group_by_source_node
+        self._is_aggregated_to_elements = is_aggregated_to_elements
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(self._parent_node,))
 
     @classmethod
@@ -86,4 +92,9 @@ class ComputeMetricsNode(ComputedMetricsOutput):
             parent_node=new_parent_nodes[0],
             metric_specs=self.metric_specs,
             for_group_by_source_node=self.for_group_by_source_node,
+            is_aggregated_to_elements=self._is_aggregated_to_elements,
         )
+
+    @property
+    def is_aggregated_to_elements(self) -> Set[LinkableElementReference]:  # noqa: D102
+        return self._is_aggregated_to_elements

--- a/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
+++ b/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
@@ -285,6 +285,14 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
             )
             return ComputeMetricsBranchCombinerResult()
 
+        if not self._current_left_node.is_aggregated_to_elements == current_right_node.is_aggregated_to_elements:
+            self._log_combine_failure(
+                left_node=self._current_left_node,
+                right_node=current_right_node,
+                combine_failure_reason="nodes are aggregated to different elements",
+            )
+            return ComputeMetricsBranchCombinerResult()
+
         assert len(combined_parent_nodes) == 1
         combined_parent_node = combined_parent_nodes[0]
         assert combined_parent_node is not None
@@ -299,6 +307,7 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         combined_node = ComputeMetricsNode(
             parent_node=combined_parent_node,
             metric_specs=unique_metric_specs,
+            is_aggregated_to_elements=current_right_node.is_aggregated_to_elements,
         )
         self._log_combine_success(
             left_node=self._current_left_node,

--- a/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
+++ b/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
@@ -172,6 +172,7 @@ class SourceScanOptimizer(
                     parent_node=optimized_parent_result.base_output_node,
                     metric_specs=node.metric_specs,
                     for_group_by_source_node=node.for_group_by_source_node,
+                    is_aggregated_to_elements=node.is_aggregated_to_elements,
                 )
             )
 

--- a/metricflow/dataset/sql_dataset.py
+++ b/metricflow/dataset/sql_dataset.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 
 from dbt_semantic_interfaces.references import SemanticModelReference
 from metricflow_semantics.assert_one_arg import assert_exactly_one_arg_set
-from metricflow_semantics.instances import (
-    InstanceSet,
-)
+from metricflow_semantics.instances import EntityInstance, InstanceSet
 from metricflow_semantics.specs.column_assoc import ColumnAssociation
 from metricflow_semantics.specs.spec_classes import DimensionSpec, EntitySpec, TimeDimensionSpec
 from typing_extensions import override
@@ -60,25 +58,33 @@ class SqlDataSet(DataSet):
         entity_spec: EntitySpec,
     ) -> Sequence[ColumnAssociation]:
         """Given the name of the entity, return the set of columns associated with it in the data set."""
-        matching_instances = 0
-        column_associations_to_return = None
+        matching_instances_with_same_entity_links: List[EntityInstance] = []
+        matching_instances_with_different_entity_links: List[EntityInstance] = []
         for linkable_instance in self.instance_set.entity_instances:
-            if (
-                entity_spec.element_name == linkable_instance.spec.element_name
-                and entity_spec.entity_links == linkable_instance.spec.entity_links
-            ):
-                column_associations_to_return = linkable_instance.associated_columns
-                matching_instances += 1
+            if entity_spec.element_name == linkable_instance.spec.element_name:
+                if entity_spec.entity_links == linkable_instance.spec.entity_links:
+                    matching_instances_with_same_entity_links.append(linkable_instance)
+                else:
+                    matching_instances_with_different_entity_links.append(linkable_instance)
 
-        if matching_instances > 1:
+        # Prioritize instances with matching entity links, but use mismatched links if matching links not found.
+        # Semantic model source data sets might have multiple instances of the same entity, in which case we want the one without
+        # links. But group by metric source data sets might only have an instance of the entity with links, and we can join to that.
+        matching_instances = matching_instances_with_same_entity_links or matching_instances_with_different_entity_links
+
+        if len(matching_instances) != 1:
             raise RuntimeError(
-                f"More than one instance with spec {entity_spec} in " f"instance set: {self.instance_set}"
+                f"Expected exactly one matching instance for {entity_spec} in instance set, but found: {matching_instances}"
+            )
+        matching_instance = matching_instances[0]
+        if not matching_instance.associated_columns:
+            print("entity links to compare:", entity_spec.entity_links, linkable_instance.spec.entity_links)
+            raise RuntimeError(
+                f"No associated columns for entity instance {matching_instance} in data set."
+                "This indicates internal misconfiguration."
             )
 
-        if not column_associations_to_return:
-            raise RuntimeError(f"No instances with spec {entity_spec} in instance set: {self.instance_set}")
-
-        return column_associations_to_return
+        return matching_instance.associated_columns
 
     def column_association_for_dimension(
         self,

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -19,7 +19,6 @@ from metricflow_semantics.filters.time_constraint import TimeRangeConstraint
 from metricflow_semantics.instances import (
     GroupByMetricInstance,
     InstanceSet,
-    InstanceSetTransform,
     MetadataInstance,
     MetricInstance,
     TimeDimensionInstance,
@@ -83,6 +82,7 @@ from metricflow.plan_conversion.instance_converters import (
     CreateSqlColumnReferencesForInstances,
     FilterElements,
     FilterLinkableInstancesWithLeadingLink,
+    InstanceSetTransform,
     RemoveMeasures,
     RemoveMetrics,
     UpdateMeasureFillNullsWith,

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -19,6 +19,7 @@ from metricflow.dataflow.builder.partitions import PartitionJoinResolver
 from metricflow.dataflow.dataflow_plan import (
     BaseOutput,
 )
+from metricflow.dataflow.nodes.compute_metrics import ComputeMetricsNode
 from metricflow.dataflow.nodes.constrain_time import ConstrainTimeRangeNode
 from metricflow.dataflow.nodes.filter_elements import FilterElementsNode
 from metricflow.dataflow.nodes.join_to_base import JoinDescription, JoinToBaseOutputNode
@@ -132,9 +133,6 @@ class PreJoinNodeProcessor:
             if entity_spec_in_first_node.reference != entity_reference:
                 continue
 
-            if len(entity_spec_in_first_node.entity_links) > 0:
-                continue
-
             assert (
                 len(entity_instance_in_first_node.defined_from) == 1
             ), "Multiple items in defined_from not yet supported"
@@ -217,6 +215,8 @@ class PreJoinNodeProcessor:
                     left_instance_set=data_set_of_first_node_that_could_be_joined.instance_set,
                     right_instance_set=data_set_of_second_node_that_can_be_joined.instance_set,
                     on_entity_reference=entity_reference_to_join_first_and_second_nodes,
+                    # TODO: make this check more substantial in V2
+                    right_node_is_subquery=isinstance(second_node_that_could_be_joined, ComputeMetricsNode),
                 ):
                     continue
 

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -19,7 +19,6 @@ from metricflow.dataflow.builder.partitions import PartitionJoinResolver
 from metricflow.dataflow.dataflow_plan import (
     BaseOutput,
 )
-from metricflow.dataflow.nodes.compute_metrics import ComputeMetricsNode
 from metricflow.dataflow.nodes.constrain_time import ConstrainTimeRangeNode
 from metricflow.dataflow.nodes.filter_elements import FilterElementsNode
 from metricflow.dataflow.nodes.join_to_base import JoinDescription, JoinToBaseOutputNode
@@ -215,8 +214,8 @@ class PreJoinNodeProcessor:
                     left_instance_set=data_set_of_first_node_that_could_be_joined.instance_set,
                     right_instance_set=data_set_of_second_node_that_can_be_joined.instance_set,
                     on_entity_reference=entity_reference_to_join_first_and_second_nodes,
-                    # TODO: make this check more substantial in V2
-                    right_node_is_subquery=isinstance(second_node_that_could_be_joined, ComputeMetricsNode),
+                    right_node_is_aggregated_to_entity=second_node_that_could_be_joined.is_aggregated_to_elements
+                    == {entity_reference_to_join_first_and_second_nodes},
                 ):
                     continue
 

--- a/metricflow/validation/dataflow_join_validator.py
+++ b/metricflow/validation/dataflow_join_validator.py
@@ -40,13 +40,13 @@ class JoinDataflowOutputValidator:
         left_instance_set: InstanceSet,
         right_instance_set: InstanceSet,
         on_entity_reference: EntityReference,
-        right_node_is_subquery: bool = False,
+        right_node_is_aggregated_to_entity: bool = False,
     ) -> bool:
         """Return true if the instance sets can be joined using the given entity."""
         left_semantic_model_reference = self._semantic_model_of_entity_in_instance_set(
             instance_set=left_instance_set, entity_reference=on_entity_reference
         )
-        if right_node_is_subquery:
+        if right_node_is_aggregated_to_entity:
             left_entity = self._join_evaluator._semantic_model_lookup.get_entity_in_semantic_model(
                 SemanticModelElementReference.create_from_references(left_semantic_model_reference, on_entity_reference)
             )

--- a/metricflow/validation/dataflow_join_validator.py
+++ b/metricflow/validation/dataflow_join_validator.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List
 
-from dbt_semantic_interfaces.references import (
-    EntityReference,
-    SemanticModelReference,
-)
+from dbt_semantic_interfaces.references import EntityReference, SemanticModelElementReference, SemanticModelReference
 from metricflow_semantics.instances import EntityInstance, InstanceSet
 from metricflow_semantics.mf_logging.pretty_print import mf_pformat
 from metricflow_semantics.model.semantics.semantic_model_join_evaluator import SemanticModelJoinEvaluator
@@ -43,15 +40,36 @@ class JoinDataflowOutputValidator:
         left_instance_set: InstanceSet,
         right_instance_set: InstanceSet,
         on_entity_reference: EntityReference,
+        right_node_is_subquery: bool = False,
     ) -> bool:
         """Return true if the instance sets can be joined using the given entity."""
-        return self._join_evaluator.is_valid_semantic_model_join(
-            left_semantic_model_reference=JoinDataflowOutputValidator._semantic_model_of_entity_in_instance_set(
-                instance_set=left_instance_set, entity_reference=on_entity_reference
-            ),
-            right_semantic_model_reference=JoinDataflowOutputValidator._semantic_model_of_entity_in_instance_set(
-                instance_set=right_instance_set,
-                entity_reference=on_entity_reference,
-            ),
-            on_entity_reference=on_entity_reference,
+        left_semantic_model_reference = self._semantic_model_of_entity_in_instance_set(
+            instance_set=left_instance_set, entity_reference=on_entity_reference
         )
+        if right_node_is_subquery:
+            left_entity = self._join_evaluator._semantic_model_lookup.get_entity_in_semantic_model(
+                SemanticModelElementReference.create_from_references(left_semantic_model_reference, on_entity_reference)
+            )
+            if not left_entity:
+                return False
+            possible_right_entities = [
+                entity_instance
+                for entity_instance in right_instance_set.entity_instances
+                if entity_instance.spec.reference == on_entity_reference
+            ]
+            if len(possible_right_entities) != 1:
+                return False
+
+            # No fan-out check needed since right subquery is aggregated to the entity level, ensuring uniqueness.
+            return True
+        else:
+            return self._join_evaluator.is_valid_semantic_model_join(
+                left_semantic_model_reference=JoinDataflowOutputValidator._semantic_model_of_entity_in_instance_set(
+                    instance_set=left_instance_set, entity_reference=on_entity_reference
+                ),
+                right_semantic_model_reference=JoinDataflowOutputValidator._semantic_model_of_entity_in_instance_set(
+                    instance_set=right_instance_set,
+                    entity_reference=on_entity_reference,
+                ),
+                on_entity_reference=on_entity_reference,
+            )

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -442,7 +442,11 @@ def test_compute_metrics_node(
     )
 
     metric_spec = MetricSpec(element_name="bookings")
-    compute_metrics_node = ComputeMetricsNode(parent_node=aggregated_measure_node, metric_specs=[metric_spec])
+    compute_metrics_node = ComputeMetricsNode(
+        parent_node=aggregated_measure_node,
+        metric_specs=[metric_spec],
+        is_aggregated_to_elements={entity_spec.reference, dimension_spec.reference},
+    )
 
     convert_and_check(
         request=request,
@@ -507,7 +511,11 @@ def test_compute_metrics_node_simple_expr(
         parent_node=join_node, metric_input_measure_specs=metric_input_measure_specs
     )
     metric_spec = MetricSpec(element_name="booking_fees")
-    compute_metrics_node = ComputeMetricsNode(parent_node=aggregated_measures_node, metric_specs=[metric_spec])
+    compute_metrics_node = ComputeMetricsNode(
+        parent_node=aggregated_measures_node,
+        metric_specs=[metric_spec],
+        is_aggregated_to_elements={entity_spec.reference, dimension_spec.reference},
+    )
 
     sink_node = WriteToResultDataframeNode(compute_metrics_node)
     dataflow_plan = DataflowPlan(sink_output_nodes=[sink_node], plan_id=DagId.from_str("plan0"))
@@ -567,7 +575,11 @@ def test_join_to_time_spine_node_without_offset(
         parent_node=filtered_measure_node, metric_input_measure_specs=metric_input_measure_specs
     )
     metric_spec = MetricSpec(element_name="booking_fees")
-    compute_metrics_node = ComputeMetricsNode(parent_node=aggregated_measures_node, metric_specs=[metric_spec])
+    compute_metrics_node = ComputeMetricsNode(
+        parent_node=aggregated_measures_node,
+        metric_specs=[metric_spec],
+        is_aggregated_to_elements={entity_spec.reference},
+    )
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
@@ -634,7 +646,11 @@ def test_join_to_time_spine_node_with_offset_window(
         parent_node=filtered_measure_node, metric_input_measure_specs=metric_input_measure_specs
     )
     metric_spec = MetricSpec(element_name="booking_fees")
-    compute_metrics_node = ComputeMetricsNode(parent_node=aggregated_measures_node, metric_specs=[metric_spec])
+    compute_metrics_node = ComputeMetricsNode(
+        parent_node=aggregated_measures_node,
+        metric_specs=[metric_spec],
+        is_aggregated_to_elements={entity_spec.reference, metric_time_spec.reference},
+    )
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
@@ -703,7 +719,11 @@ def test_join_to_time_spine_node_with_offset_to_grain(
         parent_node=filtered_measure_node, metric_input_measure_specs=metric_input_measure_specs
     )
     metric_spec = MetricSpec(element_name="booking_fees")
-    compute_metrics_node = ComputeMetricsNode(parent_node=aggregated_measures_node, metric_specs=[metric_spec])
+    compute_metrics_node = ComputeMetricsNode(
+        parent_node=aggregated_measures_node,
+        metric_specs=[metric_spec],
+        is_aggregated_to_elements={entity_spec.reference, metric_time_spec.reference},
+    )
     join_to_time_spine_node = JoinToTimeSpineNode(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
@@ -801,7 +821,11 @@ def test_compute_metrics_node_ratio_from_single_semantic_model(
         parent_node=join_node, metric_input_measure_specs=metric_input_measure_specs
     )
     metric_spec = MetricSpec(element_name="bookings_per_booker")
-    compute_metrics_node = ComputeMetricsNode(parent_node=aggregated_measures_node, metric_specs=[metric_spec])
+    compute_metrics_node = ComputeMetricsNode(
+        parent_node=aggregated_measures_node,
+        metric_specs=[metric_spec],
+        is_aggregated_to_elements={entity_spec.reference, dimension_spec.reference},
+    )
 
     convert_and_check(
         request=request,
@@ -853,7 +877,11 @@ def test_order_by_node(
     )
 
     metric_spec = MetricSpec(element_name="bookings")
-    compute_metrics_node = ComputeMetricsNode(parent_node=aggregated_measure_node, metric_specs=[metric_spec])
+    compute_metrics_node = ComputeMetricsNode(
+        parent_node=aggregated_measure_node,
+        metric_specs=[metric_spec],
+        is_aggregated_to_elements={dimension_spec.reference, time_dimension_spec.reference},
+    )
 
     order_by_node = OrderByLimitNode(
         order_by_specs=[


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
There was a lot of logic in the dataflow plan builder that assumed all source nodes and joinable nodes would be `ReadSqlSourceNode` or `MetricTimeDimensionTransformNode` (as was previously true). This is no longer true since adding `LinkableMetrics`, for which you might have a `ComputeMetricsNode` as a source node. This comes with a lot of changes, like the fact that the entity links might look different for this source node than for others. Here we update the DFP building logic to account for those nodes.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
