### PR TITLE
Add support for set type collections in the pretty-printer

### DIFF
--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -39,7 +39,9 @@ class MetricFlowPrettyFormatter:
         # Checking the attribute as the BaseModel check fails for newer version of Pydantic.
         return isinstance(obj, BaseModel) or hasattr(obj, "__config__")
 
-    def _handle_sequence_obj(self, list_like_obj: Union[list, tuple], remaining_line_width: Optional[int]) -> str:
+    def _handle_sequence_obj(
+        self, list_like_obj: Union[list, tuple, set, frozenset], remaining_line_width: Optional[int]
+    ) -> str:
         """Pretty prints a sequence object i.e. list or tuple.
 
         Args:
@@ -55,6 +57,10 @@ class MetricFlowPrettyFormatter:
         elif isinstance(list_like_obj, tuple):
             left_enclose_str = "("
             right_enclose_str = ")"
+        elif isinstance(list_like_obj, set) or isinstance(list_like_obj, frozenset):
+            left_enclose_str = f"{type(list_like_obj).__name__}("
+            right_enclose_str = ")"
+            list_like_obj = sorted(list_like_obj)
         else:
             raise RuntimeError(f"Unhandled type: {type(list_like_obj)}")
 
@@ -317,7 +323,7 @@ class MetricFlowPrettyFormatter:
         if isinstance(obj, Enum):
             return obj.name
 
-        if isinstance(obj, (list, tuple)):
+        if isinstance(obj, (list, tuple, set, frozenset)):
             return self._handle_sequence_obj(obj, remaining_line_width=remaining_line_width)
 
         if isinstance(obj, dict):

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__accumulate_last_2_months_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__accumulate_last_2_months_metric__result.txt
@@ -13,7 +13,7 @@ GroupByItemResolution(
           ),
           element_name='metric_time',
           dimension_type=TIME,
-          properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+          properties=frozenset(METRIC_TIME,),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_different_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_different_parent_time_grains__result.txt
@@ -25,7 +25,9 @@ GroupByItemResolution(
                     ),
                     element_name='metric_time',
                     dimension_type=TIME,
-                    properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                    properties=frozenset(
+                      METRIC_TIME,
+                    ),
                     time_granularity=MONTH,
                   ),
                 ),
@@ -63,7 +65,9 @@ GroupByItemResolution(
                     ),
                     element_name='metric_time',
                     dimension_type=TIME,
-                    properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                    properties=frozenset(
+                      METRIC_TIME,
+                    ),
                     time_granularity=YEAR,
                   ),
                 ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_same_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_same_parent_time_grains__result.txt
@@ -13,7 +13,7 @@ GroupByItemResolution(
           ),
           element_name='metric_time',
           dimension_type=TIME,
-          properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+          properties=frozenset(METRIC_TIME,),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_different_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_different_time_grains__result.txt
@@ -22,7 +22,9 @@ GroupByItemResolution(
                     ),
                     element_name='metric_time',
                     dimension_type=TIME,
-                    properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                    properties=frozenset(
+                      METRIC_TIME,
+                    ),
                     time_granularity=MONTH,
                   ),
                 ),
@@ -58,7 +60,9 @@ GroupByItemResolution(
                     ),
                     element_name='metric_time',
                     dimension_type=TIME,
-                    properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                    properties=frozenset(
+                      METRIC_TIME,
+                    ),
                     time_granularity=YEAR,
                   ),
                 ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_same_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_same_time_grains__result.txt
@@ -13,7 +13,7 @@ GroupByItemResolution(
           ),
           element_name='metric_time',
           dimension_type=TIME,
-          properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+          properties=frozenset(METRIC_TIME,),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__no_metrics__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__no_metrics__result.txt
@@ -10,7 +10,7 @@ GroupByItemResolution(
         LinkableDimension(
           element_name='metric_time',
           dimension_type=TIME,
-          properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+          properties=frozenset(METRIC_TIME,),
           time_granularity=DAY,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__simple_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__simple_metric__result.txt
@@ -13,7 +13,7 @@ GroupByItemResolution(
           ),
           element_name='metric_time',
           dimension_type=TIME,
-          properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+          properties=frozenset(METRIC_TIME,),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_derived_metrics_with_common_filtered_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_derived_metrics_with_common_filtered_metric__result.txt
@@ -35,7 +35,9 @@ FilterSpecResolutionLookUp(
               ),
               element_name='metric_time',
               dimension_type=TIME,
-              properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+              properties=frozenset(
+                METRIC_TIME,
+              ),
               time_granularity=MONTH,
             ),
           ),
@@ -91,7 +93,9 @@ FilterSpecResolutionLookUp(
               ),
               element_name='metric_time',
               dimension_type=TIME,
-              properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+              properties=frozenset(
+                METRIC_TIME,
+              ),
               time_granularity=MONTH,
             ),
           ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_filter__result.txt
@@ -54,7 +54,9 @@ FilterSpecResolutionLookUp(
                         ),
                         element_name='metric_time',
                         dimension_type=TIME,
-                        properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                        properties=frozenset(
+                          METRIC_TIME,
+                        ),
                         time_granularity=MONTH,
                       ),
                     ),
@@ -92,7 +94,9 @@ FilterSpecResolutionLookUp(
                         ),
                         element_name='metric_time',
                         dimension_type=TIME,
-                        properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                        properties=frozenset(
+                          METRIC_TIME,
+                        ),
                         time_granularity=YEAR,
                       ),
                     ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_input_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_input_filter__result.txt
@@ -55,7 +55,9 @@ FilterSpecResolutionLookUp(
                         ),
                         element_name='metric_time',
                         dimension_type=TIME,
-                        properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                        properties=frozenset(
+                          METRIC_TIME,
+                        ),
                         time_granularity=MONTH,
                       ),
                     ),
@@ -95,7 +97,9 @@ FilterSpecResolutionLookUp(
                         ),
                         element_name='metric_time',
                         dimension_type=TIME,
-                        properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                        properties=frozenset(
+                          METRIC_TIME,
+                        ),
                         time_granularity=YEAR,
                       ),
                     ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_filter__result.txt
@@ -35,7 +35,9 @@ FilterSpecResolutionLookUp(
               ),
               element_name='metric_time',
               dimension_type=TIME,
-              properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+              properties=frozenset(
+                METRIC_TIME,
+              ),
               time_granularity=MONTH,
             ),
           ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_input_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_input_filter__result.txt
@@ -35,7 +35,9 @@ FilterSpecResolutionLookUp(
               ),
               element_name='metric_time',
               dimension_type=TIME,
-              properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+              properties=frozenset(
+                METRIC_TIME,
+              ),
               time_granularity=MONTH,
             ),
           ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__accumulate_last_2_months_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__accumulate_last_2_months_metric__result.txt
@@ -35,7 +35,9 @@ FilterSpecResolutionLookUp(
               ),
               element_name='metric_time',
               dimension_type=TIME,
-              properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+              properties=frozenset(
+                METRIC_TIME,
+              ),
               time_granularity=MONTH,
             ),
           ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_different_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_different_parent_time_grains__result.txt
@@ -54,7 +54,9 @@ FilterSpecResolutionLookUp(
                         ),
                         element_name='metric_time',
                         dimension_type=TIME,
-                        properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                        properties=frozenset(
+                          METRIC_TIME,
+                        ),
                         time_granularity=MONTH,
                       ),
                     ),
@@ -92,7 +94,9 @@ FilterSpecResolutionLookUp(
                         ),
                         element_name='metric_time',
                         dimension_type=TIME,
-                        properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                        properties=frozenset(
+                          METRIC_TIME,
+                        ),
                         time_granularity=YEAR,
                       ),
                     ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_same_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_same_parent_time_grains__result.txt
@@ -35,7 +35,9 @@ FilterSpecResolutionLookUp(
               ),
               element_name='metric_time',
               dimension_type=TIME,
-              properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+              properties=frozenset(
+                METRIC_TIME,
+              ),
               time_granularity=MONTH,
             ),
           ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_different_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_different_time_grains__result.txt
@@ -56,7 +56,9 @@ FilterSpecResolutionLookUp(
                         ),
                         element_name='metric_time',
                         dimension_type=TIME,
-                        properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                        properties=frozenset(
+                          METRIC_TIME,
+                        ),
                         time_granularity=MONTH,
                       ),
                     ),
@@ -92,7 +94,9 @@ FilterSpecResolutionLookUp(
                         ),
                         element_name='metric_time',
                         dimension_type=TIME,
-                        properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+                        properties=frozenset(
+                          METRIC_TIME,
+                        ),
                         time_granularity=YEAR,
                       ),
                     ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_same_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_same_time_grains__result.txt
@@ -38,7 +38,9 @@ FilterSpecResolutionLookUp(
               ),
               element_name='metric_time',
               dimension_type=TIME,
-              properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+              properties=frozenset(
+                METRIC_TIME,
+              ),
               time_granularity=MONTH,
             ),
           ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__simple_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__simple_metric__result.txt
@@ -35,7 +35,9 @@ FilterSpecResolutionLookUp(
               ),
               element_name='metric_time',
               dimension_type=TIME,
-              properties=frozenset({<LinkableElementProperty.METRIC_TIME: 'metric_time'>}),
+              properties=frozenset(
+                METRIC_TIME,
+              ),
               time_granularity=MONTH,
             ),
           ),


### PR DESCRIPTION
Our snapshot files rely on consistent order for all rendered
collections, but we were assuming that all input objects would
be strictly ordered. Unfortunately, the fallback method of using
Python's pretty-printer does not allow for ordered sets, so
any inputs involving set or frozenset types will be fundamentally
unstable.

This expands our list-like formatted print handling to cover set
types, indicating the distinction between set and frozenset and
printing all values in a stable sort order. This does assume all
set values are sortable, which should be the case.

As you can see from the snapshot updates, this is a pre-existing
problem in the codebase. We've gotten away with it because all of
the sets in our snapshots have, thus far, all been of length 1. This
will change in coming updates.