### PR TITLE
Don't allow LinkableMetrics for case when entity reference is in entity links

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -198,6 +198,10 @@ class ValidLinkableSpecResolver:
             )
             for linkable_entities in linkable_element_set_for_metric.path_key_to_linkable_entities.values():
                 for linkable_entity in linkable_entities:
+                    # TODO: some users encounter a situation in which the entity reference is in the entity links. Debug why.
+                    if linkable_entity.reference in linkable_entity.entity_links:
+                        logger.info(f"Found entity reference in entity links for linkable entity: {linkable_entity}")
+                        continue
                     metric_subquery_join_path_element = MetricSubqueryJoinPathElement(
                         metric_reference=metric_reference,
                         derived_from_semantic_models=defined_from_semantic_models,


### PR DESCRIPTION

### Description
Some users have run into a scenario where the entity reference can be found in the entity links for some `LinkableEntities`. I haven't yet been able to reproduce that error with our test configs. Releasing metrics as dimensions is blocked on this edge case, so I'm skipping that scenario here to ensure that customers won't run into it until when using `LinkableMetrics` until we can debug further. This will allow us to release the feature and handle this case in a follow up version.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
