### PR TITLE
Test case where dataflow plan semantic models don't match query parser

### DIFF
--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/group_by_item_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/group_by_item_resolver.py
@@ -93,7 +93,12 @@ class GroupByItemResolver:
         )
 
         push_down_result: PushDownResult = self._resolution_dag.sink_node.accept(push_down_visitor)
+        print(push_down_result.candidate_set.linkable_element_set.path_key_to_linkable_entities)
 
+        # This tells you the number of canditate specs, NOT the number of candidate LinkableElements.
+        # There can be many LinkableElements that map to one spec. In this case, there are 4 LinkableEntities that map to
+        # the same EntitySpec('listings', entity_links=())
+        # Nowhere in the query parser do we narrow down which semantic model we should use to resolve a given group by item spec.
         if push_down_result.candidate_set.num_candidates == 0:
             return GroupByItemResolution(
                 spec=None,

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -521,6 +521,7 @@ class MetricFlowQueryParser:
                 queried_semantic_models=query_resolution.queried_semantic_models,
             )
 
+        # This does not actually tell you the queried semantic models. It tells you the semantic models that COULD be queried.
         return ParseQueryResult(
             query_spec=query_spec,
             queried_semantic_models=query_resolution.queried_semantic_models,

--- a/tests_metricflow/integration/test_cases/itest_dimensions.yaml
+++ b/tests_metricflow/integration/test_cases/itest_dimensions.yaml
@@ -370,3 +370,17 @@ integration_test:
     ) outer_subq
     WHERE listing__bookings > 2
     GROUP BY listing
+---
+integration_test:
+  name: just_listings
+  description: Query without metrics using a metric filter
+  model: SIMPLE_MODEL
+  group_bys: ["listing"]
+  # I don't see how you could specify you want listing from the listings_latest source
+  check_query: |
+    SELECT
+      listing_id AS listing
+    FROM {{ source_schema }}.dim_lux_listing_id_mapping l
+    GROUP BY
+      listing_id
+   

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -232,7 +232,8 @@ def filter_not_supported_features(
 
 @pytest.mark.parametrize(
     "name",
-    CONFIGURED_INTEGRATION_TESTS_REPOSITORY.all_test_case_names,
+    # CONFIGURED_INTEGRATION_TESTS_REPOSITORY.all_test_case_names,
+    ["itest_dimensions.yaml/just_listings"],
     ids=lambda name: f"name={name}",
 )
 def test_case(
@@ -337,6 +338,7 @@ def test_case(
     )
 
     actual = query_result.result_df
+    # assert 0, query_result.sql
 
     expected = sql_client.query(
         jinja2.Template(
@@ -364,11 +366,6 @@ def test_case(
     assert_dataframes_equal(actual, expected, sort_columns=not case.check_order, allow_empty=case.allow_empty)
 
     # Check that the parse result and the dataflow plan show the same semantic models read.
-    if name in {"itest_dimensions.yaml/distinct_values_query_with_metric_filter"}:
-        pytest.skip(
-            "Skipping the congruence check for semantic models queried by the parser vs. the dataflow as "
-            "metrics-in-filters is a WIP."
-        )
     parse_query_result = query_result.explain_result.parse_query_result
 
     dataflow_plan_lookup = DataflowPlanLookup(query_result.dataflow_plan)

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -371,4 +371,5 @@ def test_case(
     dataflow_plan_lookup = DataflowPlanLookup(query_result.dataflow_plan)
     dataflow_queried_semantic_models = dataflow_plan_lookup.read_semantic_models()
 
+    # Dataflow plan has the correct semantic models, query parser does not
     assert tuple(parse_query_result.queried_semantic_models) == tuple(dataflow_queried_semantic_models)


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->


### Description
Demonstrate that the `queried_semantic_models` property on `ParseQueryResult` is not correct.
<!---
  Provide context for the Pull Request here, including more details on what
  is changing and why. Add any references and info to help reviewers
  understand your changes, such as any tradeoffs you considered, and the local
  test process you followed.
-->

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
