### PR TITLE
Test that all available single-hop metrics don't error

### DIFF
--- a/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
+++ b/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
@@ -2,20 +2,24 @@ from __future__ import annotations
 
 import datetime
 import logging
+import string
 
 import pytest
 from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.implementations.filters.where_filter import PydanticWhereFilter
 from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
+from dbt_semantic_interfaces.references import MeasureReference
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from metricflow_semantics.errors.error_classes import UnableToSatisfyQueryError
 from metricflow_semantics.filters.time_constraint import TimeRangeConstraint
+from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
 from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.specs.spec_classes import (
     DimensionSpec,
     EntityReference,
+    GroupByMetricSpec,
     MetricSpec,
     OrderBySpec,
     TimeDimensionSpec,
@@ -1324,3 +1328,27 @@ def test_metric_in_metric_where_filter(
         mf_test_configuration=mf_test_configuration,
         dag_graph=dataflow_plan,
     )
+
+
+def test_all_available_single_join_metric_filters(
+    dataflow_plan_builder: DataflowPlanBuilder, query_parser: MetricFlowQueryParser
+) -> None:
+    """Checks that all allowed metric filters do not error when used in dataflow plan (single-hop for both inner and out query)."""
+    for linkable_metric_tuple in dataflow_plan_builder._metric_lookup.linkable_elements_for_measure(
+        MeasureReference("listings"), without_any_of={LinkableElementProperty.MULTI_HOP}
+    ).path_key_to_linkable_metrics.values():
+        for linkable_metric in linkable_metric_tuple:
+            group_by_metric_spec = linkable_metric.path_key.spec
+            assert isinstance(group_by_metric_spec, GroupByMetricSpec)
+            entity_spec = group_by_metric_spec.metric_subquery_entity_spec
+            if entity_spec.entity_links:  # multi-hop for inner query
+                continue
+            query_spec = query_parser.parse_and_validate_query(
+                metric_names=("listings",),
+                where_constraint=PydanticWhereFilter(
+                    where_sql_template=string.Template("{{ Metric('$metric_name', ['$entity_name']) }} > 2").substitute(
+                        metric_name=linkable_metric.element_name, entity_name=entity_spec.element_name
+                    ),
+                ),
+            )
+            dataflow_plan_builder.build_plan(query_spec)


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Test that these things actually work! This test loops through the allowed linkable metrics and runs them through the query parser & dataflow plan builder. This ensures that they will work for both group by resolution logic and dataflow plan logic.

More tests to come:
- multi-hop linkable metrics (multi-hop for both inner and outer join paths)
- e2e query tests: query rendering + check query tests
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
