### PR TITLE
Rename PredicatePushdownParameters to PredicatePushdownState

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -245,8 +245,8 @@ class DataflowPlanBuilder:
         # Due to other outstanding issues with conversion metric filters, we disable predicate
         # pushdown for any filter parameter set that is not part of the original time range constraint
         # implementation.
-        disabled_pushdown_parameters = PredicatePushdownState.with_pushdown_disabled()
-        time_range_only_pushdown_parameters = PredicatePushdownState(
+        disabled_pushdown_state = PredicatePushdownState.with_pushdown_disabled()
+        time_range_only_pushdown_state = PredicatePushdownState(
             time_range_constraint=predicate_pushdown_state.time_range_constraint,
             pushdown_enabled_types=frozenset([PredicateInputType.TIME_RANGE_CONSTRAINT]),
         )
@@ -258,13 +258,13 @@ class DataflowPlanBuilder:
         )
         base_measure_recipe = self._find_dataflow_recipe(
             measure_spec_properties=self._build_measure_spec_properties([base_measure_spec.measure_spec]),
-            predicate_pushdown_state=time_range_only_pushdown_parameters,
+            predicate_pushdown_state=time_range_only_pushdown_state,
             linkable_spec_set=base_required_linkable_specs,
         )
         logger.info(f"Recipe for base measure aggregation:\n{mf_pformat(base_measure_recipe)}")
         conversion_measure_recipe = self._find_dataflow_recipe(
             measure_spec_properties=self._build_measure_spec_properties([conversion_measure_spec.measure_spec]),
-            predicate_pushdown_state=disabled_pushdown_parameters,
+            predicate_pushdown_state=disabled_pushdown_state,
             linkable_spec_set=LinkableSpecSet(),
         )
         logger.info(f"Recipe for conversion measure aggregation:\n{mf_pformat(conversion_measure_recipe)}")
@@ -281,7 +281,7 @@ class DataflowPlanBuilder:
         aggregated_base_measure_node = self.build_aggregated_measure(
             metric_input_measure_spec=base_measure_spec,
             queried_linkable_specs=queried_linkable_specs,
-            predicate_pushdown_state=time_range_only_pushdown_parameters,
+            predicate_pushdown_state=time_range_only_pushdown_state,
         )
 
         # Build unaggregated conversions source node
@@ -357,7 +357,7 @@ class DataflowPlanBuilder:
         aggregated_conversions_node = self.build_aggregated_measure(
             metric_input_measure_spec=conversion_measure_spec,
             queried_linkable_specs=queried_linkable_specs,
-            predicate_pushdown_state=disabled_pushdown_parameters,
+            predicate_pushdown_state=disabled_pushdown_state,
             measure_recipe=recipe_with_join_conversion_source_node,
         )
 

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -84,7 +84,7 @@ from metricflow.dataflow.optimizer.dataflow_plan_optimizer import DataflowPlanOp
 from metricflow.dataset.dataset_classes import DataSet
 from metricflow.plan_conversion.node_processor import (
     PredicateInputType,
-    PredicatePushdownParameters,
+    PredicatePushdownState,
     PreJoinNodeProcessor,
 )
 from metricflow.sql.sql_table import SqlTable
@@ -181,7 +181,7 @@ class DataflowPlanBuilder:
             )
         )
 
-        predicate_pushdown_params = PredicatePushdownParameters(time_range_constraint=query_spec.time_range_constraint)
+        predicate_pushdown_params = PredicatePushdownState(time_range_constraint=query_spec.time_range_constraint)
 
         return self._build_metrics_output_node(
             metric_specs=tuple(
@@ -237,7 +237,7 @@ class DataflowPlanBuilder:
         entity_spec: EntitySpec,
         window: Optional[MetricTimeWindow],
         queried_linkable_specs: LinkableSpecSet,
-        predicate_pushdown_params: PredicatePushdownParameters,
+        predicate_pushdown_params: PredicatePushdownState,
         constant_properties: Optional[Sequence[ConstantPropertyInput]] = None,
     ) -> DataflowPlanNode:
         """Builds a node that contains aggregated values of conversions and opportunities."""
@@ -245,8 +245,8 @@ class DataflowPlanBuilder:
         # Due to other outstanding issues with conversion metric filters, we disable predicate
         # pushdown for any filter parameter set that is not part of the original time range constraint
         # implementation.
-        disabled_pushdown_parameters = PredicatePushdownParameters.with_pushdown_disabled()
-        time_range_only_pushdown_parameters = PredicatePushdownParameters(
+        disabled_pushdown_parameters = PredicatePushdownState.with_pushdown_disabled()
+        time_range_only_pushdown_parameters = PredicatePushdownState(
             time_range_constraint=predicate_pushdown_params.time_range_constraint,
             pushdown_enabled_types=frozenset([PredicateInputType.TIME_RANGE_CONSTRAINT]),
         )
@@ -369,7 +369,7 @@ class DataflowPlanBuilder:
         metric_spec: MetricSpec,
         queried_linkable_specs: LinkableSpecSet,
         filter_spec_factory: WhereSpecFactory,
-        predicate_pushdown_params: PredicatePushdownParameters,
+        predicate_pushdown_params: PredicatePushdownState,
         for_group_by_source_node: bool = False,
     ) -> ComputeMetricsNode:
         """Builds a compute metric node for a conversion metric."""
@@ -414,7 +414,7 @@ class DataflowPlanBuilder:
         metric_spec: MetricSpec,
         queried_linkable_specs: LinkableSpecSet,
         filter_spec_factory: WhereSpecFactory,
-        predicate_pushdown_params: PredicatePushdownParameters,
+        predicate_pushdown_params: PredicatePushdownState,
         for_group_by_source_node: bool = False,
     ) -> ComputeMetricsNode:
         """Builds a node to compute a metric that is not defined from other metrics."""
