### PR TITLE
Push resolved linkable elements through to WhereFilterSpec

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import FrozenSet, Optional, Sequence, Tuple
 
+from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.protocols.dimension import DimensionType
 from dbt_semantic_interfaces.references import (
@@ -87,14 +88,15 @@ class SemanticModelJoinPathElement:
     join_on_entity: EntityReference
 
 
-class LinkableElement(SemanticModelDerivation, ABC):
+@dataclass(frozen=True)
+class LinkableElement(SemanticModelDerivation, SerializableDataclass, ABC):
     """An entity / dimension that may have been joined by entities."""
 
     pass
 
 
 @dataclass(frozen=True)
-class LinkableDimension(LinkableElement):
+class LinkableDimension(LinkableElement, SerializableDataclass):
     """Describes how a dimension can be realized by joining based on entity links."""
 
     # The semantic model where this dimension was defined.
@@ -139,7 +141,7 @@ class LinkableDimension(LinkableElement):
 
 
 @dataclass(frozen=True)
-class LinkableEntity(LinkableElement):
+class LinkableEntity(LinkableElement, SerializableDataclass):
     """Describes how an entity can be realized by joining based on entity links."""
 
     # The semantic model where this entity was defined.
@@ -170,7 +172,7 @@ class LinkableEntity(LinkableElement):
 
 
 @dataclass(frozen=True)
-class LinkableMetric(LinkableElement):
+class LinkableMetric(LinkableElement, SerializableDataclass):
     """Describes how a metric can be realized by joining based on entity links."""
 
     properties: FrozenSet[LinkableElementProperty]

--- a/metricflow-semantics/metricflow_semantics/specs/rendered_spec_tracker.py
+++ b/metricflow-semantics/metricflow_semantics/specs/rendered_spec_tracker.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import List, Sequence
+from typing import List, Sequence, Tuple
 
+from metricflow_semantics.model.semantics.linkable_element import LinkableElement
 from metricflow_semantics.specs.spec_classes import LinkableInstanceSpec
 
 
@@ -12,13 +13,18 @@ class RenderedSpecTracker:
     """
 
     def __init__(self) -> None:  # noqa: D107
-        self._rendered_specs: List[LinkableInstanceSpec] = []
+        self._rendered_specs_to_elements: List[Tuple[LinkableInstanceSpec, Sequence[LinkableElement]]] = []
 
-    def record_rendered_spec(self, spec: LinkableInstanceSpec) -> None:
-        """Records a spec that was rendered in a where filter and can be retrieved later through rendered_specs()."""
-        self._rendered_specs.append(spec)
+    def record_rendered_spec_to_elements_mapping(
+        self, spec_to_elements: Tuple[LinkableInstanceSpec, Sequence[LinkableElement]]
+    ) -> None:
+        """Records a spec that was rendered in a where filter and can be retrieved later through rendered_specs().
+
+        The mapping to LinkableElements is to facilitate predicate pushdown evaluation on a filter-by-filter basis.
+        """
+        self._rendered_specs_to_elements.append(spec_to_elements)
 
     @property
-    def rendered_specs(self) -> Sequence[LinkableInstanceSpec]:
+    def rendered_specs_to_elements(self) -> Sequence[Tuple[LinkableInstanceSpec, Sequence[LinkableElement]]]:
         """Returns specs that were recorded by record_rendered_spec()."""
-        return self._rendered_specs
+        return self._rendered_specs_to_elements

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter_dimension.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter_dimension.py
@@ -106,13 +106,14 @@ class WhereFilterDimension(ProtocolHint[QueryInterfaceDimension]):
                 dimension_reference=DimensionReference(self._element_name),
             )
 
-        resolved_spec = self._resolved_spec_lookup.checked_resolved_spec(
-            ResolvedSpecLookUpKey(
-                filter_location=self._where_filter_location,
-                call_parameter_set=call_parameter_set,
-            )
+        resolved_spec_key = ResolvedSpecLookUpKey(
+            filter_location=self._where_filter_location,
+            call_parameter_set=call_parameter_set,
         )
-        self._rendered_spec_tracker.record_rendered_spec(resolved_spec)
+
+        resolved_spec = self._resolved_spec_lookup.checked_resolved_spec(resolved_spec_key)
+        resolved_elements = self._resolved_spec_lookup.checked_resolved_linkable_elements(resolved_spec_key)
+        self._rendered_spec_tracker.record_rendered_spec_to_elements_mapping((resolved_spec, resolved_elements))
         column_association = self._column_association_resolver.resolve_spec(resolved_spec)
 
         return column_association.column_name

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter_entity.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter_entity.py
@@ -65,13 +65,15 @@ class WhereFilterEntity(ProtocolHint[QueryInterfaceEntity]):
             entity_path=self._entity_links,
             entity_reference=EntityReference(self._element_name),
         )
-        resolved_spec = self._resolved_spec_lookup.checked_resolved_spec(
-            ResolvedSpecLookUpKey(
-                filter_location=self._where_filter_location,
-                call_parameter_set=call_parameter_set,
-            )
+
+        resolved_spec_key = ResolvedSpecLookUpKey(
+            filter_location=self._where_filter_location,
+            call_parameter_set=call_parameter_set,
         )
-        self._rendered_spec_tracker.record_rendered_spec(resolved_spec)
+
+        resolved_spec = self._resolved_spec_lookup.checked_resolved_spec(resolved_spec_key)
+        resolved_elements = self._resolved_spec_lookup.checked_resolved_linkable_elements(resolved_spec_key)
+        self._rendered_spec_tracker.record_rendered_spec_to_elements_mapping((resolved_spec, resolved_elements))
         column_association = self._column_association_resolver.resolve_spec(resolved_spec)
 
         return column_association.column_name

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter_metric.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter_metric.py
@@ -58,13 +58,15 @@ class WhereFilterMetric(ProtocolHint[QueryInterfaceMetric]):
             group_by=tuple(EntityReference(element_name=group_by_ref.element_name) for group_by_ref in self._group_by),
             metric_reference=MetricReference(self._element_name),
         )
-        resolved_spec = self._resolved_spec_lookup.checked_resolved_spec(
-            ResolvedSpecLookUpKey(
-                filter_location=self._where_filter_location,
-                call_parameter_set=call_parameter_set,
-            )
+
+        resolved_spec_key = ResolvedSpecLookUpKey(
+            filter_location=self._where_filter_location,
+            call_parameter_set=call_parameter_set,
         )
-        self._rendered_spec_tracker.record_rendered_spec(resolved_spec)
+
+        resolved_spec = self._resolved_spec_lookup.checked_resolved_spec(resolved_spec_key)
+        resolved_elements = self._resolved_spec_lookup.checked_resolved_linkable_elements(resolved_spec_key)
+        self._rendered_spec_tracker.record_rendered_spec_to_elements_mapping((resolved_spec, resolved_elements))
         column_association = self._column_association_resolver.resolve_spec(resolved_spec)
 
         return column_association.column_name

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter_time_dimension.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter_time_dimension.py
@@ -40,13 +40,15 @@ class WhereFilterTimeDimension(WhereFilterDimension):
             time_granularity=self._time_grain,
             date_part=self._date_part,
         )
-        resolved_spec = self._resolved_spec_lookup.checked_resolved_spec(
-            ResolvedSpecLookUpKey(
-                filter_location=self._where_filter_location,
-                call_parameter_set=call_parameter_set,
-            )
+
+        resolved_spec_key = ResolvedSpecLookUpKey(
+            filter_location=self._where_filter_location,
+            call_parameter_set=call_parameter_set,
         )
-        self._rendered_spec_tracker.record_rendered_spec(resolved_spec)
+
+        resolved_spec = self._resolved_spec_lookup.checked_resolved_spec(resolved_spec_key)
+        resolved_elements = self._resolved_spec_lookup.checked_resolved_linkable_elements(resolved_spec_key)
+        self._rendered_spec_tracker.record_rendered_spec_to_elements_mapping((resolved_spec, resolved_elements))
         column_association = self._column_association_resolver.resolve_spec(resolved_spec)
 
         return column_association.column_name

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter_transform.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter_transform.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import logging
 from typing import List, Optional, Sequence
 
@@ -99,11 +100,16 @@ class WhereSpecFactory:
                 raise RenderSqlTemplateException(
                     f"Error while rendering Jinja template:\n{where_filter.where_sql_template}"
                 ) from e
+            rendered_specs = tuple(result[0] for result in rendered_spec_tracker.rendered_specs_to_elements)
+            linkable_elements = tuple(
+                itertools.chain.from_iterable(result[1] for result in rendered_spec_tracker.rendered_specs_to_elements)
+            )
             filter_specs.append(
                 WhereFilterSpec(
                     where_sql=where_sql,
                     bind_parameters=SqlBindParameters(),
-                    linkable_specs=tuple(rendered_spec_tracker.rendered_specs),
+                    linkable_specs=rendered_specs,
+                    linkable_elements=linkable_elements,
                 )
             )
 

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -5,12 +5,14 @@ from typing import List, Mapping
 import pytest
 from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.implementations.metric import PydanticMetricTimeWindow
-from dbt_semantic_interfaces.references import EntityReference, TimeDimensionReference
+from dbt_semantic_interfaces.references import EntityReference, SemanticModelReference, TimeDimensionReference
 from dbt_semantic_interfaces.test_utils import as_datetime
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
+from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from metricflow_semantics.dag.mf_dag import DagId
 from metricflow_semantics.filters.time_constraint import TimeRangeConstraint
+from metricflow_semantics.model.semantics.linkable_element import LinkableDimension
 from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
@@ -196,6 +198,18 @@ def test_filter_with_where_constraint_node(
                     element_name="ds",
                     entity_links=(EntityReference(element_name="booking"),),
                     time_granularity=TimeGranularity.DAY,
+                ),
+            ),
+            linkable_elements=(
+                LinkableDimension(
+                    semantic_model_origin=SemanticModelReference("bookings_source"),
+                    element_name="ds",
+                    dimension_type=DimensionType.TIME,
+                    entity_links=(EntityReference(element_name="booking"),),
+                    properties=frozenset(),
+                    time_granularity=TimeGranularity.DAY,
+                    date_part=None,
+                    join_path=(),
                 ),
             ),
         ),

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -36,6 +36,17 @@
                     <!--         entity_links=(EntityReference(element_name='listing'),), -->
                     <!--       ),                                                         -->
                     <!--     ),                                                           -->
+                    <!--     linkable_elements=(                                          -->
+                    <!--       LinkableDimension(                                         -->
+                    <!--         semantic_model_origin=SemanticModelReference(            -->
+                    <!--           semantic_model_name='listings_latest',                 -->
+                    <!--         ),                                                       -->
+                    <!--         element_name='country_latest',                           -->
+                    <!--         dimension_type=CATEGORICAL,                              -->
+                    <!--         entity_links=(EntityReference(element_name='listing'),), -->
+                    <!--         properties=frozenset(LOCAL,),                            -->
+                    <!--       ),                                                         -->
+                    <!--     ),                                                           -->
                     <!--   )                                                              -->
                     <ReadSqlSourceNode>
                         <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
@@ -41,6 +41,17 @@
                     <!--         entity_links=(EntityReference(element_name='listing'),), -->
                     <!--       ),                                                         -->
                     <!--     ),                                                           -->
+                    <!--     linkable_elements=(                                          -->
+                    <!--       LinkableDimension(                                         -->
+                    <!--         semantic_model_origin=SemanticModelReference(            -->
+                    <!--           semantic_model_name='listings_latest',                 -->
+                    <!--         ),                                                       -->
+                    <!--         element_name='country_latest',                           -->
+                    <!--         dimension_type=CATEGORICAL,                              -->
+                    <!--         entity_links=(EntityReference(element_name='listing'),), -->
+                    <!--         properties=frozenset(LOCAL,),                            -->
+                    <!--       ),                                                         -->
+                    <!--     ),                                                           -->
                     <!--   )                                                              -->
                     <JoinToBaseOutputNode>
                         <!-- description = 'Join Standard Outputs' -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -15,6 +15,17 @@
             <!--         linkable_specs=(                                                       -->
             <!--           TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
             <!--         ),                                                                     -->
+            <!--         linkable_elements=(                                                    -->
+            <!--           LinkableDimension(                                                   -->
+            <!--             semantic_model_origin=SemanticModelReference(                      -->
+            <!--               semantic_model_name='bookings_source',                           -->
+            <!--             ),                                                                 -->
+            <!--             element_name='metric_time',                                        -->
+            <!--             dimension_type=TIME,                                               -->
+            <!--             properties=frozenset(METRIC_TIME,),                                -->
+            <!--             time_granularity=DAY,                                              -->
+            <!--           ),                                                                   -->
+            <!--         ),                                                                     -->
             <!--       ),                                                                       -->
             <!--     ),                                                                         -->
             <!--   )                                                                            -->
@@ -31,6 +42,17 @@
                     <!--     where_sql="metric_time__day = '2020-01-01'",                                           -->
                     <!--     bind_parameters=SqlBindParameters(),                                                   -->
                     <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
+                    <!--     linkable_elements=(                                                                    -->
+                    <!--       LinkableDimension(                                                                   -->
+                    <!--         semantic_model_origin=SemanticModelReference(                                      -->
+                    <!--           semantic_model_name='bookings_source',                                           -->
+                    <!--         ),                                                                                 -->
+                    <!--         element_name='metric_time',                                                        -->
+                    <!--         dimension_type=TIME,                                                               -->
+                    <!--         properties=frozenset(METRIC_TIME,),                                                -->
+                    <!--         time_granularity=DAY,                                                              -->
+                    <!--       ),                                                                                   -->
+                    <!--     ),                                                                                     -->
                     <!--   )                                                                                        -->
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
@@ -52,17 +74,28 @@
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
                                 <!-- node_id = NodeId(id_str='wcc_0') -->
-                                <!-- where_condition =                                -->
-                                <!--   WhereFilterSpec(                               -->
-                                <!--     where_sql="metric_time__day = '2020-01-01'", -->
-                                <!--     bind_parameters=SqlBindParameters(),         -->
-                                <!--     linkable_specs=(                             -->
-                                <!--       TimeDimensionSpec(                         -->
-                                <!--         element_name='metric_time',              -->
-                                <!--         time_granularity=DAY,                    -->
-                                <!--       ),                                         -->
-                                <!--     ),                                           -->
-                                <!--   )                                              -->
+                                <!-- where_condition =                                     -->
+                                <!--   WhereFilterSpec(                                    -->
+                                <!--     where_sql="metric_time__day = '2020-01-01'",      -->
+                                <!--     bind_parameters=SqlBindParameters(),              -->
+                                <!--     linkable_specs=(                                  -->
+                                <!--       TimeDimensionSpec(                              -->
+                                <!--         element_name='metric_time',                   -->
+                                <!--         time_granularity=DAY,                         -->
+                                <!--       ),                                              -->
+                                <!--     ),                                                -->
+                                <!--     linkable_elements=(                               -->
+                                <!--       LinkableDimension(                              -->
+                                <!--         semantic_model_origin=SemanticModelReference( -->
+                                <!--           semantic_model_name='bookings_source',      -->
+                                <!--         ),                                            -->
+                                <!--         element_name='metric_time',                   -->
+                                <!--         dimension_type=TIME,                          -->
+                                <!--         properties=frozenset(METRIC_TIME,),           -->
+                                <!--         time_granularity=DAY,                         -->
+                                <!--       ),                                              -->
+                                <!--     ),                                                -->
+                                <!--   )                                                   -->
                                 <FilterElementsNode>
                                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                                     <!-- node_id = NodeId(id_str='pfe_0') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -25,6 +25,29 @@
                     <!--             entity_links=(EntityReference(element_name='listing'),), -->
                     <!--           ),                                                         -->
                     <!--         ),                                                           -->
+                    <!--         linkable_elements=(                                          -->
+                    <!--           LinkableDimension(                                         -->
+                    <!--             semantic_model_origin=SemanticModelReference(            -->
+                    <!--               semantic_model_name='listings_latest',                 -->
+                    <!--             ),                                                       -->
+                    <!--             element_name='is_lux_latest',                            -->
+                    <!--             dimension_type=CATEGORICAL,                              -->
+                    <!--             entity_links=(                                           -->
+                    <!--               EntityReference(element_name='listing'),               -->
+                    <!--             ),                                                       -->
+                    <!--             join_path=(                                              -->
+                    <!--               SemanticModelJoinPathElement(                          -->
+                    <!--                 semantic_model_reference=SemanticModelReference(     -->
+                    <!--                   semantic_model_name='listings_latest',             -->
+                    <!--                 ),                                                   -->
+                    <!--                 join_on_entity=EntityReference(                      -->
+                    <!--                   element_name='listing',                            -->
+                    <!--                 ),                                                   -->
+                    <!--               ),                                                     -->
+                    <!--             ),                                                       -->
+                    <!--             properties=frozenset(JOINED,),                           -->
+                    <!--           ),                                                         -->
+                    <!--         ),                                                           -->
                     <!--       ),                                                             -->
                     <!--     ),                                                               -->
                     <!--   )                                                                  -->
@@ -48,6 +71,27 @@
                                 <!--       DimensionSpec(                                             -->
                                 <!--         element_name='is_lux_latest',                            -->
                                 <!--         entity_links=(EntityReference(element_name='listing'),), -->
+                                <!--       ),                                                         -->
+                                <!--     ),                                                           -->
+                                <!--     linkable_elements=(                                          -->
+                                <!--       LinkableDimension(                                         -->
+                                <!--         semantic_model_origin=SemanticModelReference(            -->
+                                <!--           semantic_model_name='listings_latest',                 -->
+                                <!--         ),                                                       -->
+                                <!--         element_name='is_lux_latest',                            -->
+                                <!--         dimension_type=CATEGORICAL,                              -->
+                                <!--         entity_links=(EntityReference(element_name='listing'),), -->
+                                <!--         join_path=(                                              -->
+                                <!--           SemanticModelJoinPathElement(                          -->
+                                <!--             semantic_model_reference=SemanticModelReference(     -->
+                                <!--               semantic_model_name='listings_latest',             -->
+                                <!--             ),                                                   -->
+                                <!--             join_on_entity=EntityReference(                      -->
+                                <!--               element_name='listing',                            -->
+                                <!--             ),                                                   -->
+                                <!--           ),                                                     -->
+                                <!--         ),                                                       -->
+                                <!--         properties=frozenset(JOINED,),                           -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->
@@ -136,6 +180,29 @@
                     <!--             entity_links=(EntityReference(element_name='listing'),), -->
                     <!--           ),                                                         -->
                     <!--         ),                                                           -->
+                    <!--         linkable_elements=(                                          -->
+                    <!--           LinkableDimension(                                         -->
+                    <!--             semantic_model_origin=SemanticModelReference(            -->
+                    <!--               semantic_model_name='listings_latest',                 -->
+                    <!--             ),                                                       -->
+                    <!--             element_name='is_lux_latest',                            -->
+                    <!--             dimension_type=CATEGORICAL,                              -->
+                    <!--             entity_links=(                                           -->
+                    <!--               EntityReference(element_name='listing'),               -->
+                    <!--             ),                                                       -->
+                    <!--             join_path=(                                              -->
+                    <!--               SemanticModelJoinPathElement(                          -->
+                    <!--                 semantic_model_reference=SemanticModelReference(     -->
+                    <!--                   semantic_model_name='listings_latest',             -->
+                    <!--                 ),                                                   -->
+                    <!--                 join_on_entity=EntityReference(                      -->
+                    <!--                   element_name='listing',                            -->
+                    <!--                 ),                                                   -->
+                    <!--               ),                                                     -->
+                    <!--             ),                                                       -->
+                    <!--             properties=frozenset(JOINED,),                           -->
+                    <!--           ),                                                         -->
+                    <!--         ),                                                           -->
                     <!--       ),                                                             -->
                     <!--     ),                                                               -->
                     <!--   )                                                                  -->
@@ -159,6 +226,27 @@
                                 <!--       DimensionSpec(                                             -->
                                 <!--         element_name='is_lux_latest',                            -->
                                 <!--         entity_links=(EntityReference(element_name='listing'),), -->
+                                <!--       ),                                                         -->
+                                <!--     ),                                                           -->
+                                <!--     linkable_elements=(                                          -->
+                                <!--       LinkableDimension(                                         -->
+                                <!--         semantic_model_origin=SemanticModelReference(            -->
+                                <!--           semantic_model_name='listings_latest',                 -->
+                                <!--         ),                                                       -->
+                                <!--         element_name='is_lux_latest',                            -->
+                                <!--         dimension_type=CATEGORICAL,                              -->
+                                <!--         entity_links=(EntityReference(element_name='listing'),), -->
+                                <!--         join_path=(                                              -->
+                                <!--           SemanticModelJoinPathElement(                          -->
+                                <!--             semantic_model_reference=SemanticModelReference(     -->
+                                <!--               semantic_model_name='listings_latest',             -->
+                                <!--             ),                                                   -->
+                                <!--             join_on_entity=EntityReference(                      -->
+                                <!--               element_name='listing',                            -->
+                                <!--             ),                                                   -->
+                                <!--           ),                                                     -->
+                                <!--         ),                                                       -->
+                                <!--         properties=frozenset(JOINED,),                           -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -25,6 +25,19 @@
                     <!--             entity_links=(EntityReference(element_name='booking'),), -->
                     <!--           ),                                                         -->
                     <!--         ),                                                           -->
+                    <!--         linkable_elements=(                                          -->
+                    <!--           LinkableDimension(                                         -->
+                    <!--             semantic_model_origin=SemanticModelReference(            -->
+                    <!--               semantic_model_name='bookings_source',                 -->
+                    <!--             ),                                                       -->
+                    <!--             element_name='is_instant',                               -->
+                    <!--             dimension_type=CATEGORICAL,                              -->
+                    <!--             entity_links=(                                           -->
+                    <!--               EntityReference(element_name='booking'),               -->
+                    <!--             ),                                                       -->
+                    <!--             properties=frozenset(LOCAL,),                            -->
+                    <!--           ),                                                         -->
+                    <!--         ),                                                           -->
                     <!--       ),                                                             -->
                     <!--     ),                                                               -->
                     <!--     alias='booking_value_with_is_instant_constraint',                -->
@@ -49,6 +62,17 @@
                                 <!--       DimensionSpec(                                             -->
                                 <!--         element_name='is_instant',                               -->
                                 <!--         entity_links=(EntityReference(element_name='booking'),), -->
+                                <!--       ),                                                         -->
+                                <!--     ),                                                           -->
+                                <!--     linkable_elements=(                                          -->
+                                <!--       LinkableDimension(                                         -->
+                                <!--         semantic_model_origin=SemanticModelReference(            -->
+                                <!--           semantic_model_name='bookings_source',                 -->
+                                <!--         ),                                                       -->
+                                <!--         element_name='is_instant',                               -->
+                                <!--         dimension_type=CATEGORICAL,                              -->
+                                <!--         entity_links=(EntityReference(element_name='booking'),), -->
+                                <!--         properties=frozenset(LOCAL,),                            -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -15,30 +15,52 @@
             <!--         linkable_specs=(                                                       -->
             <!--           TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
             <!--         ),                                                                     -->
+            <!--         linkable_elements=(                                                    -->
+            <!--           LinkableDimension(                                                   -->
+            <!--             semantic_model_origin=SemanticModelReference(                      -->
+            <!--               semantic_model_name='bookings_source',                           -->
+            <!--             ),                                                                 -->
+            <!--             element_name='metric_time',                                        -->
+            <!--             dimension_type=TIME,                                               -->
+            <!--             properties=frozenset(METRIC_TIME,),                                -->
+            <!--             time_granularity=DAY,                                              -->
+            <!--           ),                                                                   -->
+            <!--         ),                                                                     -->
             <!--       ),                                                                       -->
             <!--     ),                                                                         -->
             <!--   )                                                                            -->
             <ComputeMetricsNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
                 <!-- node_id = NodeId(id_str='cm_0') -->
-                <!-- metric_spec =                                        -->
-                <!--   MetricSpec(                                        -->
-                <!--     element_name='bookings',                         -->
-                <!--     filter_specs=(                                   -->
-                <!--       WhereFilterSpec(                               -->
-                <!--         where_sql="metric_time__day = '2020-01-01'", -->
-                <!--         bind_parameters=SqlBindParameters(),         -->
-                <!--         linkable_specs=(                             -->
-                <!--           TimeDimensionSpec(                         -->
-                <!--             element_name='metric_time',              -->
-                <!--             time_granularity=DAY,                    -->
-                <!--           ),                                         -->
-                <!--         ),                                           -->
-                <!--       ),                                             -->
-                <!--     ),                                               -->
-                <!--     alias='bookings_start_of_month',                 -->
-                <!--     offset_to_grain=MONTH,                           -->
-                <!--   )                                                  -->
+                <!-- metric_spec =                                             -->
+                <!--   MetricSpec(                                             -->
+                <!--     element_name='bookings',                              -->
+                <!--     filter_specs=(                                        -->
+                <!--       WhereFilterSpec(                                    -->
+                <!--         where_sql="metric_time__day = '2020-01-01'",      -->
+                <!--         bind_parameters=SqlBindParameters(),              -->
+                <!--         linkable_specs=(                                  -->
+                <!--           TimeDimensionSpec(                              -->
+                <!--             element_name='metric_time',                   -->
+                <!--             time_granularity=DAY,                         -->
+                <!--           ),                                              -->
+                <!--         ),                                                -->
+                <!--         linkable_elements=(                               -->
+                <!--           LinkableDimension(                              -->
+                <!--             semantic_model_origin=SemanticModelReference( -->
+                <!--               semantic_model_name='bookings_source',      -->
+                <!--             ),                                            -->
+                <!--             element_name='metric_time',                   -->
+                <!--             dimension_type=TIME,                          -->
+                <!--             properties=frozenset(METRIC_TIME,),           -->
+                <!--             time_granularity=DAY,                         -->
+                <!--           ),                                              -->
+                <!--         ),                                                -->
+                <!--       ),                                                  -->
+                <!--     ),                                                    -->
+                <!--     alias='bookings_start_of_month',                      -->
+                <!--     offset_to_grain=MONTH,                                -->
+                <!--   )                                                       -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
                     <!-- node_id = NodeId(id_str='am_0') -->
@@ -56,6 +78,17 @@
                             <!--     where_sql="metric_time__day = '2020-01-01'",                                           -->
                             <!--     bind_parameters=SqlBindParameters(),                                                   -->
                             <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
+                            <!--     linkable_elements=(                                                                    -->
+                            <!--       LinkableDimension(                                                                   -->
+                            <!--         semantic_model_origin=SemanticModelReference(                                      -->
+                            <!--           semantic_model_name='bookings_source',                                           -->
+                            <!--         ),                                                                                 -->
+                            <!--         element_name='metric_time',                                                        -->
+                            <!--         dimension_type=TIME,                                                               -->
+                            <!--         properties=frozenset(METRIC_TIME,),                                                -->
+                            <!--         time_granularity=DAY,                                                              -->
+                            <!--       ),                                                                                   -->
+                            <!--     ),                                                                                     -->
                             <!--   )                                                                                        -->
                             <FilterElementsNode>
                                 <!-- description =                                                                  -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -15,6 +15,17 @@
             <!--         linkable_specs=(                                                       -->
             <!--           TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
             <!--         ),                                                                     -->
+            <!--         linkable_elements=(                                                    -->
+            <!--           LinkableDimension(                                                   -->
+            <!--             semantic_model_origin=SemanticModelReference(                      -->
+            <!--               semantic_model_name='bookings_source',                           -->
+            <!--             ),                                                                 -->
+            <!--             element_name='metric_time',                                        -->
+            <!--             dimension_type=TIME,                                               -->
+            <!--             properties=frozenset(METRIC_TIME,),                                -->
+            <!--             time_granularity=DAY,                                              -->
+            <!--           ),                                                                   -->
+            <!--         ),                                                                     -->
             <!--       ),                                                                       -->
             <!--     ),                                                                         -->
             <!--   )                                                                            -->
@@ -37,6 +48,17 @@
                     <!--             time_granularity=DAY,                                      -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
+                    <!--         linkable_elements=(                                            -->
+                    <!--           LinkableDimension(                                           -->
+                    <!--             semantic_model_origin=SemanticModelReference(              -->
+                    <!--               semantic_model_name='bookings_source',                   -->
+                    <!--             ),                                                         -->
+                    <!--             element_name='metric_time',                                -->
+                    <!--             dimension_type=TIME,                                       -->
+                    <!--             properties=frozenset(METRIC_TIME,),                        -->
+                    <!--             time_granularity=DAY,                                      -->
+                    <!--           ),                                                           -->
+                    <!--         ),                                                             -->
                     <!--       ),                                                               -->
                     <!--     ),                                                                 -->
                     <!--     offset_window=PydanticMetricTimeWindow(count=1, granularity=WEEK), -->
@@ -53,17 +75,28 @@
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
                                 <!-- node_id = NodeId(id_str='wcc_0') -->
-                                <!-- where_condition =                                -->
-                                <!--   WhereFilterSpec(                               -->
-                                <!--     where_sql="metric_time__day = '2020-01-01'", -->
-                                <!--     bind_parameters=SqlBindParameters(),         -->
-                                <!--     linkable_specs=(                             -->
-                                <!--       TimeDimensionSpec(                         -->
-                                <!--         element_name='metric_time',              -->
-                                <!--         time_granularity=DAY,                    -->
-                                <!--       ),                                         -->
-                                <!--     ),                                           -->
-                                <!--   )                                              -->
+                                <!-- where_condition =                                     -->
+                                <!--   WhereFilterSpec(                                    -->
+                                <!--     where_sql="metric_time__day = '2020-01-01'",      -->
+                                <!--     bind_parameters=SqlBindParameters(),              -->
+                                <!--     linkable_specs=(                                  -->
+                                <!--       TimeDimensionSpec(                              -->
+                                <!--         element_name='metric_time',                   -->
+                                <!--         time_granularity=DAY,                         -->
+                                <!--       ),                                              -->
+                                <!--     ),                                                -->
+                                <!--     linkable_elements=(                               -->
+                                <!--       LinkableDimension(                              -->
+                                <!--         semantic_model_origin=SemanticModelReference( -->
+                                <!--           semantic_model_name='bookings_source',      -->
+                                <!--         ),                                            -->
+                                <!--         element_name='metric_time',                   -->
+                                <!--         dimension_type=TIME,                          -->
+                                <!--         properties=frozenset(METRIC_TIME,),           -->
+                                <!--         time_granularity=DAY,                         -->
+                                <!--       ),                                              -->
+                                <!--     ),                                                -->
+                                <!--   )                                                   -->
                                 <FilterElementsNode>
                                     <!-- description =                                                     -->
                                     <!--   ("Pass Only Elements: ['booking_value', 'metric_time__month', " -->
@@ -104,22 +137,33 @@
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_1') -->
-                    <!-- metric_spec =                                        -->
-                    <!--   MetricSpec(                                        -->
-                    <!--     element_name='bookers',                          -->
-                    <!--     filter_specs=(                                   -->
-                    <!--       WhereFilterSpec(                               -->
-                    <!--         where_sql="metric_time__day = '2020-01-01'", -->
-                    <!--         bind_parameters=SqlBindParameters(),         -->
-                    <!--         linkable_specs=(                             -->
-                    <!--           TimeDimensionSpec(                         -->
-                    <!--             element_name='metric_time',              -->
-                    <!--             time_granularity=DAY,                    -->
-                    <!--           ),                                         -->
-                    <!--         ),                                           -->
-                    <!--       ),                                             -->
-                    <!--     ),                                               -->
-                    <!--   )                                                  -->
+                    <!-- metric_spec =                                             -->
+                    <!--   MetricSpec(                                             -->
+                    <!--     element_name='bookers',                               -->
+                    <!--     filter_specs=(                                        -->
+                    <!--       WhereFilterSpec(                                    -->
+                    <!--         where_sql="metric_time__day = '2020-01-01'",      -->
+                    <!--         bind_parameters=SqlBindParameters(),              -->
+                    <!--         linkable_specs=(                                  -->
+                    <!--           TimeDimensionSpec(                              -->
+                    <!--             element_name='metric_time',                   -->
+                    <!--             time_granularity=DAY,                         -->
+                    <!--           ),                                              -->
+                    <!--         ),                                                -->
+                    <!--         linkable_elements=(                               -->
+                    <!--           LinkableDimension(                              -->
+                    <!--             semantic_model_origin=SemanticModelReference( -->
+                    <!--               semantic_model_name='bookings_source',      -->
+                    <!--             ),                                            -->
+                    <!--             element_name='metric_time',                   -->
+                    <!--             dimension_type=TIME,                          -->
+                    <!--             properties=frozenset(METRIC_TIME,),           -->
+                    <!--             time_granularity=DAY,                         -->
+                    <!--           ),                                              -->
+                    <!--         ),                                                -->
+                    <!--       ),                                                  -->
+                    <!--     ),                                                    -->
+                    <!--   )                                                       -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
                         <!-- node_id = NodeId(id_str='am_1') -->
@@ -132,17 +176,28 @@
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
                                 <!-- node_id = NodeId(id_str='wcc_1') -->
-                                <!-- where_condition =                                -->
-                                <!--   WhereFilterSpec(                               -->
-                                <!--     where_sql="metric_time__day = '2020-01-01'", -->
-                                <!--     bind_parameters=SqlBindParameters(),         -->
-                                <!--     linkable_specs=(                             -->
-                                <!--       TimeDimensionSpec(                         -->
-                                <!--         element_name='metric_time',              -->
-                                <!--         time_granularity=DAY,                    -->
-                                <!--       ),                                         -->
-                                <!--     ),                                           -->
-                                <!--   )                                              -->
+                                <!-- where_condition =                                     -->
+                                <!--   WhereFilterSpec(                                    -->
+                                <!--     where_sql="metric_time__day = '2020-01-01'",      -->
+                                <!--     bind_parameters=SqlBindParameters(),              -->
+                                <!--     linkable_specs=(                                  -->
+                                <!--       TimeDimensionSpec(                              -->
+                                <!--         element_name='metric_time',                   -->
+                                <!--         time_granularity=DAY,                         -->
+                                <!--       ),                                              -->
+                                <!--     ),                                                -->
+                                <!--     linkable_elements=(                               -->
+                                <!--       LinkableDimension(                              -->
+                                <!--         semantic_model_origin=SemanticModelReference( -->
+                                <!--           semantic_model_name='bookings_source',      -->
+                                <!--         ),                                            -->
+                                <!--         element_name='metric_time',                   -->
+                                <!--         dimension_type=TIME,                          -->
+                                <!--         properties=frozenset(METRIC_TIME,),           -->
+                                <!--         time_granularity=DAY,                         -->
+                                <!--       ),                                              -->
+                                <!--     ),                                                -->
+                                <!--   )                                                   -->
                                 <FilterElementsNode>
                                     <!-- description =                                                                 -->
                                     <!--   "Pass Only Elements: ['bookers', 'metric_time__month', 'metric_time__day']" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -18,6 +18,27 @@
             <!--             entity_links=(EntityReference(element_name='listing'),), -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
+            <!--         linkable_elements=(                                          -->
+            <!--           LinkableDimension(                                         -->
+            <!--             semantic_model_origin=SemanticModelReference(            -->
+            <!--               semantic_model_name='listings_latest',                 -->
+            <!--             ),                                                       -->
+            <!--             element_name='country_latest',                           -->
+            <!--             dimension_type=CATEGORICAL,                              -->
+            <!--             entity_links=(EntityReference(element_name='listing'),), -->
+            <!--             join_path=(                                              -->
+            <!--               SemanticModelJoinPathElement(                          -->
+            <!--                 semantic_model_reference=SemanticModelReference(     -->
+            <!--                   semantic_model_name='listings_latest',             -->
+            <!--                 ),                                                   -->
+            <!--                 join_on_entity=EntityReference(                      -->
+            <!--                   element_name='listing',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
+            <!--             properties=frozenset(JOINED,),                           -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
             <!--       ),                                                             -->
             <!--     ),                                                               -->
             <!--   )                                                                  -->
@@ -45,6 +66,27 @@
                         <!--       DimensionSpec(                                             -->
                         <!--         element_name='country_latest',                           -->
                         <!--         entity_links=(EntityReference(element_name='listing'),), -->
+                        <!--       ),                                                         -->
+                        <!--     ),                                                           -->
+                        <!--     linkable_elements=(                                          -->
+                        <!--       LinkableDimension(                                         -->
+                        <!--         semantic_model_origin=SemanticModelReference(            -->
+                        <!--           semantic_model_name='listings_latest',                 -->
+                        <!--         ),                                                       -->
+                        <!--         element_name='country_latest',                           -->
+                        <!--         dimension_type=CATEGORICAL,                              -->
+                        <!--         entity_links=(EntityReference(element_name='listing'),), -->
+                        <!--         join_path=(                                              -->
+                        <!--           SemanticModelJoinPathElement(                          -->
+                        <!--             semantic_model_reference=SemanticModelReference(     -->
+                        <!--               semantic_model_name='listings_latest',             -->
+                        <!--             ),                                                   -->
+                        <!--             join_on_entity=EntityReference(                      -->
+                        <!--               element_name='listing',                            -->
+                        <!--             ),                                                   -->
+                        <!--           ),                                                     -->
+                        <!--         ),                                                       -->
+                        <!--         properties=frozenset(JOINED,),                           -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -15,6 +15,17 @@
             <!--         linkable_specs=(                                                       -->
             <!--           TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
             <!--         ),                                                                     -->
+            <!--         linkable_elements=(                                                    -->
+            <!--           LinkableDimension(                                                   -->
+            <!--             semantic_model_origin=SemanticModelReference(                      -->
+            <!--               semantic_model_name='bookings_source',                           -->
+            <!--             ),                                                                 -->
+            <!--             element_name='metric_time',                                        -->
+            <!--             dimension_type=TIME,                                               -->
+            <!--             properties=frozenset(METRIC_TIME,),                                -->
+            <!--             time_granularity=DAY,                                              -->
+            <!--           ),                                                                   -->
+            <!--         ),                                                                     -->
             <!--       ),                                                                       -->
             <!--     ),                                                                         -->
             <!--   )                                                                            -->
@@ -39,6 +50,17 @@
                         <!--     where_sql="metric_time__day >= '2020-01-01'",                                          -->
                         <!--     bind_parameters=SqlBindParameters(),                                                   -->
                         <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
+                        <!--     linkable_elements=(                                                                    -->
+                        <!--       LinkableDimension(                                                                   -->
+                        <!--         semantic_model_origin=SemanticModelReference(                                      -->
+                        <!--           semantic_model_name='bookings_source',                                           -->
+                        <!--         ),                                                                                 -->
+                        <!--         element_name='metric_time',                                                        -->
+                        <!--         dimension_type=TIME,                                                               -->
+                        <!--         properties=frozenset(METRIC_TIME,),                                                -->
+                        <!--         time_granularity=DAY,                                                              -->
+                        <!--       ),                                                                                   -->
+                        <!--     ),                                                                                     -->
                         <!--   )                                                                                        -->
                         <FilterElementsNode>
                             <!-- description =                                                                   -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -18,6 +18,27 @@
             <!--             entity_links=(EntityReference(element_name='listing'),), -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
+            <!--         linkable_elements=(                                          -->
+            <!--           LinkableDimension(                                         -->
+            <!--             semantic_model_origin=SemanticModelReference(            -->
+            <!--               semantic_model_name='listings_latest',                 -->
+            <!--             ),                                                       -->
+            <!--             element_name='country_latest',                           -->
+            <!--             dimension_type=CATEGORICAL,                              -->
+            <!--             entity_links=(EntityReference(element_name='listing'),), -->
+            <!--             join_path=(                                              -->
+            <!--               SemanticModelJoinPathElement(                          -->
+            <!--                 semantic_model_reference=SemanticModelReference(     -->
+            <!--                   semantic_model_name='listings_latest',             -->
+            <!--                 ),                                                   -->
+            <!--                 join_on_entity=EntityReference(                      -->
+            <!--                   element_name='listing',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
+            <!--             properties=frozenset(JOINED,),                           -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
             <!--       ),                                                             -->
             <!--     ),                                                               -->
             <!--   )                                                                  -->
@@ -27,17 +48,36 @@
                 <WhereConstraintNode>
                     <!-- description = 'Constrain Output with WHERE' -->
                     <!-- node_id = NodeId(id_str='wcc_0') -->
-                    <!-- where_condition =                                                -->
-                    <!--   WhereFilterSpec(                                               -->
-                    <!--     where_sql="listing__country_latest = 'us'",                  -->
-                    <!--     bind_parameters=SqlBindParameters(),                         -->
-                    <!--     linkable_specs=(                                             -->
-                    <!--       DimensionSpec(                                             -->
-                    <!--         element_name='country_latest',                           -->
-                    <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                    <!--       ),                                                         -->
-                    <!--     ),                                                           -->
-                    <!--   )                                                              -->
+                    <!-- where_condition =                                                   -->
+                    <!--   WhereFilterSpec(                                                  -->
+                    <!--     where_sql="listing__country_latest = 'us'",                     -->
+                    <!--     bind_parameters=SqlBindParameters(),                            -->
+                    <!--     linkable_specs=(                                                -->
+                    <!--       DimensionSpec(                                                -->
+                    <!--         element_name='country_latest',                              -->
+                    <!--         entity_links=(EntityReference(element_name='listing'),),    -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--     linkable_elements=(                                             -->
+                    <!--       LinkableDimension(                                            -->
+                    <!--         semantic_model_origin=SemanticModelReference(               -->
+                    <!--           semantic_model_name='listings_latest',                    -->
+                    <!--         ),                                                          -->
+                    <!--         element_name='country_latest',                              -->
+                    <!--         dimension_type=CATEGORICAL,                                 -->
+                    <!--         entity_links=(EntityReference(element_name='listing'),),    -->
+                    <!--         join_path=(                                                 -->
+                    <!--           SemanticModelJoinPathElement(                             -->
+                    <!--             semantic_model_reference=SemanticModelReference(        -->
+                    <!--               semantic_model_name='listings_latest',                -->
+                    <!--             ),                                                      -->
+                    <!--             join_on_entity=EntityReference(element_name='listing'), -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         properties=frozenset(JOINED,),                              -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--   )                                                                 -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['bookings', 'listing__country_latest']" -->
                         <!-- node_id = NodeId(id_str='pfe_2') -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -57,6 +57,17 @@
                             <!--         entity_links=(EntityReference(element_name='booking'),), -->
                             <!--       ),                                                         -->
                             <!--     ),                                                           -->
+                            <!--     linkable_elements=(                                          -->
+                            <!--       LinkableDimension(                                         -->
+                            <!--         semantic_model_origin=SemanticModelReference(            -->
+                            <!--           semantic_model_name='bookings_source',                 -->
+                            <!--         ),                                                       -->
+                            <!--         element_name='is_instant',                               -->
+                            <!--         dimension_type=CATEGORICAL,                              -->
+                            <!--         entity_links=(EntityReference(element_name='booking'),), -->
+                            <!--         properties=frozenset(LOCAL,),                            -->
+                            <!--       ),                                                         -->
+                            <!--     ),                                                           -->
                             <!--   )                                                              -->
                             <FilterElementsNode>
                                 <!-- description =                                                                        -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -57,6 +57,17 @@
                             <!--         entity_links=(EntityReference(element_name='booking'),), -->
                             <!--       ),                                                         -->
                             <!--     ),                                                           -->
+                            <!--     linkable_elements=(                                          -->
+                            <!--       LinkableDimension(                                         -->
+                            <!--         semantic_model_origin=SemanticModelReference(            -->
+                            <!--           semantic_model_name='bookings_source',                 -->
+                            <!--         ),                                                       -->
+                            <!--         element_name='is_instant',                               -->
+                            <!--         dimension_type=CATEGORICAL,                              -->
+                            <!--         entity_links=(EntityReference(element_name='booking'),), -->
+                            <!--         properties=frozenset(LOCAL,),                            -->
+                            <!--       ),                                                         -->
+                            <!--     ),                                                           -->
                             <!--   )                                                              -->
                             <FilterElementsNode>
                                 <!-- description =                                                                        -->


### PR DESCRIPTION
Push resolved linkable elements through to WhereFilterSpec

The resolved LinkableElements gathered during the filter spec
resolution phase of query processing need to be available to
each WhereFilterSpec so that we can determine whether or not
a given WhereFilterSpec is eligible for predicate pushdown.

This change simply adds the necessary property and wires these
elements through to where we will need to access them in the
DataflowPlanBuilder. This change proved a bit troublesome due
to the SerializableDataclass construct, which has some particular
requirements which required some slightly odd inheritance tagging.