### PR TITLE
Add element type property to LinkableElement interface

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
@@ -101,7 +101,7 @@ class LinkableElement(SemanticModelDerivation, SerializableDataclass, ABC):
     @property
     @abstractmethod
     def element_type(self) -> LinkableElementType:
-        """Blah."""
+        """The LinkableElementType describing what this instance represents."""
         raise NotImplementedError
 
 


### PR DESCRIPTION
The LinkableElement interface is used in cases where we have a
set of LinkableElements undifferentiated by underlying type.
In predicate pushdown, this happens with where specs that reference
some set of linkable elements but store them in an undifferentiated
collection.

In practice, we need to know not just the object type, but the more
refined LinkableElementType in order to apply the pushdown evaluation
logic, as time dimensions and categorical dimensions need to be
considered in a distinct way.

This makes the relevant property available in the parent interface
so we can access it directly.