@@ -473,7 +473,7 @@ class DataflowPlanBuilder:
         metric_spec: MetricSpec,
         queried_linkable_specs: LinkableSpecSet,
         filter_spec_factory: WhereSpecFactory,
-        predicate_pushdown_params: PredicatePushdownParameters,
+        predicate_pushdown_params: PredicatePushdownState,
         for_group_by_source_node: bool = False,
     ) -> DataflowPlanNode:
         """Builds a node to compute a metric defined from other metrics."""
@@ -512,7 +512,7 @@ class DataflowPlanBuilder:
             metric_pushdown_params = (
                 predicate_pushdown_params
                 if not metric_spec.has_time_offset
-                else PredicatePushdownParameters.with_pushdown_disabled()
+                else PredicatePushdownState.with_pushdown_disabled()
             )
 
             parent_nodes.append(
@@ -577,7 +577,7 @@ class DataflowPlanBuilder:
         metric_spec: MetricSpec,
         queried_linkable_specs: LinkableSpecSet,
         filter_spec_factory: WhereSpecFactory,
-        predicate_pushdown_params: PredicatePushdownParameters,
+        predicate_pushdown_params: PredicatePushdownState,
         for_group_by_source_node: bool = False,
     ) -> DataflowPlanNode:
         """Builds a node to compute a metric of any type."""
@@ -616,7 +616,7 @@ class DataflowPlanBuilder:
         metric_specs: Sequence[MetricSpec],
         queried_linkable_specs: LinkableSpecSet,
         filter_spec_factory: WhereSpecFactory,
-        predicate_pushdown_params: PredicatePushdownParameters,
+        predicate_pushdown_params: PredicatePushdownState,
         for_group_by_source_node: bool = False,
     ) -> DataflowPlanNode:
         """Builds a node that computes all requested metrics.
@@ -680,7 +680,7 @@ class DataflowPlanBuilder:
         required_linkable_specs, _ = self.__get_required_and_extraneous_linkable_specs(
             queried_linkable_specs=query_spec.linkable_specs, filter_specs=query_level_filter_specs
         )
-        predicate_pushdown_params = PredicatePushdownParameters(time_range_constraint=query_spec.time_range_constraint)
+        predicate_pushdown_params = PredicatePushdownState(time_range_constraint=query_spec.time_range_constraint)
         dataflow_recipe = self._find_dataflow_recipe(
             linkable_spec_set=required_linkable_specs, predicate_pushdown_params=predicate_pushdown_params
         )
@@ -847,7 +847,7 @@ class DataflowPlanBuilder:
     def _find_dataflow_recipe(
         self,
         linkable_spec_set: LinkableSpecSet,
-        predicate_pushdown_params: PredicatePushdownParameters,
+        predicate_pushdown_params: PredicatePushdownState,
         measure_spec_properties: Optional[MeasureSpecProperties] = None,
     ) -> Optional[DataflowRecipe]:
         linkable_specs = linkable_spec_set.as_tuple
@@ -1212,7 +1212,7 @@ class DataflowPlanBuilder:
         self,
         metric_input_measure_spec: MetricInputMeasureSpec,
         queried_linkable_specs: LinkableSpecSet,
-        predicate_pushdown_params: PredicatePushdownParameters,
+        predicate_pushdown_params: PredicatePushdownState,
         measure_recipe: Optional[DataflowRecipe] = None,
     ) -> DataflowPlanNode:
         """Returns a node where the measures are aggregated by the linkable specs and constrained appropriately.
