### PR TITLE
Encapsulate time range constraint application in more general method

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -882,16 +882,13 @@ class DataflowPlanBuilder:
             semantic_model_lookup=self._semantic_model_lookup,
             node_data_set_resolver=self._node_data_set_resolver,
         )
-        # TODO - Pushdown: Encapsulate this in the node processor
-        if (
-            predicate_pushdown_state.is_pushdown_enabled_for_time_range_constraint
-            and predicate_pushdown_state.time_range_constraint
-        ):
+
+        if predicate_pushdown_state.has_pushdown_potential:
             candidate_nodes_for_left_side_of_join = list(
-                node_processor.add_time_range_constraint(
+                node_processor.apply_matching_filter_predicates(
                     source_nodes=candidate_nodes_for_left_side_of_join,
+                    predicate_pushdown_state=predicate_pushdown_state,
                     metric_time_dimension_reference=self._metric_time_dimension_reference,
-                    time_range_constraint=predicate_pushdown_state.time_range_constraint,
                 )
             )
 

--- a/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
+++ b/tests_metricflow/dataflow/builder/test_predicate_pushdown.py
@@ -23,13 +23,13 @@ def test_time_range_pushdown_enabled_states(fully_enabled_pushdown_state: Predic
     )
 
     enabled_states = {
-        "fully enabled": fully_enabled_pushdown_state.is_pushdown_enabled_for_time_range_constraint,
-        "enabled for time range only": time_range_only_state.is_pushdown_enabled_for_time_range_constraint,
+        "fully enabled": fully_enabled_pushdown_state.has_time_range_constraint_to_push_down,
+        "enabled for time range only": time_range_only_state.has_time_range_constraint_to_push_down,
     }
 
     assert all(list(enabled_states.values())), (
         "Expected pushdown to be enabled for pushdown state with time range constraint and global pushdown enabled, "
-        "but some states returned False for is_pushdown_enabled_for_time_range_constraints.\n"
+        "but some states returned False for has_time_range_constraint_to_push_down.\n"
         f"Pushdown enabled states: {enabled_states}\n"
         f"Fully enabled state: {fully_enabled_pushdown_state}\n"
         f"Time range only state: {time_range_only_state}"


### PR DESCRIPTION
The time range constraint is our currently supported predicate pushdown
operation. The specific application of a time range constraint is
inlined in the DataflowPlanBuilder. This moves it to a more general
function, which will make it easier for us to handle other predicate
pushdown states while keeping the conditional logic contained.

Note this is effectively a no-op as the new function is currently a
pass-through. This is borne out by the lack of changes in our snapshots,
several of which cover the time range node.