### PR TITLE
Use pushdown params to disable time range constraint pushdown

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1323,9 +1323,14 @@ class DataflowPlanBuilder:
                 if not before_aggregation_time_spine_join_description
                 else None
             )
-            measure_pushdown_params = PredicatePushdownParameters.with_time_range_constraint(
-                predicate_pushdown_params, time_range_constraint=measure_time_constraint
-            )
+            if measure_time_constraint is None:
+                measure_pushdown_params = PredicatePushdownParameters.without_time_range_constraint(
+                    predicate_pushdown_params
+                )
+            else:
+                measure_pushdown_params = PredicatePushdownParameters.with_time_range_constraint(
+                    predicate_pushdown_params, time_range_constraint=measure_time_constraint
+                )
 
             find_recipe_start_time = time.time()
             measure_recipe = self._find_dataflow_recipe(
@@ -1448,12 +1453,12 @@ class DataflowPlanBuilder:
         if non_additive_dimension_spec is not None:
             # Apply semi additive join on the node
             agg_time_dimension = measure_properties.agg_time_dimension
-            queried_time_dimension_spec: Optional[TimeDimensionSpec] = (
-                self._find_non_additive_dimension_in_linkable_specs(
-                    agg_time_dimension=agg_time_dimension,
-                    linkable_specs=queried_linkable_specs.as_tuple,
-                    non_additive_dimension_spec=non_additive_dimension_spec,
-                )
+            queried_time_dimension_spec: Optional[
+                TimeDimensionSpec
+            ] = self._find_non_additive_dimension_in_linkable_specs(
+                agg_time_dimension=agg_time_dimension,
+                linkable_specs=queried_linkable_specs.as_tuple,
+                non_additive_dimension_spec=non_additive_dimension_spec,
             )
             time_dimension_spec = TimeDimensionSpec.from_name(non_additive_dimension_spec.name)
             window_groupings = tuple(

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -83,9 +83,9 @@ from metricflow.dataflow.nodes.write_to_table import WriteToResultTableNode
 from metricflow.dataflow.optimizer.dataflow_plan_optimizer import DataflowPlanOptimizer
 from metricflow.dataset.dataset_classes import DataSet
 from metricflow.plan_conversion.node_processor import (
+    PredicateInputType,
     PredicatePushdownParameters,
     PreJoinNodeProcessor,
-    PushdownPredicateInputType,
 )
 from metricflow.sql.sql_table import SqlTable
 
@@ -248,7 +248,7 @@ class DataflowPlanBuilder:
         disabled_pushdown_parameters = PredicatePushdownParameters.with_pushdown_disabled()
         time_range_only_pushdown_parameters = PredicatePushdownParameters(
             time_range_constraint=predicate_pushdown_params.time_range_constraint,
-            pushdown_enabled_types=frozenset([PushdownPredicateInputType.TIME_RANGE_CONSTRAINT]),
+            pushdown_enabled_types=frozenset([PredicateInputType.TIME_RANGE_CONSTRAINT]),
         )
 
         # Build measure recipes

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -242,7 +242,7 @@ class DataflowPlanBuilder:
     ) -> DataflowPlanNode:
         """Builds a node that contains aggregated values of conversions and opportunities."""
         # Pushdown parameters vary with conversion metrics due to the way the time joins are applied.
-        # Due to other outstanding issues with conversion metric fitlers, we disable predicate
+        # Due to other outstanding issues with conversion metric filters, we disable predicate
         # pushdown for any filter parameter set that is not part of the original time range constraint
         # implementation.
         disabled_pushdown_parameters = PredicatePushdownParameters.with_pushdown_disabled()

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -82,7 +82,11 @@ from metricflow.dataflow.nodes.write_to_dataframe import WriteToResultDataframeN
 from metricflow.dataflow.nodes.write_to_table import WriteToResultTableNode
 from metricflow.dataflow.optimizer.dataflow_plan_optimizer import DataflowPlanOptimizer
 from metricflow.dataset.dataset_classes import DataSet
-from metricflow.plan_conversion.node_processor import PredicatePushdownParameters, PreJoinNodeProcessor
+from metricflow.plan_conversion.node_processor import (
+    PredicatePushdownParameters,
+    PredicatePushdownState,
+    PreJoinNodeProcessor,
+)
 from metricflow.sql.sql_table import SqlTable
 
 logger = logging.getLogger(__name__)
@@ -237,6 +241,16 @@ class DataflowPlanBuilder:
         constant_properties: Optional[Sequence[ConstantPropertyInput]] = None,
     ) -> DataflowPlanNode:
         """Builds a node that contains aggregated values of conversions and opportunities."""
+        # Pushdown parameters vary with conversion metrics due to the way the time joins are applied.
+        # Due to other outstanding issues with conversion metric fitlers, we disable predicate
+        # pushdown for any filter parameter set that is not part of the original time range constraint
+        # implementation.
+        disabled_pushdown_parameters = PredicatePushdownParameters.with_pushdown_disabled()
+        time_range_only_pushdown_parameters = PredicatePushdownParameters(
+            time_range_constraint=predicate_pushdown_params.time_range_constraint,
+            pushdown_state=PredicatePushdownState.ENABLED_FOR_TIME_RANGE_ONLY,
+        )
+
         # Build measure recipes
         base_required_linkable_specs, _ = self.__get_required_and_extraneous_linkable_specs(
             queried_linkable_specs=queried_linkable_specs,
@@ -244,14 +258,13 @@ class DataflowPlanBuilder:
         )
         base_measure_recipe = self._find_dataflow_recipe(
             measure_spec_properties=self._build_measure_spec_properties([base_measure_spec.measure_spec]),
-            predicate_pushdown_params=predicate_pushdown_params,
+            predicate_pushdown_params=time_range_only_pushdown_parameters,
             linkable_spec_set=base_required_linkable_specs,
         )
         logger.info(f"Recipe for base measure aggregation:\n{mf_pformat(base_measure_recipe)}")
         conversion_measure_recipe = self._find_dataflow_recipe(
             measure_spec_properties=self._build_measure_spec_properties([conversion_measure_spec.measure_spec]),
-            # TODO - Pushdown: Evaluate the potential for applying time constraints and other predicates for conversion
-            predicate_pushdown_params=PredicatePushdownParameters(time_range_constraint=None),
+            predicate_pushdown_params=disabled_pushdown_parameters,
             linkable_spec_set=LinkableSpecSet(),
         )
         logger.info(f"Recipe for conversion measure aggregation:\n{mf_pformat(conversion_measure_recipe)}")
@@ -268,7 +281,7 @@ class DataflowPlanBuilder:
         aggregated_base_measure_node = self.build_aggregated_measure(
             metric_input_measure_spec=base_measure_spec,
             queried_linkable_specs=queried_linkable_specs,
-            predicate_pushdown_params=predicate_pushdown_params,
+            predicate_pushdown_params=time_range_only_pushdown_parameters,
         )
 
         # Build unaggregated conversions source node
@@ -337,10 +350,14 @@ class DataflowPlanBuilder:
             required_local_linkable_specs=base_measure_recipe.required_local_linkable_specs,
             join_linkable_instances_recipes=base_measure_recipe.join_linkable_instances_recipes,
         )