@@ -1264,7 +1264,7 @@ class DataflowPlanBuilder:
         self,
         metric_input_measure_spec: MetricInputMeasureSpec,
         queried_linkable_specs: LinkableSpecSet,
-        predicate_pushdown_params: PredicatePushdownParameters,
+        predicate_pushdown_params: PredicatePushdownState,
         measure_recipe: Optional[DataflowRecipe] = None,
     ) -> DataflowPlanNode:
         measure_spec = metric_input_measure_spec.measure_spec
@@ -1324,11 +1324,11 @@ class DataflowPlanBuilder:
                 else None
             )
             if measure_time_constraint is None:
-                measure_pushdown_params = PredicatePushdownParameters.without_time_range_constraint(
+                measure_pushdown_params = PredicatePushdownState.without_time_range_constraint(
                     predicate_pushdown_params
                 )
             else:
-                measure_pushdown_params = PredicatePushdownParameters.with_time_range_constraint(
+                measure_pushdown_params = PredicatePushdownState.with_time_range_constraint(
                     predicate_pushdown_params, time_range_constraint=measure_time_constraint
                 )
 

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -79,7 +79,7 @@ class PredicateInputType(Enum):
 
 
 @dataclasses.dataclass(frozen=True)
-class PredicatePushdownParameters:
+class PredicatePushdownState:
     """Container class for managing information about whether and how to do filter predicate pushdown.
 
     The time_range_constraint property holds the time window for setting up a time range filter expression.
@@ -89,7 +89,7 @@ class PredicatePushdownParameters:
     pushdown_enabled_types: FrozenSet[PredicateInputType] = frozenset([PredicateInputType.TIME_RANGE_CONSTRAINT])
 
     def __post_init__(self) -> None:
-        """Validation to ensure pushdown properties are configured correctly.
+        """Validation to ensure pushdown states are configured correctly.
 
         In particular, this asserts that cases where pushdown is disabled cannot leak pushdown operations via
         outside property access - if pushdown is disabled, no further pushdown operations of any kind are allowed
@@ -143,8 +143,8 @@ class PredicatePushdownParameters:
 
     @staticmethod
     def with_time_range_constraint(
-        original_pushdown_params: PredicatePushdownParameters, time_range_constraint: TimeRangeConstraint
-    ) -> PredicatePushdownParameters:
+        original_pushdown_params: PredicatePushdownState, time_range_constraint: TimeRangeConstraint
+    ) -> PredicatePushdownState:
         """Factory method for adding or updating a time range constraint input to a set of pushdown parameters.
 
         This allows for temporarily overriding a time range constraint with an adjusted one, or enabling a time
@@ -153,22 +153,22 @@ class PredicatePushdownParameters:
         pushdown_enabled_types = original_pushdown_params.pushdown_enabled_types.union(
             {PredicateInputType.TIME_RANGE_CONSTRAINT}
         )
-        return PredicatePushdownParameters(
+        return PredicatePushdownState(
             time_range_constraint=time_range_constraint, pushdown_enabled_types=pushdown_enabled_types
         )
 
     @staticmethod
     def without_time_range_constraint(
-        original_pushdown_params: PredicatePushdownParameters,
-    ) -> PredicatePushdownParameters:
+        original_pushdown_params: PredicatePushdownState,
+    ) -> PredicatePushdownState:
         """Factory method for removing the time range constraint, if any, from the given set of pushdown parameters."""
         pushdown_enabled_types = original_pushdown_params.pushdown_enabled_types.difference(
             {PredicateInputType.TIME_RANGE_CONSTRAINT}
         )
-        return PredicatePushdownParameters(time_range_constraint=None, pushdown_enabled_types=pushdown_enabled_types)
+        return PredicatePushdownState(time_range_constraint=None, pushdown_enabled_types=pushdown_enabled_types)
 
     @staticmethod
-    def with_pushdown_disabled() -> PredicatePushdownParameters:
+    def with_pushdown_disabled() -> PredicatePushdownState:
         """Factory method for disabling predicate pushdown for all parameter types.
 
         This is useful in cases where there is a branched path where pushdown should be disabled in one branch while the
@@ -176,7 +176,7 @@ class PredicatePushdownParameters:
         configuration might send a disabled copy of the pushdown parameters down that path while retaining the potential
         for using another path.
         """
-        return PredicatePushdownParameters(
+        return PredicatePushdownState(
             time_range_constraint=None,
             pushdown_enabled_types=frozenset(),
         )

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -143,14 +143,14 @@ class PredicatePushdownState:
 
     @staticmethod
     def with_time_range_constraint(
-        original_pushdown_params: PredicatePushdownState, time_range_constraint: TimeRangeConstraint
+        original_pushdown_state: PredicatePushdownState, time_range_constraint: TimeRangeConstraint
     ) -> PredicatePushdownState:
         """Factory method for adding or updating a time range constraint input to a set of pushdown parameters.
 
         This allows for temporarily overriding a time range constraint with an adjusted one, or enabling a time
         range constraint filter if one becomes available mid-stream during dataflow plan construction.
         """
-        pushdown_enabled_types = original_pushdown_params.pushdown_enabled_types.union(
+        pushdown_enabled_types = original_pushdown_state.pushdown_enabled_types.union(
             {PredicateInputType.TIME_RANGE_CONSTRAINT}
         )
         return PredicatePushdownState(
@@ -159,10 +159,10 @@ class PredicatePushdownState:
 
     @staticmethod
     def without_time_range_constraint(
-        original_pushdown_params: PredicatePushdownState,
+        original_pushdown_state: PredicatePushdownState,
     ) -> PredicatePushdownState:
         """Factory method for removing the time range constraint, if any, from the given set of pushdown parameters."""
-        pushdown_enabled_types = original_pushdown_params.pushdown_enabled_types.difference(
+        pushdown_enabled_types = original_pushdown_state.pushdown_enabled_types.difference(
             {PredicateInputType.TIME_RANGE_CONSTRAINT}
         )
         return PredicatePushdownState(time_range_constraint=None, pushdown_enabled_types=pushdown_enabled_types)

--- a/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
+++ b/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
@@ -7,7 +7,7 @@ from metricflow.plan_conversion.node_processor import PredicateInputType, Predic
 
 
 @pytest.fixture
-def all_pushdown_state() -> PredicatePushdownState:
+def fully_enabled_pushdown_state() -> PredicatePushdownState:
     """Tests a valid configuration with all predicate properties set and pushdown fully enabled."""
     params = PredicatePushdownState(
         time_range_constraint=TimeRangeConstraint.all_time(),
@@ -15,26 +15,28 @@ def all_pushdown_state() -> PredicatePushdownState:
     return params
 
 
-def test_time_range_pushdown_enabled_states(all_pushdown_state: PredicatePushdownState) -> None:
+def test_time_range_pushdown_enabled_states(fully_enabled_pushdown_state: PredicatePushdownState) -> None:
     """Tests pushdown enabled check for time range pushdown operations."""
-    time_range_only_params = PredicatePushdownState(
+    time_range_only_state = PredicatePushdownState(
         time_range_constraint=TimeRangeConstraint.all_time(),
         pushdown_enabled_types=frozenset([PredicateInputType.TIME_RANGE_CONSTRAINT]),
     )
 
     enabled_states = {
-        "fully enabled": all_pushdown_state.is_pushdown_enabled_for_time_range_constraint,
-        "enabled for time range only": time_range_only_params.is_pushdown_enabled_for_time_range_constraint,
+        "fully enabled": fully_enabled_pushdown_state.is_pushdown_enabled_for_time_range_constraint,
+        "enabled for time range only": time_range_only_state.is_pushdown_enabled_for_time_range_constraint,
     }
 
     assert all(list(enabled_states.values())), (
-        "Expected pushdown to be enabled for pushdown params with time range constraint and global pushdown enabled, "
-        f"but some params returned False for is_pushdown_enabled.\nPushdown enabled states: {enabled_states}\n"
-        f"All params: {all_pushdown_state}\nTime range only params: {time_range_only_params}"
+        "Expected pushdown to be enabled for pushdown state with time range constraint and global pushdown enabled, "
+        "but some states returned False for is_pushdown_enabled_for_time_range_constraints.\n"
+        f"Pushdown enabled states: {enabled_states}\n"
+        f"Fully enabled state: {fully_enabled_pushdown_state}\n"
+        f"Time range only state: {time_range_only_state}"
     )
 
 
 def test_invalid_disabled_pushdown_state() -> None:
     """Tests checks for invalid param configuration on disabled pushdown parameters."""
-    with pytest.raises(AssertionError, match="Disabled pushdown parameters cannot have properties set"):
+    with pytest.raises(AssertionError, match="Disabled pushdown state objects cannot have properties set"):
         PredicatePushdownState(time_range_constraint=TimeRangeConstraint.all_time(), pushdown_enabled_types=frozenset())

--- a/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
+++ b/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
@@ -7,7 +7,7 @@ from metricflow.plan_conversion.node_processor import PredicateInputType, Predic
 
 
 @pytest.fixture
-def all_pushdown_params() -> PredicatePushdownState:
+def all_pushdown_state() -> PredicatePushdownState:
     """Tests a valid configuration with all predicate properties set and pushdown fully enabled."""
     params = PredicatePushdownState(
         time_range_constraint=TimeRangeConstraint.all_time(),
@@ -15,7 +15,7 @@ def all_pushdown_params() -> PredicatePushdownState:
     return params
 
 
-def test_time_range_pushdown_enabled_states(all_pushdown_params: PredicatePushdownState) -> None:
+def test_time_range_pushdown_enabled_states(all_pushdown_state: PredicatePushdownState) -> None:
     """Tests pushdown enabled check for time range pushdown operations."""
     time_range_only_params = PredicatePushdownState(
         time_range_constraint=TimeRangeConstraint.all_time(),
@@ -23,18 +23,18 @@ def test_time_range_pushdown_enabled_states(all_pushdown_params: PredicatePushdo
     )
 
     enabled_states = {
-        "fully enabled": all_pushdown_params.is_pushdown_enabled_for_time_range_constraint,
+        "fully enabled": all_pushdown_state.is_pushdown_enabled_for_time_range_constraint,
         "enabled for time range only": time_range_only_params.is_pushdown_enabled_for_time_range_constraint,
     }
 
     assert all(list(enabled_states.values())), (
         "Expected pushdown to be enabled for pushdown params with time range constraint and global pushdown enabled, "
         f"but some params returned False for is_pushdown_enabled.\nPushdown enabled states: {enabled_states}\n"
-        f"All params: {all_pushdown_params}\nTime range only params: {time_range_only_params}"
+        f"All params: {all_pushdown_state}\nTime range only params: {time_range_only_params}"
     )
 
 
-def test_invalid_disabled_pushdown_params() -> None:
+def test_invalid_disabled_pushdown_state() -> None:
     """Tests checks for invalid param configuration on disabled pushdown parameters."""
     with pytest.raises(AssertionError, match="Disabled pushdown parameters cannot have properties set"):
         PredicatePushdownState(time_range_constraint=TimeRangeConstraint.all_time(), pushdown_enabled_types=frozenset())

--- a/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
+++ b/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
@@ -3,21 +3,21 @@ from __future__ import annotations
 import pytest
 from metricflow_semantics.filters.time_constraint import TimeRangeConstraint
 
-from metricflow.plan_conversion.node_processor import PredicateInputType, PredicatePushdownParameters
+from metricflow.plan_conversion.node_processor import PredicateInputType, PredicatePushdownState
 
 
 @pytest.fixture
-def all_pushdown_params() -> PredicatePushdownParameters:
+def all_pushdown_params() -> PredicatePushdownState:
     """Tests a valid configuration with all predicate properties set and pushdown fully enabled."""
-    params = PredicatePushdownParameters(
+    params = PredicatePushdownState(
         time_range_constraint=TimeRangeConstraint.all_time(),
     )
     return params
 
 
-def test_time_range_pushdown_enabled_states(all_pushdown_params: PredicatePushdownParameters) -> None:
+def test_time_range_pushdown_enabled_states(all_pushdown_params: PredicatePushdownState) -> None:
     """Tests pushdown enabled check for time range pushdown operations."""
-    time_range_only_params = PredicatePushdownParameters(
+    time_range_only_params = PredicatePushdownState(
         time_range_constraint=TimeRangeConstraint.all_time(),
         pushdown_enabled_types=frozenset([PredicateInputType.TIME_RANGE_CONSTRAINT]),
     )
@@ -37,6 +37,4 @@ def test_time_range_pushdown_enabled_states(all_pushdown_params: PredicatePushdo
 def test_invalid_disabled_pushdown_params() -> None:
     """Tests checks for invalid param configuration on disabled pushdown parameters."""
     with pytest.raises(AssertionError, match="Disabled pushdown parameters cannot have properties set"):
-        PredicatePushdownParameters(
-            time_range_constraint=TimeRangeConstraint.all_time(), pushdown_enabled_types=frozenset()
-        )
+        PredicatePushdownState(time_range_constraint=TimeRangeConstraint.all_time(), pushdown_enabled_types=frozenset())


### PR DESCRIPTION
Rename PredicatePushdownParameters to PredicatePushdownState

The PredicatePushdownParameters class is really a state tracking
container to help us determine whether and how to do predicate pushdown,
o we update the name to match its function.

Update pushdown_params -> pushdown_state

Straggling renames plus documentation updates