### PR TITLE
Add Python 3.12 Support

### DIFF
--- a/.changes/unreleased/Breaking Changes-20240307-095610.yaml
+++ b/.changes/unreleased/Breaking Changes-20240307-095610.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: dd Python 3.12 Support / Remove Python 3.8 Support
+time: 2024-03-07T09:56:10.062042-08:00
+custom:
+  Author: plypaul
+  Issue: "1065"

--- a/.github/workflows/cd-push-to-pypi.yaml
+++ b/.github/workflows/cd-push-to-pypi.yaml
@@ -6,7 +6,7 @@ on:
       - "*"
 
 env:
-  PYTHON_VERSION: "3.8"
+  PYTHON_VERSION: "3.9"
 
 jobs:
   pypi-publish:

--- a/.github/workflows/cd-sql-engine-populate-persistent-source-schema.yaml
+++ b/.github/workflows/cd-sql-engine-populate-persistent-source-schema.yaml
@@ -15,7 +15,7 @@ on:
 
 env:
   # Unclear on how to make 'Reload Test Data in SQL Engines' a constant here as it does not work here.
-  PYTHON_VERSION: "3.8"
+  PYTHON_VERSION: "3.9"
   ADDITIONAL_PYTEST_OPTIONS: "--log-cli-level info"
 
 jobs:

--- a/.github/workflows/cd-sql-engine-tests.yaml
+++ b/.github/workflows/cd-sql-engine-tests.yaml
@@ -8,7 +8,7 @@ on:
     types: [labeled]
 
 env:
-  PYTHON_VERSION: "3.8"
+  PYTHON_VERSION: "3.9"
   EXTERNAL_ENGINE_TEST_PARALLELISM: 8
   ADDITIONAL_PYTEST_OPTIONS: "--use-persistent-source-schema"
 

--- a/.github/workflows/ci-linting.yaml
+++ b/.github/workflows/ci-linting.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Run Pre-Commit Linting Hooks
     runs-on: ubuntu-latest
     env:
-      python-version: "3.8"
+      python-version: "3.9"
     steps:
 
       - name: Check-out the repo

--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.12"]
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -46,10 +46,10 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v3
 
-      - name: Test w/ Python 3.11
+      - name: Test w/ Python 3.12
         uses: ./.github/actions/run-mf-tests
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           make-target: "test-postgresql"
 
   metricflow-unit-tests:

--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
   # Internal dependencies
   "dbt-core>=1.7.4, <1.8.0",
-  "metricflow>=0.205.0, <0.206.0",
+  "metricflow>=0.205.0, <0.207.0",
 
   # dsi version should be fixed by MetricFlow/dbt-core, not set here
   "dbt-semantic-interfaces",

--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dbt-metricflow"
-version = "0.6.0"
+version = "0.6.1"
 description = "Execute commands against the MetricFlow semantic layer with dbt."
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8,<3.13"
 license = "BUSL-1.1"
 authors = [
   { name = "dbt Labs", email = "info@dbtlabs.com" },
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/metricflow-semantics/pyproject.toml
+++ b/metricflow-semantics/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metricflow-semantics"
-version = "0.1.0"
+version = "0.1.1"
 description = "Modules for semantic understanding of a MetricFlow query."
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8,<3.13"
 license = "BUSL-1.1"
 authors = [
   { name = "dbt Labs", email = "info@dbtlabs.com" },
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metricflow"
-version = "0.206.0.dev2"
+version = "0.206.0.dev3"
 description = "Translates a simple metric definition into reusable SQL and executes it against the SQL engine of your choice."
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8,<3.13"
 license = "BUSL-1.1"
 keywords = []
 authors = [
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
Resolves #1065 

### Description

This is a rework of https://github.com/dbt-labs/metricflow/pull/1066 to add support for Python 3.12 but to leave in support for Python 3.8. This is now possible with the removal of the `pandas` dependency.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
