### PR TITLE
Revert "Move `_path_key_to_spec` to `ElementPathKey`."

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
@@ -20,13 +20,6 @@ from typing_extensions import override
 
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
 from metricflow_semantics.model.semantic_model_derivation import SemanticModelDerivation
-from metricflow_semantics.specs.spec_classes import (
-    DimensionSpec,
-    EntitySpec,
-    GroupByMetricSpec,
-    LinkableInstanceSpec,
-    TimeDimensionSpec,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -84,42 +77,6 @@ class ElementPathKey:
             pass
         else:
             assert_values_exhausted(element_type)
-
-    @property
-    def spec(self) -> LinkableInstanceSpec:
-        """The corresponding spec object for this path key."""
-        if self.element_type is LinkableElementType.DIMENSION:
-            return DimensionSpec(
-                element_name=self.element_name,
-                entity_links=self.entity_links,
-            )
-        elif self.element_type is LinkableElementType.TIME_DIMENSION:
-            assert (
-                self.time_granularity is not None
-            ), f"{self.time_granularity=} should not be None as per check in dataclass validation"
-            return TimeDimensionSpec(
-                element_name=self.element_name,
-                entity_links=self.entity_links,
-                time_granularity=self.time_granularity,
-                date_part=self.date_part,
-            )
-        elif self.element_type is LinkableElementType.ENTITY:
-            return EntitySpec(
-                element_name=self.element_name,
-                entity_links=self.entity_links,
-            )
-        elif self.element_type is LinkableElementType.METRIC:
-            assert self.metric_subquery_entity_links is not None, (
-                "ElementPathKeys for metrics must have non-null metric_subquery_entity_links."
-                "This should have been checked in post_init."
-            )
-            return GroupByMetricSpec(
-                element_name=self.element_name,
-                entity_links=self.entity_links,
-                metric_subquery_entity_links=self.metric_subquery_entity_links,
-            )
-        else:
-            assert_values_exhausted(self.element_type)
 
 
 @dataclass(frozen=True)

--- a/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
+++ b/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
@@ -13,6 +13,7 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from metricflow_semantics.errors.error_classes import UnableToSatisfyQueryError
 from metricflow_semantics.filters.time_constraint import TimeRangeConstraint
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.linkable_element_set import LinkableElementSet
 from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
@@ -1338,7 +1339,7 @@ def test_all_available_single_join_metric_filters(
         MeasureReference("listings"), without_any_of={LinkableElementProperty.MULTI_HOP}
     ).path_key_to_linkable_metrics.values():
         for linkable_metric in linkable_metric_tuple:
-            group_by_metric_spec = linkable_metric.path_key.spec
+            group_by_metric_spec = LinkableElementSet._path_key_to_spec(linkable_metric.path_key)
             assert isinstance(group_by_metric_spec, GroupByMetricSpec)
             entity_spec = group_by_metric_spec.metric_subquery_entity_spec
             if entity_spec.entity_links:  # multi-hop for inner query


### PR DESCRIPTION
This reverts commit bcbf1bf6b8368506e23b2f2a4242e236eb8a9823.

The original layout of linkable_element, with the private helper
converting ElementPathKey to the relevant LinkableInstanceSpec,
was intentionally placed to avoid circular dependencies with
the WhereFilterSpec during predicate pushdown implementation.

The code configuration from the reverted commit is nicer in many
respects, but unfortunately an attempt to use it ran into
circular dependencies as expected, and the TYPE_CHECKING work-around
ultimately failed because of the way SerializableDataclass works.
Specifically, SerializableDataclass needs the class to create a concrete
object during its operation, so runtime access to the object is required
it's part of a SerializableDataclass hierarchy.

Since the SerializableDataclass mechanism is fully in use in the
implementation of some dbt cloud extensions we cannot easily
evalaute updates to that model here, and it is therefore much
simpler to just revert this change and move forward.