### PR TITLE
Configure snapshot directory in `SnapshotConfiguration`

### DIFF
--- a/metricflow-semantics/tests_metricflow_semantics/__init__.py
+++ b/metricflow-semantics/tests_metricflow_semantics/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from metricflow_semantics.test_helpers.config_helpers import DirectoryPathAnchor
+
+TESTS_METRICFLOW_SEMANTICS_DIRECTORY_ANCHOR = DirectoryPathAnchor()

--- a/metricflow-semantics/tests_metricflow_semantics/fixtures/setup_fixtures.py
+++ b/metricflow-semantics/tests_metricflow_semantics/fixtures/setup_fixtures.py
@@ -13,6 +13,9 @@ from metricflow_semantics.test_helpers.snapshot_helpers import (
     add_overwrite_snapshots_cli_flag,
 )
 
+from tests_metricflow_semantics import TESTS_METRICFLOW_SEMANTICS_DIRECTORY_ANCHOR
+from tests_metricflow_semantics.snapshots import METRICFLOW_SEMANTICS_SNAPSHOT_DIRECTORY_ANCHOR
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,4 +38,6 @@ def mf_test_configuration(  # noqa: D103
         display_graphs=False,
         overwrite_snapshots=bool(request.config.getoption(OVERWRITE_SNAPSHOTS_CLI_FLAG, default=False)),
         use_persistent_source_schema=False,
+        snapshot_directory=METRICFLOW_SEMANTICS_SNAPSHOT_DIRECTORY_ANCHOR.directory,
+        tests_directory=TESTS_METRICFLOW_SEMANTICS_DIRECTORY_ANCHOR.directory,
     )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/__init__.py
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/__init__.py
@@ -2,4 +2,4 @@ from __future__ import annotations
 
 from metricflow_semantics.test_helpers.config_helpers import DirectoryPathAnchor
 
-TESTS_METRICFLOW_DIRECTORY_ANCHOR = DirectoryPathAnchor()
+METRICFLOW_SEMANTICS_SNAPSHOT_DIRECTORY_ANCHOR = DirectoryPathAnchor()

--- a/tests_metricflow/dataflow_plan_to_svg.py
+++ b/tests_metricflow/dataflow_plan_to_svg.py
@@ -20,8 +20,13 @@ def display_graph_if_requested(
     if len(request.session.items) > 1:
         raise ValueError("Displaying graphs is only supported when there's a single item in a testing session.")
 
-    plan_svg_output_path_prefix = snapshot_path_prefix(
-        request=request, snapshot_group=dag_graph.__class__.__name__, snapshot_id=str(dag_graph.dag_id)
+    plan_svg_output_path_prefix = str(
+        snapshot_path_prefix(
+            request=request,
+            snapshot_configuration=mf_test_configuration,
+            snapshot_group=dag_graph.__class__.__name__,
+            snapshot_id=str(dag_graph.dag_id),
+        )
     )
 
     # Create parent directory since it might not exist

--- a/tests_metricflow/fixtures/setup_fixtures.py
+++ b/tests_metricflow/fixtures/setup_fixtures.py
@@ -18,7 +18,9 @@ from metricflow_semantics.test_helpers.snapshot_helpers import (
 )
 from sqlalchemy.engine import make_url
 
+from tests_metricflow import TESTS_METRICFLOW_DIRECTORY_ANCHOR
 from tests_metricflow.fixtures.sql_clients.common_client import SqlDialect
+from tests_metricflow.snapshots import METRICFLOW_SNAPSHOT_DIRECTORY_ANCHOR
 from tests_metricflow.table_snapshot.table_snapshots import SqlTableSnapshotHash, SqlTableSnapshotRepository
 
 logger = logging.getLogger(__name__)
@@ -143,6 +145,8 @@ def mf_test_configuration(  # noqa: D103
         use_persistent_source_schema=bool(
             request.config.getoption(USE_PERSISTENT_SOURCE_SCHEMA_CLI_FLAG, default=False)
         ),
+        snapshot_directory=METRICFLOW_SNAPSHOT_DIRECTORY_ANCHOR.directory,
+        tests_directory=TESTS_METRICFLOW_DIRECTORY_ANCHOR.directory,
     )
 
 

--- a/tests_metricflow/snapshots/__init__.py
+++ b/tests_metricflow/snapshots/__init__.py
@@ -2,4 +2,4 @@ from __future__ import annotations
 
 from metricflow_semantics.test_helpers.config_helpers import DirectoryPathAnchor
 
-TESTS_METRICFLOW_DIRECTORY_ANCHOR = DirectoryPathAnchor()
+METRICFLOW_SNAPSHOT_DIRECTORY_ANCHOR = DirectoryPathAnchor()


### PR DESCRIPTION
### Description

Instead of searching the directory hierarchy of the test file to locate the snapshot directory, this PR uses a directory anchor to configure the snapshot directory.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
