### PR TITLE
Change `MetricFlowQueryParser.parse_and_validate_query()` to return `ParseQueryResult`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -321,7 +321,7 @@ class MetricFlowQueryParser:
         order_by_names: Optional[Sequence[str]] = None,
         order_by: Optional[Sequence[OrderByQueryParameter]] = None,
         min_max_only: bool = False,
-    ) -> MetricFlowQuerySpec:
+    ) -> ParseQueryResult:
         """Parse the query into spec objects, validating them in the process.
 
         e.g. make sure that the given metric is a valid metric name.
@@ -341,7 +341,7 @@ class MetricFlowQueryParser:
             order_by_names=order_by_names,
             order_by=order_by,
             min_max_only=min_max_only,
-        ).query_spec
+        )
 
     @log_runtime()
     def _parse_and_validate_query(
@@ -533,7 +533,7 @@ class MetricFlowQueryParser:
         return self.parse_and_validate_query(
             metrics=(MetricParameter(group_by_metric_spec.reference.element_name),),
             group_by=(DimensionOrEntityParameter(group_by_metric_spec.metric_subquery_entity_spec.qualified_name),),
-        )
+        ).query_spec
 
 
 @dataclass(frozen=True)

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_ambiguous_entity_path.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_ambiguous_entity_path.py
@@ -28,7 +28,7 @@ def test_resolvable_ambiguous_entity_path(  # noqa: D103
     query_spec = multi_hop_query_parser.parse_and_validate_query(
         metric_names=["entity_1_metric"],
         group_by_names=["entity_0__country"],
-    )
+    ).query_spec
 
     assert_object_snapshot_equal(
         request=request,
@@ -47,7 +47,7 @@ def test_ambiguous_entity_path_resolves_to_shortest_entity_path_item(
     query_spec = multi_hop_query_parser.parse_and_validate_query(
         metric_names=["all_entity_metric"],
         group_by_names=["entity_1__country"],
-    )
+    ).query_spec
 
     assert_object_snapshot_equal(
         request=request,
@@ -70,7 +70,7 @@ def test_non_resolvable_ambiguous_entity_path_due_to_multiple_matches(
         multi_hop_query_parser.parse_and_validate_query(
             metric_names=["entity_1_and_entity_2_metric"],
             group_by_names=["entity_0__country"],
-        )
+        ).query_spec
 
     assert_str_snapshot_equal(
         request=request,
@@ -93,7 +93,7 @@ def test_non_resolvable_ambiguous_entity_path_due_to_mismatch(
         multi_hop_query_parser.parse_and_validate_query(
             metric_names=["entity_0_metric", "entity_1_metric"],
             group_by_names=["entity_0__country"],
-        )
+        ).query_spec
 
     assert_str_snapshot_equal(
         request=request,

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_suggestions.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_suggestions.py
@@ -32,7 +32,9 @@ def test_suggestions_for_group_by_item(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, query_parser: MetricFlowQueryParser
 ) -> None:
     with pytest.raises(InvalidQueryException) as e:
-        query_parser.parse_and_validate_query(metric_names=("bookings",), group_by_names=("booking__instant",))
+        query_parser.parse_and_validate_query(
+            metric_names=("bookings",), group_by_names=("booking__instant",)
+        ).query_spec
 
     assert_str_snapshot_equal(
         request=request,
@@ -46,7 +48,9 @@ def test_suggestions_for_metric(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, query_parser: MetricFlowQueryParser
 ) -> None:
     with pytest.raises(InvalidQueryException) as e:
-        query_parser.parse_and_validate_query(metric_names=("booking",), group_by_names=(METRIC_TIME_ELEMENT_NAME,))
+        query_parser.parse_and_validate_query(
+            metric_names=("booking",), group_by_names=(METRIC_TIME_ELEMENT_NAME,)
+        ).query_spec
 
     assert_str_snapshot_equal(
         request=request,
@@ -60,7 +64,9 @@ def test_suggestions_for_multiple_metrics(  # noqa: D103
     request: FixtureRequest, mf_test_configuration: MetricFlowTestConfiguration, query_parser: MetricFlowQueryParser
 ) -> None:
     with pytest.raises(InvalidQueryException) as e:
-        query_parser.parse_and_validate_query(metric_names=("bookings", "listings"), group_by_names=("booking__ds",))
+        query_parser.parse_and_validate_query(
+            metric_names=("bookings", "listings"), group_by_names=("booking__ds",)
+        ).query_spec
 
     assert_str_snapshot_equal(
         request=request,
@@ -93,7 +99,9 @@ def test_suggestions_for_defined_where_filter(  # noqa: D103
         semantic_manifest_lookup=semantic_manifest_lookup,
     )
     with pytest.raises(InvalidQueryException) as e:
-        query_parser.parse_and_validate_query(metric_names=("listings",), group_by_names=(METRIC_TIME_ELEMENT_NAME,))
+        query_parser.parse_and_validate_query(
+            metric_names=("listings",), group_by_names=(METRIC_TIME_ELEMENT_NAME,)
+        ).query_spec
 
     assert_str_snapshot_equal(
         request=request,
@@ -145,7 +153,7 @@ def test_suggestions_for_defined_filters_in_multi_metric_query(
                 "listings",
             ),
             group_by_names=(METRIC_TIME_ELEMENT_NAME,),
-        )
+        ).query_spec
 
     assert_str_snapshot_equal(
         request=request,

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -485,7 +485,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 order_by_names=mf_query_request.order_by_names,
                 order_by=mf_query_request.order_by,
                 min_max_only=mf_query_request.min_max_only,
-            )
+            ).query_spec
         logger.info(f"Query spec is:\n{mf_pformat(query_spec)}")
 
         output_selection_specs: Optional[InstanceSpecSet] = None

--- a/scripts/ci_tests/metricflow_semantics_package_test.py
+++ b/scripts/ci_tests/metricflow_semantics_package_test.py
@@ -80,7 +80,7 @@ def log_query_spec() -> None:  # noqa: D103
     query_parser = MetricFlowQueryParser(SemanticManifestLookup(semantic_manifest))
     query_spec = query_parser.parse_and_validate_query(
         metric_names=["bookings"], group_by_names=["booking__is_instant"]
-    )
+    ).query_spec
 
     logger.info(f"{query_spec.__class__.__name__}:\n{mf_pformat(query_spec)}")
 

--- a/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
+++ b/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
@@ -361,7 +361,7 @@ def test_where_constrained_plan(
         metric_names=("bookings",),
         group_by_names=("booking__is_instant",),
         where_constraint_str="{{ Dimension('listing__country_latest') }} = 'us'",
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -390,7 +390,7 @@ def test_where_constrained_plan_time_dimension(
         metric_names=("bookings",),
         group_by_names=("booking__is_instant",),
         where_constraint_str="{{ TimeDimension('metric_time', 'day') }} >= '2020-01-01'",
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -420,7 +420,7 @@ def test_where_constrained_with_common_linkable_plan(
         metric_names=("bookings",),
         group_by_names=("listing__country_latest",),
         where_constraint_str="{{ Dimension('listing__country_latest') }} = 'us'",
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -559,7 +559,7 @@ def test_distinct_values_plan(
         where_constraint_str="{{ Dimension('listing__country_latest') }} = 'us'",
         order_by_names=("-listing__country_latest",),
         limit=100,
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -589,7 +589,7 @@ def test_distinct_values_plan_with_join(
         where_constraint_str="{{ Dimension('listing__country_latest') }} = 'us'",
         order_by_names=("-listing__is_lux_latest",),
         limit=100,
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -617,7 +617,7 @@ def test_measure_constraint_plan(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("lux_booking_value_rate_expr",),
         group_by_names=(METRIC_TIME_ELEMENT_NAME,),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -645,7 +645,7 @@ def test_measure_constraint_with_reused_measure_plan(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("instant_booking_value_ratio",),
         group_by_names=(METRIC_TIME_ELEMENT_NAME,),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -1197,7 +1197,7 @@ def test_join_to_time_spine_with_filters(
         ),
         time_constraint_start=datetime.datetime(2020, 1, 3),
         time_constraint_end=datetime.datetime(2020, 1, 5),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -1228,7 +1228,7 @@ def test_offset_window_metric_filter_and_query_have_different_granularities(
         where_constraint=PydanticWhereFilter(
             where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -1259,7 +1259,7 @@ def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
         where_constraint=PydanticWhereFilter(
             where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -1286,7 +1286,7 @@ def test_metric_in_query_where_filter(
     """Test querying a metric that has a metric in its where filter."""
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("listings",), where_constraint_str="{{ Metric('bookings', ['listing'])}} > 2"
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -1313,7 +1313,7 @@ def test_metric_in_metric_where_filter(
     """Test querying a metric that has a metric in its where filter."""
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("active_listings",),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     assert_plan_snapshot_text_equal(
@@ -1348,5 +1348,5 @@ def test_all_available_metric_filters(
                         metric_name=linkable_metric.element_name, entity_name=entity_spec.qualified_name
                     ),
                 ),
-            )
+            ).query_spec
             dataflow_plan_builder.build_plan(query_spec)

--- a/tests_metricflow/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
+++ b/tests_metricflow/dataflow/optimizer/source_scan/test_source_scan_optimizer.py
@@ -242,7 +242,7 @@ def test_constrained_metric_not_combined(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("booking_value", "instant_booking_value"),
         group_by_names=(METRIC_TIME_ELEMENT_NAME,),
-    )
+    ).query_spec
     check_optimization(
         request=request,
         mf_test_configuration=mf_test_configuration,

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_distinct_values_to_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_distinct_values_to_sql.py
@@ -58,7 +58,7 @@ def test_dimension_values_with_a_join_and_a_filter(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Dimension('user__home_state_latest') }} = 'us'",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec)
 
     convert_and_check(

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -1205,7 +1205,7 @@ def test_dimension_with_joined_where_constraint(
     query_spec = query_parser.parse_and_validate_query(
         group_by_names=("user__home_state_latest",),
         where_constraint_str="{{ Dimension('listing__country_latest') }} = 'us'",
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec)
 
     convert_and_check(

--- a/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
@@ -125,7 +125,7 @@ def test_cumulative_metric_with_non_adjustable_time_filter(
                 "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-07'"
             )
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(

--- a/tests_metricflow/query_rendering/test_derived_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_derived_metric_rendering.py
@@ -122,7 +122,7 @@ def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D103
                 "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-14'"
             )
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -396,7 +396,7 @@ def test_nested_offsets_with_where_constraint(  # noqa: D103
                 "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-13'"
             )
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -474,7 +474,7 @@ def test_nested_filters(
     create_source_tables: bool,
 ) -> None:
     """Tests derived metric rendering for a nested derived metric with filters on the outer metric spec."""
-    query_spec = query_parser.parse_and_validate_query(metric_names=("instant_lux_booking_value_rate",))
+    query_spec = query_parser.parse_and_validate_query(metric_names=("instant_lux_booking_value_rate",)).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec=query_spec)
 
     convert_and_check(
@@ -532,7 +532,7 @@ def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(
         metric_names=("bookings_offset_twice",),
         group_by_names=(group_by_name,),
         where_constraint_str="{{ Dimension('booking__is_instant') }}",
-    )
+    ).query_spec
 
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
     convert_and_check(
@@ -558,7 +558,7 @@ def test_offset_window_with_agg_time_dim(  # noqa: D103
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_growth_2_weeks",),
         group_by_names=("booking__ds__day",),
-    )
+    ).query_spec
 
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
     convert_and_check(
@@ -584,7 +584,7 @@ def test_offset_to_grain_with_agg_time_dim(  # noqa: D103
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_growth_since_start_of_month",),
         group_by_names=("booking__ds__day",),
-    )
+    ).query_spec
 
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
     convert_and_check(
@@ -610,7 +610,7 @@ def test_derived_offset_metric_with_agg_time_dim(  # noqa: D103
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("booking_fees_last_week_per_booker_this_week",),
         group_by_names=("booking__ds__day",),
-    )
+    ).query_spec
 
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
     convert_and_check(
@@ -717,7 +717,7 @@ def test_offset_window_metric_multiple_granularities(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("booking_fees_last_week_per_booker_this_week",),
         group_by_names=("metric_time__day", "metric_time__month", "metric_time__year"),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -743,7 +743,7 @@ def test_offset_to_grain_metric_multiple_granularities(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_at_start_of_month",),
         group_by_names=("metric_time__day", "metric_time__month", "metric_time__year"),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -772,7 +772,7 @@ def test_offset_window_metric_filter_and_query_have_different_granularities(
         where_constraint=PydanticWhereFilter(
             where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -801,7 +801,7 @@ def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
         where_constraint=PydanticWhereFilter(
             where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(

--- a/tests_metricflow/query_rendering/test_fill_nulls_with_rendering.py
+++ b/tests_metricflow/query_rendering/test_fill_nulls_with_rendering.py
@@ -214,7 +214,7 @@ def test_join_to_time_spine_with_filters(  # noqa: D103
         ),
         time_constraint_start=datetime.datetime(2020, 1, 3),
         time_constraint_end=datetime.datetime(2020, 1, 5),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(

--- a/tests_metricflow/query_rendering/test_metric_filter_rendering.py
+++ b/tests_metricflow/query_rendering/test_metric_filter_rendering.py
@@ -27,7 +27,7 @@ def test_query_with_simple_metric_in_where_filter(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Metric('bookings', ['listing']) }} > 2",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -52,7 +52,7 @@ def test_metric_with_metric_in_where_filter(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("active_listings",),
         group_by_names=("metric_time__day",),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -79,7 +79,7 @@ def test_query_with_derived_metric_in_where_filter(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Metric('views_times_booking_value', ['listing']) }} > 1",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -106,7 +106,7 @@ def test_query_with_ratio_metric_in_where_filter(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Metric('bookings_per_booker', ['listing']) }} > 1",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -136,7 +136,7 @@ def test_query_with_cumulative_metric_in_where_filter(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Metric('revenue_all_time', ['user']) }} > 1",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -163,7 +163,7 @@ def test_query_with_multiple_metrics_in_filter(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Metric('bookings', ['listing']) }} > 2 AND {{ Metric('bookers', ['listing']) }} > 1",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -190,7 +190,7 @@ def test_filter_by_metric_in_same_semantic_model_as_queried_metric(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Metric('booking_value', ['guest']) }} > 1.00",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -217,7 +217,7 @@ def test_distinct_values_query_with_metric_filter(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Metric('bookings', ['listing']) }} > 2",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec)
 
     convert_and_check(
@@ -244,7 +244,7 @@ def test_metric_filtered_by_itself(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Metric('bookers', ['guest']) }} > 1.00",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -270,7 +270,7 @@ def test_group_by_has_local_entity_prefix(  # noqa: D103
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Metric('average_booking_value', ['listing__user']) }} > 1",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -296,7 +296,7 @@ def test_filter_with_conversion_metric(  # noqa: D103
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Metric('visit_buy_conversion_rate', ['user']) }} > 2",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(

--- a/tests_metricflow/query_rendering/test_query_rendering.py
+++ b/tests_metricflow/query_rendering/test_query_rendering.py
@@ -83,7 +83,7 @@ def test_filter_with_where_constraint_on_join_dim(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Dimension('listing__country_latest') }} = 'us'",
         ),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -174,7 +174,7 @@ def test_distinct_values(
             where_sql_template="{{ Dimension('listing__country_latest') }} = 'us'",
         ),
         limit=100,
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec)
 
     convert_and_check(
@@ -227,7 +227,7 @@ def test_measure_constraint(  # noqa: D103
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("lux_booking_value_rate_expr",),
         group_by_names=(MTD_SPEC_DAY.qualified_name,),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -251,7 +251,7 @@ def test_measure_constraint_with_reused_measure(  # noqa: D103
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("instant_booking_value_ratio",),
         group_by_names=(MTD_SPEC_DAY.qualified_name,),
-    )
+    ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(
@@ -275,7 +275,7 @@ def test_measure_constraint_with_single_expr_and_alias(  # noqa: D103
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("double_counted_delayed_bookings",),
         group_by_names=(MTD_SPEC_DAY.qualified_name,),
-    )
+    ).query_spec
 
     dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
@@ -305,7 +305,7 @@ def test_join_to_scd_dimension(
         where_constraint=PydanticWhereFilter(
             where_sql_template="{{ Dimension('listing__capacity') }} > 2",
         ),
-    )
+    ).query_spec
     dataflow_plan = scd_dataflow_plan_builder.build_plan(query_spec)
 
     convert_and_check(


### PR DESCRIPTION
### Description

Similar to the parser update for saved queries, this PR updates `MetricFlowQueryParser.parse_and_validate_query()` to return a result object so that more context can be returned to the caller.

Note: `.query_spec` was added to get tests to pass in this PR. In a later PR, snapshots are used to check the parser results, so those go away.
<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
