### PR TITLE
Update snapshot-diff error-messages to be more compact

### DIFF
--- a/metricflow-semantics/metricflow_semantics/test_helpers/snapshot_helpers.py
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/snapshot_helpers.py
@@ -106,9 +106,13 @@ def assert_snapshot_text_equal(
         # pytest should show a detailed diff with "assert actual_modified == expected_modified", but it's not, so doing
         # this instead.
         if snapshot_text != expected_snapshot_text:
-            differ = difflib.Differ()
-            diff = differ.compare(expected_snapshot_text.splitlines(), snapshot_text.splitlines())
-            assert False, f"Snapshot from {file_path} does not match. Diff from expected to actual:\n" + "\n".join(diff)
+            diff = difflib.unified_diff(
+                a=expected_snapshot_text.splitlines(keepends=True),
+                b=snapshot_text.splitlines(keepends=True),
+                fromfile=f"Expected Result in {file_path}",
+                tofile="Actual Result",
+            )
+            assert False, "Result does not match the stored snapshot. Diff from expected to actual:\n\n" + "".join(diff)
 
 
 def snapshot_path_prefix(


### PR DESCRIPTION
### Description

When a test fails due to a difference in the snapshot, the current error message includes the full snapshot. In some cases, the snapshot is large, so it's hard to manage in the console. This PR changes the error messages to use a more compact form that only includes a few lines of context around the diff like:

```
FAILED tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py::test_join_to_time_spine_node_with_offset_window - AssertionError: Result does not match the stored snapshot. Diff from expected to actual:

--- Expected Result in [...]/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ Actual Result
@@ -29,7 +29,7 @@
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
                         <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                         <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                        <!-- distinct = True -->
+                        <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
                             <!-- node_id = NodeId(id_str='sma_0') -->
```

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
