### PR TITLE
Fix pretty print bug for sets containing enums

### DIFF
--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -45,7 +45,7 @@ class MetricFlowPrettyFormatter:
         """Pretty prints a sequence object i.e. list or tuple.
 
         Args:
-            list_like_obj: A list or a tuple.
+            list_like_obj: A list, tuple, set, or frozenset.
             remaining_line_width: If specified, try to make the string representation <= this many columns wide.
 
         Returns:
@@ -60,7 +60,10 @@ class MetricFlowPrettyFormatter:
         elif isinstance(list_like_obj, set) or isinstance(list_like_obj, frozenset):
             left_enclose_str = f"{type(list_like_obj).__name__}("
             right_enclose_str = ")"
-            list_like_obj = sorted(list_like_obj)
+            list_like_obj = sorted(
+                list_like_obj,
+                key=(lambda x: x.name) if (list_like_obj and isinstance(list(list_like_obj)[0], Enum)) else None,
+            )
         else:
             raise RuntimeError(f"Unhandled type: {type(list_like_obj)}")
 

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -60,10 +60,7 @@ class MetricFlowPrettyFormatter:
         elif isinstance(list_like_obj, set) or isinstance(list_like_obj, frozenset):
             left_enclose_str = f"{type(list_like_obj).__name__}("
             right_enclose_str = ")"
-            list_like_obj = sorted(
-                list_like_obj,
-                key=(lambda x: x.name) if (list_like_obj and isinstance(list(list_like_obj)[0], Enum)) else None,
-            )
+            list_like_obj = sorted(self._handle_any_obj(obj, None) for obj in list_like_obj)
         else:
             raise RuntimeError(f"Unhandled type: {type(list_like_obj)}")
 

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__accumulate_last_2_months_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__accumulate_last_2_months_metric__result.txt
@@ -13,7 +13,7 @@ GroupByItemResolution(
           ),
           element_name='metric_time',
           dimension_type=TIME,
-          properties=frozenset(METRIC_TIME,),
+          properties=frozenset('METRIC_TIME',),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_different_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_different_parent_time_grains__result.txt
@@ -26,7 +26,7 @@ GroupByItemResolution(
                     element_name='metric_time',
                     dimension_type=TIME,
                     properties=frozenset(
-                      METRIC_TIME,
+                      'METRIC_TIME',
                     ),
                     time_granularity=MONTH,
                   ),
@@ -66,7 +66,7 @@ GroupByItemResolution(
                     element_name='metric_time',
                     dimension_type=TIME,
                     properties=frozenset(
-                      METRIC_TIME,
+                      'METRIC_TIME',
                     ),
                     time_granularity=YEAR,
                   ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_same_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_same_parent_time_grains__result.txt
@@ -13,7 +13,7 @@ GroupByItemResolution(
           ),
           element_name='metric_time',
           dimension_type=TIME,
-          properties=frozenset(METRIC_TIME,),
+          properties=frozenset('METRIC_TIME',),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_different_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_different_time_grains__result.txt
@@ -23,7 +23,7 @@ GroupByItemResolution(
                     element_name='metric_time',
                     dimension_type=TIME,
                     properties=frozenset(
-                      METRIC_TIME,
+                      'METRIC_TIME',
                     ),
                     time_granularity=MONTH,
                   ),
@@ -61,7 +61,7 @@ GroupByItemResolution(
                     element_name='metric_time',
                     dimension_type=TIME,
                     properties=frozenset(
-                      METRIC_TIME,
+                      'METRIC_TIME',
                     ),
                     time_granularity=YEAR,
                   ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_same_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_same_time_grains__result.txt
@@ -13,7 +13,7 @@ GroupByItemResolution(
           ),
           element_name='metric_time',
           dimension_type=TIME,
-          properties=frozenset(METRIC_TIME,),
+          properties=frozenset('METRIC_TIME',),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__no_metrics__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__no_metrics__result.txt
@@ -10,7 +10,7 @@ GroupByItemResolution(
         LinkableDimension(
           element_name='metric_time',
           dimension_type=TIME,
-          properties=frozenset(METRIC_TIME,),
+          properties=frozenset('METRIC_TIME',),
           time_granularity=DAY,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__simple_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__simple_metric__result.txt
@@ -13,7 +13,7 @@ GroupByItemResolution(
           ),
           element_name='metric_time',
           dimension_type=TIME,
-          properties=frozenset(METRIC_TIME,),
+          properties=frozenset('METRIC_TIME',),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_derived_metrics_with_common_filtered_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_derived_metrics_with_common_filtered_metric__result.txt
@@ -36,7 +36,7 @@ FilterSpecResolutionLookUp(
               element_name='metric_time',
               dimension_type=TIME,
               properties=frozenset(
-                METRIC_TIME,
+                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),
@@ -94,7 +94,7 @@ FilterSpecResolutionLookUp(
               element_name='metric_time',
               dimension_type=TIME,
               properties=frozenset(
-                METRIC_TIME,
+                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_filter__result.txt
@@ -55,7 +55,7 @@ FilterSpecResolutionLookUp(
                         element_name='metric_time',
                         dimension_type=TIME,
                         properties=frozenset(
-                          METRIC_TIME,
+                          'METRIC_TIME',
                         ),
                         time_granularity=MONTH,
                       ),
@@ -95,7 +95,7 @@ FilterSpecResolutionLookUp(
                         element_name='metric_time',
                         dimension_type=TIME,
                         properties=frozenset(
-                          METRIC_TIME,
+                          'METRIC_TIME',
                         ),
                         time_granularity=YEAR,
                       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_input_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_input_filter__result.txt
@@ -56,7 +56,7 @@ FilterSpecResolutionLookUp(
                         element_name='metric_time',
                         dimension_type=TIME,
                         properties=frozenset(
-                          METRIC_TIME,
+                          'METRIC_TIME',
                         ),
                         time_granularity=MONTH,
                       ),
@@ -98,7 +98,7 @@ FilterSpecResolutionLookUp(
                         element_name='metric_time',
                         dimension_type=TIME,
                         properties=frozenset(
-                          METRIC_TIME,
+                          'METRIC_TIME',
                         ),
                         time_granularity=YEAR,
                       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_filter__result.txt
@@ -36,7 +36,7 @@ FilterSpecResolutionLookUp(
               element_name='metric_time',
               dimension_type=TIME,
               properties=frozenset(
-                METRIC_TIME,
+                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_input_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_input_filter__result.txt
@@ -36,7 +36,7 @@ FilterSpecResolutionLookUp(
               element_name='metric_time',
               dimension_type=TIME,
               properties=frozenset(
-                METRIC_TIME,
+                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__accumulate_last_2_months_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__accumulate_last_2_months_metric__result.txt
@@ -36,7 +36,7 @@ FilterSpecResolutionLookUp(
               element_name='metric_time',
               dimension_type=TIME,
               properties=frozenset(
-                METRIC_TIME,
+                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_different_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_different_parent_time_grains__result.txt
@@ -55,7 +55,7 @@ FilterSpecResolutionLookUp(
                         element_name='metric_time',
                         dimension_type=TIME,
                         properties=frozenset(
-                          METRIC_TIME,
+                          'METRIC_TIME',
                         ),
                         time_granularity=MONTH,
                       ),
@@ -95,7 +95,7 @@ FilterSpecResolutionLookUp(
                         element_name='metric_time',
                         dimension_type=TIME,
                         properties=frozenset(
-                          METRIC_TIME,
+                          'METRIC_TIME',
                         ),
                         time_granularity=YEAR,
                       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_same_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_same_parent_time_grains__result.txt
@@ -36,7 +36,7 @@ FilterSpecResolutionLookUp(
               element_name='metric_time',
               dimension_type=TIME,
               properties=frozenset(
-                METRIC_TIME,
+                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_different_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_different_time_grains__result.txt
@@ -57,7 +57,7 @@ FilterSpecResolutionLookUp(
                         element_name='metric_time',
                         dimension_type=TIME,
                         properties=frozenset(
-                          METRIC_TIME,
+                          'METRIC_TIME',
                         ),
                         time_granularity=MONTH,
                       ),
@@ -95,7 +95,7 @@ FilterSpecResolutionLookUp(
                         element_name='metric_time',
                         dimension_type=TIME,
                         properties=frozenset(
-                          METRIC_TIME,
+                          'METRIC_TIME',
                         ),
                         time_granularity=YEAR,
                       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_same_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_same_time_grains__result.txt
@@ -39,7 +39,7 @@ FilterSpecResolutionLookUp(
               element_name='metric_time',
               dimension_type=TIME,
               properties=frozenset(
-                METRIC_TIME,
+                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__simple_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__simple_metric__result.txt
@@ -36,7 +36,7 @@ FilterSpecResolutionLookUp(
               element_name='metric_time',
               dimension_type=TIME,
               properties=frozenset(
-                METRIC_TIME,
+                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -44,7 +44,7 @@
                     <!--         element_name='country_latest',                           -->
                     <!--         dimension_type=CATEGORICAL,                              -->
                     <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                    <!--         properties=frozenset(LOCAL,),                            -->
+                    <!--         properties=frozenset('LOCAL',),                          -->
                     <!--       ),                                                         -->
                     <!--     ),                                                           -->
                     <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
@@ -49,7 +49,7 @@
                     <!--         element_name='country_latest',                           -->
                     <!--         dimension_type=CATEGORICAL,                              -->
                     <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                    <!--         properties=frozenset(LOCAL,),                            -->
+                    <!--         properties=frozenset('LOCAL',),                          -->
                     <!--       ),                                                         -->
                     <!--     ),                                                           -->
                     <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -22,7 +22,7 @@
             <!--             ),                                                                 -->
             <!--             element_name='metric_time',                                        -->
             <!--             dimension_type=TIME,                                               -->
-            <!--             properties=frozenset(METRIC_TIME,),                                -->
+            <!--             properties=frozenset('METRIC_TIME',),                              -->
             <!--             time_granularity=DAY,                                              -->
             <!--           ),                                                                   -->
             <!--         ),                                                                     -->
@@ -49,7 +49,7 @@
                     <!--         ),                                                                                 -->
                     <!--         element_name='metric_time',                                                        -->
                     <!--         dimension_type=TIME,                                                               -->
-                    <!--         properties=frozenset(METRIC_TIME,),                                                -->
+                    <!--         properties=frozenset('METRIC_TIME',),                                              -->
                     <!--         time_granularity=DAY,                                                              -->
                     <!--       ),                                                                                   -->
                     <!--     ),                                                                                     -->
@@ -91,7 +91,7 @@
                                 <!--         ),                                            -->
                                 <!--         element_name='metric_time',                   -->
                                 <!--         dimension_type=TIME,                          -->
-                                <!--         properties=frozenset(METRIC_TIME,),           -->
+                                <!--         properties=frozenset('METRIC_TIME',),         -->
                                 <!--         time_granularity=DAY,                         -->
                                 <!--       ),                                              -->
                                 <!--     ),                                                -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -45,7 +45,7 @@
                     <!--                 ),                                                   -->
                     <!--               ),                                                     -->
                     <!--             ),                                                       -->
-                    <!--             properties=frozenset(JOINED,),                           -->
+                    <!--             properties=frozenset('JOINED',),                         -->
                     <!--           ),                                                         -->
                     <!--         ),                                                           -->
                     <!--       ),                                                             -->
@@ -91,7 +91,7 @@
                                 <!--             ),                                                   -->
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
-                                <!--         properties=frozenset(JOINED,),                           -->
+                                <!--         properties=frozenset('JOINED',),                         -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->
@@ -200,7 +200,7 @@
                     <!--                 ),                                                   -->
                     <!--               ),                                                     -->
                     <!--             ),                                                       -->
-                    <!--             properties=frozenset(JOINED,),                           -->
+                    <!--             properties=frozenset('JOINED',),                         -->
                     <!--           ),                                                         -->
                     <!--         ),                                                           -->
                     <!--       ),                                                             -->
@@ -246,7 +246,7 @@
                                 <!--             ),                                                   -->
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
-                                <!--         properties=frozenset(JOINED,),                           -->
+                                <!--         properties=frozenset('JOINED',),                         -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -35,7 +35,7 @@
                     <!--             entity_links=(                                           -->
                     <!--               EntityReference(element_name='booking'),               -->
                     <!--             ),                                                       -->
-                    <!--             properties=frozenset(LOCAL,),                            -->
+                    <!--             properties=frozenset('LOCAL',),                          -->
                     <!--           ),                                                         -->
                     <!--         ),                                                           -->
                     <!--       ),                                                             -->
@@ -72,7 +72,7 @@
                                 <!--         element_name='is_instant',                               -->
                                 <!--         dimension_type=CATEGORICAL,                              -->
                                 <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                <!--         properties=frozenset(LOCAL,),                            -->
+                                <!--         properties=frozenset('LOCAL',),                          -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -22,7 +22,7 @@
             <!--             ),                                                                 -->
             <!--             element_name='metric_time',                                        -->
             <!--             dimension_type=TIME,                                               -->
-            <!--             properties=frozenset(METRIC_TIME,),                                -->
+            <!--             properties=frozenset('METRIC_TIME',),                              -->
             <!--             time_granularity=DAY,                                              -->
             <!--           ),                                                                   -->
             <!--         ),                                                                     -->
@@ -52,7 +52,7 @@
                 <!--             ),                                            -->
                 <!--             element_name='metric_time',                   -->
                 <!--             dimension_type=TIME,                          -->
-                <!--             properties=frozenset(METRIC_TIME,),           -->
+                <!--             properties=frozenset('METRIC_TIME',),         -->
                 <!--             time_granularity=DAY,                         -->
                 <!--           ),                                              -->
                 <!--         ),                                                -->
@@ -85,7 +85,7 @@
                             <!--         ),                                                                                 -->
                             <!--         element_name='metric_time',                                                        -->
                             <!--         dimension_type=TIME,                                                               -->
-                            <!--         properties=frozenset(METRIC_TIME,),                                                -->
+                            <!--         properties=frozenset('METRIC_TIME',),                                              -->
                             <!--         time_granularity=DAY,                                                              -->
                             <!--       ),                                                                                   -->
                             <!--     ),                                                                                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -22,7 +22,7 @@
             <!--             ),                                                                 -->
             <!--             element_name='metric_time',                                        -->
             <!--             dimension_type=TIME,                                               -->
-            <!--             properties=frozenset(METRIC_TIME,),                                -->
+            <!--             properties=frozenset('METRIC_TIME',),                              -->
             <!--             time_granularity=DAY,                                              -->
             <!--           ),                                                                   -->
             <!--         ),                                                                     -->
@@ -55,7 +55,7 @@
                     <!--             ),                                                         -->
                     <!--             element_name='metric_time',                                -->
                     <!--             dimension_type=TIME,                                       -->
-                    <!--             properties=frozenset(METRIC_TIME,),                        -->
+                    <!--             properties=frozenset('METRIC_TIME',),                      -->
                     <!--             time_granularity=DAY,                                      -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
@@ -92,7 +92,7 @@
                                 <!--         ),                                            -->
                                 <!--         element_name='metric_time',                   -->
                                 <!--         dimension_type=TIME,                          -->
-                                <!--         properties=frozenset(METRIC_TIME,),           -->
+                                <!--         properties=frozenset('METRIC_TIME',),         -->
                                 <!--         time_granularity=DAY,                         -->
                                 <!--       ),                                              -->
                                 <!--     ),                                                -->
@@ -157,7 +157,7 @@
                     <!--             ),                                            -->
                     <!--             element_name='metric_time',                   -->
                     <!--             dimension_type=TIME,                          -->
-                    <!--             properties=frozenset(METRIC_TIME,),           -->
+                    <!--             properties=frozenset('METRIC_TIME',),         -->
                     <!--             time_granularity=DAY,                         -->
                     <!--           ),                                              -->
                     <!--         ),                                                -->
@@ -193,7 +193,7 @@
                                 <!--         ),                                            -->
                                 <!--         element_name='metric_time',                   -->
                                 <!--         dimension_type=TIME,                          -->
-                                <!--         properties=frozenset(METRIC_TIME,),           -->
+                                <!--         properties=frozenset('METRIC_TIME',),         -->
                                 <!--         time_granularity=DAY,                         -->
                                 <!--       ),                                              -->
                                 <!--     ),                                                -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -36,7 +36,7 @@
             <!--                 ),                                                   -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset(JOINED,),                           -->
+            <!--             properties=frozenset('JOINED',),                         -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--       ),                                                             -->
@@ -86,7 +86,7 @@
                         <!--             ),                                                   -->
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
-                        <!--         properties=frozenset(JOINED,),                           -->
+                        <!--         properties=frozenset('JOINED',),                         -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -22,7 +22,7 @@
             <!--             ),                                                                 -->
             <!--             element_name='metric_time',                                        -->
             <!--             dimension_type=TIME,                                               -->
-            <!--             properties=frozenset(METRIC_TIME,),                                -->
+            <!--             properties=frozenset('METRIC_TIME',),                              -->
             <!--             time_granularity=DAY,                                              -->
             <!--           ),                                                                   -->
             <!--         ),                                                                     -->
@@ -57,7 +57,7 @@
                         <!--         ),                                                                                 -->
                         <!--         element_name='metric_time',                                                        -->
                         <!--         dimension_type=TIME,                                                               -->
-                        <!--         properties=frozenset(METRIC_TIME,),                                                -->
+                        <!--         properties=frozenset('METRIC_TIME',),                                              -->
                         <!--         time_granularity=DAY,                                                              -->
                         <!--       ),                                                                                   -->
                         <!--     ),                                                                                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -36,7 +36,7 @@
             <!--                 ),                                                   -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset(JOINED,),                           -->
+            <!--             properties=frozenset('JOINED',),                         -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--       ),                                                             -->
@@ -74,7 +74,7 @@
                     <!--             join_on_entity=EntityReference(element_name='listing'), -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
-                    <!--         properties=frozenset(JOINED,),                              -->
+                    <!--         properties=frozenset('JOINED',),                            -->
                     <!--       ),                                                            -->
                     <!--     ),                                                              -->
                     <!--   )                                                                 -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -65,7 +65,7 @@
                             <!--         element_name='is_instant',                               -->
                             <!--         dimension_type=CATEGORICAL,                              -->
                             <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                            <!--         properties=frozenset(LOCAL,),                            -->
+                            <!--         properties=frozenset('LOCAL',),                          -->
                             <!--       ),                                                         -->
                             <!--     ),                                                           -->
                             <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -65,7 +65,7 @@
                             <!--         element_name='is_instant',                               -->
                             <!--         dimension_type=CATEGORICAL,                              -->
                             <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                            <!--         properties=frozenset(LOCAL,),                            -->
+                            <!--         properties=frozenset('LOCAL',),                          -->
                             <!--       ),                                                         -->
                             <!--     ),                                                           -->
                             <!--   )                                                              -->


### PR DESCRIPTION
### Description
The recent change to allow & sort sets in MF pretty printing was hiding a sneaky error when pretty printing objects containing enums. Enums can't be sorted without a key. This would only show up in logs that call `mf_pformat()`, since none of our test snapshots appear to contain enums - hence why it wasn't caught in CI.
Here's an example of a logging error triggered by query parsing that was being buried by the try/except in `mf_pformat()`:
`TypeError: '<' not supported between instances of 'LinkableElementProperty' and 'LinkableElementProperty'`
