### PR TITLE
Add Check to Verify `queried_semantic_models`

### DIFF
--- a/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
+++ b/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
@@ -93,7 +93,7 @@ class SourceScanOptimizer(
     """
 
     def __init__(self) -> None:  # noqa: D107
-        super().__init__(visit_log_level=logging.ERROR, default_action_recursion=True)
+        super().__init__(visit_log_level=logging.DEBUG, default_action_recursion=True)
 
     @override
     def default_visit_action(


### PR DESCRIPTION
### Description

This PR adds a check to the integration test cases to verify that the queried semantic models returned by the parser match the semantic models queried in the dataflow plan.

Tagging @courtneyholcomb as there's currently a case that is skipped - do you have context offhand why that's the case?
<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