+        # TODO: Refine conversion metric configuration to fit into the standard dataflow plan building model
+        # In this case we override the measure recipe, which currently results in us bypassing predicate pushdown
+        # Rather than relying on happenstance in the way the code is laid out we also explicitly disable
+        # predicate pushdwon until we are ready to fully support it for conversion metrics
         aggregated_conversions_node = self.build_aggregated_measure(
             metric_input_measure_spec=conversion_measure_spec,
             queried_linkable_specs=queried_linkable_specs,
-            predicate_pushdown_params=predicate_pushdown_params,
+            predicate_pushdown_params=disabled_pushdown_parameters,
             measure_recipe=recipe_with_join_conversion_source_node,
         )
 
@@ -492,11 +509,10 @@ class DataflowPlanBuilder:
             if not metric_spec.has_time_offset:
                 filter_specs.extend(metric_spec.filter_specs)
 
-            # TODO - Pushdown: use parameters to disable pushdown operations instead of clobbering the constraints
             metric_pushdown_params = (
                 predicate_pushdown_params
                 if not metric_spec.has_time_offset
-                else PredicatePushdownParameters(time_range_constraint=None)
+                else PredicatePushdownParameters.with_pushdown_disabled()
             )
 
             parent_nodes.append(
@@ -867,7 +883,7 @@ class DataflowPlanBuilder:
             node_data_set_resolver=self._node_data_set_resolver,
         )
         # TODO - Pushdown: Encapsulate this in the node processor
-        if predicate_pushdown_params.time_range_constraint:
+        if predicate_pushdown_params.is_pushdown_enabled and predicate_pushdown_params.time_range_constraint:
             candidate_nodes_for_left_side_of_join = list(
                 node_processor.add_time_range_constraint(
                     source_nodes=candidate_nodes_for_left_side_of_join,
@@ -1298,15 +1314,16 @@ class DataflowPlanBuilder:
                 + indent(f"\nmeasure_specs:\n{mf_pformat([measure_spec])}")
                 + indent(f"\nevaluation:\n{mf_pformat(required_linkable_specs)}")
             )
-
-            # TODO - Pushdown: Update this to be more robust to additional pushdown parameters
             measure_time_constraint = (
                 (cumulative_metric_adjusted_time_constraint or predicate_pushdown_params.time_range_constraint)
                 # If joining to time spine for time offset, constraints will be applied after that join.
                 if not before_aggregation_time_spine_join_description
                 else None
             )
-            measure_pushdown_params = PredicatePushdownParameters(time_range_constraint=measure_time_constraint)
+            measure_pushdown_params = PredicatePushdownParameters.with_time_range_constraint(
+                predicate_pushdown_params, time_range_constraint=measure_time_constraint
+            )
+
             find_recipe_start_time = time.time()
             measure_recipe = self._find_dataflow_recipe(
                 measure_spec_properties=measure_properties,

--- a/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
+++ b/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from metricflow_semantics.filters.time_constraint import TimeRangeConstraint
 
-from metricflow.plan_conversion.node_processor import PredicatePushdownParameters, PushdownPredicateInputType
+from metricflow.plan_conversion.node_processor import PredicateInputType, PredicatePushdownParameters
 
 
 @pytest.fixture
@@ -19,7 +19,7 @@ def test_time_range_pushdown_enabled_states(all_pushdown_params: PredicatePushdo
     """Tests pushdown enabled check for time range pushdown operations."""
     time_range_only_params = PredicatePushdownParameters(
         time_range_constraint=TimeRangeConstraint.all_time(),
-        pushdown_enabled_types=frozenset([PushdownPredicateInputType.TIME_RANGE_CONSTRAINT]),
+        pushdown_enabled_types=frozenset([PredicateInputType.TIME_RANGE_CONSTRAINT]),
     )
 
     enabled_states = {

--- a/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
+++ b/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from metricflow_semantics.filters.time_constraint import TimeRangeConstraint
+
+from metricflow.plan_conversion.node_processor import PredicatePushdownParameters, PredicatePushdownState
+
+
+@pytest.fixture
+def all_pushdown_params() -> PredicatePushdownParameters:
+    """Tests a valid configuration with all predicate properties set and pushdown fully enabled."""
+    params = PredicatePushdownParameters(
+        time_range_constraint=TimeRangeConstraint.all_time(), pushdown_state=PredicatePushdownState.FULLY_ENABLED
+    )
+    predicate_property_names = {
+        field.name for field in dataclasses.fields(params) if field.metadata.get(params._PREDICATE_METADATA_KEY)
+    }
+    predicate_properties = {
+        name: value for name, value in dataclasses.asdict(params).items() if name in predicate_property_names
+    }
+    assert all(value is not None for value in predicate_properties.values()), (
+        "All predicate properties in this pushdown param instance should be set to something other than None. Found "
+        f"one or more None values in property map: {predicate_properties}"
+    )
+    return params
+
+
+def test_time_range_pushdown_enabled_states(all_pushdown_params: PredicatePushdownParameters) -> None:
+    """Tests pushdown enabled check for time range pushdown operations."""
+    time_range_only_params = PredicatePushdownParameters(
+        time_range_constraint=TimeRangeConstraint.all_time(),
+        pushdown_state=PredicatePushdownState.ENABLED_FOR_TIME_RANGE_ONLY,
+    )
+
+    enabled_states = {
+        "fully enabled": all_pushdown_params.is_pushdown_enabled,
+        "enabled for time range only": time_range_only_params.is_pushdown_enabled,
+    }
+
+    assert all(list(enabled_states.values())), (
+        "Expected pushdown to be enabled for pushdown params with time range constraint and global pushdown enabled, "
+        f"but some params returned False for is_pushdown_enabled.\nPushdown enabled states: {enabled_states}\n"
+        f"All params: {all_pushdown_params}\nTime range only params: {time_range_only_params}"
+    )
+
+
+def test_invalid_disabled_pushdown_params() -> None:
+    """Tests checks for invalid param configuration on disabled pushdown parameters."""
+    with pytest.raises(AssertionError, match="Disabled pushdown parameters cannot have properties set"):
+        PredicatePushdownParameters(
+            pushdown_state=PredicatePushdownState.DISABLED, time_range_constraint=TimeRangeConstraint.all_time()
+        )


### PR DESCRIPTION
The predicate pushdown operations for time range constriants currently
rely on None/not-None state to determine whether or not to push the
ConstrainTimeRange filter node to the source. With the switch to
pushdown params this None/not-None state gets tenuous, as future
updates will need to do things like manage time range constraints,
other time dimension filters, and categorical dimension (and entity)
filters, and relying on externalizing None/not-None combinations for
these various filter types will be challenging.

This change encapsulates the enabling and disabling of time range
constraints inside of PredicatePushdownParams. At the moment, in
order to maintain the existing behavior, we simply internalize the
None/not-None behavior for time range constraints. This will also
allow us to easily retain pushdown processing for categorical dimensions
even when time constraint filters should not be applied, and
gradually centralize those controls as we streamline the callsites.

There is added complexity to this change because of two things.

1. Time constraint updating is scattered around in the DataflowPlanBuilder
2. Conversion metrics currently do predicate pushdown for time constraints

The first of these will be addressed later.
Since we cannot reliably support general predicate pushdown for conversion
metrics, we need to allow for a time-range-only pushdown operation. Today
this is equivalent to pushdown enabled, but that will change shortly.