### PR TITLE
Add semantic_model_origin property to LinkableElement interface

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
@@ -184,7 +184,7 @@ class LinkableElementSet(SemanticModelDerivation):
                         dimensions,
                         key=lambda linkable_dimension: (
                             linkable_dimension.semantic_model_origin.semantic_model_name
-                            if linkable_dimension.semantic_model_origin
+                            if linkable_dimension.defined_in_semantic_model
                             else ""
                         ),
                     )
@@ -194,7 +194,8 @@ class LinkableElementSet(SemanticModelDerivation):
             path_key_to_linkable_entities={
                 path_key: tuple(
                     sorted(
-                        entities, key=lambda linkable_entity: linkable_entity.semantic_model_origin.semantic_model_name
+                        entities,
+                        key=lambda linkable_entity: linkable_entity.defined_in_semantic_model.semantic_model_name,
                     )
                 )
                 for path_key, entities in join_path_to_linkable_entities.items()

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -72,7 +72,7 @@ def _generate_linkable_time_dimensions(
 
         linkable_dimensions.append(
             LinkableDimension(
-                semantic_model_origin=semantic_model_origin,
+                defined_in_semantic_model=semantic_model_origin,
                 element_name=dimension.reference.element_name,
                 dimension_type=DimensionType.TIME,
                 entity_links=entity_links,
@@ -88,7 +88,7 @@ def _generate_linkable_time_dimensions(
             if time_granularity.to_int() <= date_part.to_int():
                 linkable_dimensions.append(
                     LinkableDimension(
-                        semantic_model_origin=semantic_model_origin,
+                        defined_in_semantic_model=semantic_model_origin,
                         element_name=dimension.reference.element_name,
                         dimension_type=DimensionType.TIME,
                         entity_links=entity_links,
@@ -331,7 +331,7 @@ class ValidLinkableSpecResolver:
         for entity in semantic_model.entities:
             linkable_entities.append(
                 LinkableEntity(
-                    semantic_model_origin=semantic_model.reference,
+                    defined_in_semantic_model=semantic_model.reference,
                     element_name=entity.reference.element_name,
                     entity_links=(),
                     join_path=SemanticModelJoinPath(
@@ -346,7 +346,7 @@ class ValidLinkableSpecResolver:
                     continue
                 linkable_entities.append(
                     LinkableEntity(
-                        semantic_model_origin=semantic_model.reference,
+                        defined_in_semantic_model=semantic_model.reference,
                         element_name=entity.reference.element_name,
                         entity_links=(entity_link,),
                         join_path=SemanticModelJoinPath(
@@ -363,7 +363,7 @@ class ValidLinkableSpecResolver:
                 if dimension_type is DimensionType.CATEGORICAL:
                     linkable_dimensions.append(
                         LinkableDimension(
-                            semantic_model_origin=semantic_model.reference,
+                            defined_in_semantic_model=semantic_model.reference,
                             element_name=dimension.reference.element_name,
                             dimension_type=DimensionType.CATEGORICAL,
                             entity_links=(entity_link,),
@@ -495,7 +495,7 @@ class ValidLinkableSpecResolver:
                 )
                 path_key_to_linkable_dimensions[path_key].append(
                     LinkableDimension(
-                        semantic_model_origin=measure_semantic_model.reference if measure_semantic_model else None,
+                        defined_in_semantic_model=measure_semantic_model.reference if measure_semantic_model else None,
                         element_name=MetricFlowReservedKeywords.METRIC_TIME.value,
                         dimension_type=DimensionType.TIME,
                         entity_links=(),
@@ -722,7 +722,7 @@ class ValidLinkableSpecResolver:
             if dimension_type == DimensionType.CATEGORICAL:
                 linkable_dimensions.append(
                     LinkableDimension(
-                        semantic_model_origin=semantic_model.reference,
+                        defined_in_semantic_model=semantic_model.reference,
                         element_name=dimension.reference.element_name,
                         dimension_type=DimensionType.CATEGORICAL,
                         entity_links=join_path.entity_links,
@@ -750,7 +750,7 @@ class ValidLinkableSpecResolver:
             if entity.reference != join_path.last_entity_link:
                 linkable_entities.append(
                     LinkableEntity(
-                        semantic_model_origin=semantic_model.reference,
+                        defined_in_semantic_model=semantic_model.reference,
                         element_name=entity.reference.element_name,
                         entity_links=join_path.entity_links,
                         join_path=join_path,

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_element_set.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_element_set.py
@@ -58,14 +58,14 @@ _base_metric_reference = MetricReference(element_name="base_metric")
 # Entities
 _base_entity = LinkableEntity(
     element_name=_base_entity_reference.element_name,
-    semantic_model_origin=_base_semantic_model,
+    defined_in_semantic_model=_base_semantic_model,
     entity_links=(),
     join_path=SemanticModelJoinPath(left_semantic_model_reference=_measure_semantic_model),
     properties=frozenset([LinkableElementProperty.ENTITY]),
 )
 _ambiguous_entity = LinkableEntity(
     element_name=AMBIGUOUS_NAME,
-    semantic_model_origin=_base_semantic_model,
+    defined_in_semantic_model=_base_semantic_model,
     entity_links=(_base_entity_reference,),
     join_path=SemanticModelJoinPath(left_semantic_model_reference=_measure_semantic_model),
     properties=frozenset([LinkableElementProperty.ENTITY, LinkableElementProperty.LOCAL_LINKED]),
@@ -73,7 +73,7 @@ _ambiguous_entity = LinkableEntity(
 # For testing deduplication on entities
 _ambiguous_entity_with_join_path = LinkableEntity(
     element_name=AMBIGUOUS_NAME,
-    semantic_model_origin=_base_semantic_model,
+    defined_in_semantic_model=_base_semantic_model,
     entity_links=(_base_entity_reference,),
     join_path=SemanticModelJoinPath(
         left_semantic_model_reference=_measure_semantic_model,
@@ -92,7 +92,7 @@ _categorical_dimension = LinkableDimension(
     element_name=_base_dimension_reference.element_name,
     entity_links=(_base_entity_reference,),
     dimension_type=DimensionType.CATEGORICAL,
-    semantic_model_origin=_base_semantic_model,
+    defined_in_semantic_model=_base_semantic_model,
     join_path=SemanticModelJoinPath(left_semantic_model_reference=_measure_semantic_model),
     properties=frozenset([LinkableElementProperty.LOCAL_LINKED]),
     time_granularity=None,
@@ -102,7 +102,7 @@ _time_dimension = LinkableDimension(
     element_name=_time_dimension_reference.element_name,
     entity_links=(_base_entity_reference,),
     dimension_type=DimensionType.TIME,
-    semantic_model_origin=_base_semantic_model,
+    defined_in_semantic_model=_base_semantic_model,
     join_path=SemanticModelJoinPath(left_semantic_model_reference=_measure_semantic_model),
     properties=frozenset([LinkableElementProperty.LOCAL_LINKED]),
     time_granularity=TimeGranularity.DAY,
@@ -113,7 +113,7 @@ _ambiguous_categorical_dimension = LinkableDimension(
     element_name=AMBIGUOUS_NAME,
     entity_links=(_base_entity_reference,),
     dimension_type=DimensionType.CATEGORICAL,
-    semantic_model_origin=_secondary_semantic_model,
+    defined_in_semantic_model=_secondary_semantic_model,
     join_path=SemanticModelJoinPath(left_semantic_model_reference=_measure_semantic_model),
     properties=frozenset([LinkableElementProperty.LOCAL_LINKED]),
     time_granularity=None,
@@ -125,7 +125,7 @@ _ambiguous_categorical_dimension_with_join_path = LinkableDimension(
     element_name=AMBIGUOUS_NAME,
     entity_links=(_base_entity_reference,),
     dimension_type=DimensionType.CATEGORICAL,
-    semantic_model_origin=_secondary_semantic_model,
+    defined_in_semantic_model=_secondary_semantic_model,
     join_path=SemanticModelJoinPath(
         left_semantic_model_reference=_measure_semantic_model,
         path_elements=(
@@ -576,7 +576,7 @@ def linkable_set() -> LinkableElementSet:  # noqa: D103
                 element_type=LinkableElementType.DIMENSION,
             ): (
                 LinkableDimension(
-                    semantic_model_origin=SemanticModelReference("dimension_source"),
+                    defined_in_semantic_model=SemanticModelReference("dimension_source"),
                     element_name="dimension_element",
                     dimension_type=DimensionType.CATEGORICAL,
                     entity_links=(entity_0,),
@@ -601,7 +601,7 @@ def linkable_set() -> LinkableElementSet:  # noqa: D103
                 time_granularity=TimeGranularity.DAY,
             ): (
                 LinkableDimension(
-                    semantic_model_origin=SemanticModelReference("time_dimension_source"),
+                    defined_in_semantic_model=SemanticModelReference("time_dimension_source"),
                     element_name="time_dimension_element",
                     dimension_type=DimensionType.TIME,
                     entity_links=(entity_1,),
@@ -627,7 +627,7 @@ def linkable_set() -> LinkableElementSet:  # noqa: D103
                 element_type=LinkableElementType.ENTITY,
             ): (
                 LinkableEntity(
-                    semantic_model_origin=SemanticModelReference("entity_source"),
+                    defined_in_semantic_model=SemanticModelReference("entity_source"),
                     element_name="entity_element",
                     entity_links=(entity_2,),
                     join_path=SemanticModelJoinPath(

--- a/metricflow-semantics/tests_metricflow_semantics/model/test_where_filter_spec.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/test_where_filter_spec.py
@@ -115,7 +115,7 @@ def test_dimension_in_filter(  # noqa: D103
                         date_part=None,
                     ): (
                         LinkableDimension(
-                            semantic_model_origin=SemanticModelReference("bookings"),
+                            defined_in_semantic_model=SemanticModelReference("bookings"),
                             dimension_type=DimensionType.CATEGORICAL,
                             element_name="country_latest",
                             entity_links=(EntityReference("listing"),),
@@ -173,7 +173,7 @@ def test_dimension_in_filter_with_grain(  # noqa: D103
                         date_part=None,
                     ): (
                         LinkableDimension(
-                            semantic_model_origin=SemanticModelReference("listings_source"),
+                            defined_in_semantic_model=SemanticModelReference("listings_source"),
                             dimension_type=DimensionType.TIME,
                             element_name="created_at",
                             entity_links=(EntityReference("listing"),),
@@ -237,7 +237,7 @@ def test_time_dimension_in_filter(  # noqa: D103
                         date_part=None,
                     ): (
                         LinkableDimension(
-                            semantic_model_origin=SemanticModelReference("listings_source"),
+                            defined_in_semantic_model=SemanticModelReference("listings_source"),
                             dimension_type=DimensionType.CATEGORICAL,
                             element_name="created_at",
                             entity_links=(EntityReference("listing"),),
@@ -302,7 +302,7 @@ def test_date_part_in_filter(  # noqa: D103
                         date_part=DatePart.YEAR,
                     ): (
                         LinkableDimension(
-                            semantic_model_origin=SemanticModelReference("bookings"),
+                            defined_in_semantic_model=SemanticModelReference("bookings"),
                             dimension_type=DimensionType.TIME,
                             element_name="metric_time",
                             entity_links=(),
@@ -370,7 +370,7 @@ def resolved_spec_lookup() -> FilterSpecResolutionLookUp:
                             date_part=DatePart.YEAR,
                         ): (
                             LinkableDimension(
-                                semantic_model_origin=SemanticModelReference("bookings"),
+                                defined_in_semantic_model=SemanticModelReference("bookings"),
                                 dimension_type=DimensionType.TIME,
                                 element_name="metric_time",
                                 entity_links=(),
@@ -492,7 +492,7 @@ def test_entity_in_filter(  # noqa: D103
                         date_part=DatePart.YEAR,
                     ): (
                         LinkableEntity(
-                            semantic_model_origin=SemanticModelReference("bookings"),
+                            defined_in_semantic_model=SemanticModelReference("bookings"),
                             element_name="user",
                             entity_links=(EntityReference("listing"),),
                             join_path=SemanticModelJoinPath(
@@ -603,7 +603,7 @@ def test_dimension_time_dimension_parity(column_association_resolver: ColumnAsso
                                     date_part=DatePart.YEAR,
                                 ): (
                                     LinkableDimension(
-                                        semantic_model_origin=SemanticModelReference("bookings"),
+                                        defined_in_semantic_model=SemanticModelReference("bookings"),
                                         dimension_type=DimensionType.TIME,
                                         element_name=METRIC_TIME_ELEMENT_NAME,
                                         entity_links=(),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__accumulate_last_2_months_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__accumulate_last_2_months_metric__result.txt
@@ -8,7 +8,7 @@ GroupByItemResolution(
         time_granularity=MONTH,
       ): (
         LinkableDimension(
-          semantic_model_origin=SemanticModelReference(
+          defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='monthly_measures_source',
           ),
           element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_different_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_different_parent_time_grains__result.txt
@@ -20,7 +20,7 @@ GroupByItemResolution(
                   time_granularity=MONTH,
                 ): (
                   LinkableDimension(
-                    semantic_model_origin=SemanticModelReference(
+                    defined_in_semantic_model=SemanticModelReference(
                       semantic_model_name='monthly_measures_source',
                     ),
                     element_name='metric_time',
@@ -65,7 +65,7 @@ GroupByItemResolution(
                   time_granularity=YEAR,
                 ): (
                   LinkableDimension(
-                    semantic_model_origin=SemanticModelReference(
+                    defined_in_semantic_model=SemanticModelReference(
                       semantic_model_name='yearly_measure_source',
                     ),
                     element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_same_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_same_parent_time_grains__result.txt
@@ -8,7 +8,7 @@ GroupByItemResolution(
         time_granularity=MONTH,
       ): (
         LinkableDimension(
-          semantic_model_origin=SemanticModelReference(
+          defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='monthly_measures_source',
           ),
           element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_different_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_different_time_grains__result.txt
@@ -17,7 +17,7 @@ GroupByItemResolution(
                   time_granularity=MONTH,
                 ): (
                   LinkableDimension(
-                    semantic_model_origin=SemanticModelReference(
+                    defined_in_semantic_model=SemanticModelReference(
                       semantic_model_name='monthly_measures_source',
                     ),
                     element_name='metric_time',
@@ -60,7 +60,7 @@ GroupByItemResolution(
                   time_granularity=YEAR,
                 ): (
                   LinkableDimension(
-                    semantic_model_origin=SemanticModelReference(
+                    defined_in_semantic_model=SemanticModelReference(
                       semantic_model_name='yearly_measure_source',
                     ),
                     element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_same_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_same_time_grains__result.txt
@@ -8,7 +8,7 @@ GroupByItemResolution(
         time_granularity=MONTH,
       ): (
         LinkableDimension(
-          semantic_model_origin=SemanticModelReference(
+          defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='monthly_measures_source',
           ),
           element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__simple_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__simple_metric__result.txt
@@ -8,7 +8,7 @@ GroupByItemResolution(
         time_granularity=MONTH,
       ): (
         LinkableDimension(
-          semantic_model_origin=SemanticModelReference(
+          defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='monthly_measures_source',
           ),
           element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
@@ -54,7 +54,7 @@ ParseQueryResult(
                 ),
               ): (
                 LinkableDimension(
-                  semantic_model_origin=SemanticModelReference(
+                  defined_in_semantic_model=SemanticModelReference(
                     semantic_model_name='bookings_source',
                   ),
                   element_name='is_instant',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_derived_metrics_with_common_filtered_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_derived_metrics_with_common_filtered_metric__result.txt
@@ -30,7 +30,7 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
-              semantic_model_origin=SemanticModelReference(
+              defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
               element_name='metric_time',
@@ -93,7 +93,7 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
-              semantic_model_origin=SemanticModelReference(
+              defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
               element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_filter__result.txt
@@ -49,7 +49,7 @@ FilterSpecResolutionLookUp(
                       time_granularity=MONTH,
                     ): (
                       LinkableDimension(
-                        semantic_model_origin=SemanticModelReference(
+                        defined_in_semantic_model=SemanticModelReference(
                           semantic_model_name='monthly_measures_source',
                         ),
                         element_name='metric_time',
@@ -94,7 +94,7 @@ FilterSpecResolutionLookUp(
                       time_granularity=YEAR,
                     ): (
                       LinkableDimension(
-                        semantic_model_origin=SemanticModelReference(
+                        defined_in_semantic_model=SemanticModelReference(
                           semantic_model_name='yearly_measure_source',
                         ),
                         element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_input_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_input_filter__result.txt
@@ -50,7 +50,7 @@ FilterSpecResolutionLookUp(
                       time_granularity=MONTH,
                     ): (
                       LinkableDimension(
-                        semantic_model_origin=SemanticModelReference(
+                        defined_in_semantic_model=SemanticModelReference(
                           semantic_model_name='monthly_measures_source',
                         ),
                         element_name='metric_time',
@@ -97,7 +97,7 @@ FilterSpecResolutionLookUp(
                       time_granularity=YEAR,
                     ): (
                       LinkableDimension(
-                        semantic_model_origin=SemanticModelReference(
+                        defined_in_semantic_model=SemanticModelReference(
                           semantic_model_name='yearly_measure_source',
                         ),
                         element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_filter__result.txt
@@ -30,7 +30,7 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
-              semantic_model_origin=SemanticModelReference(
+              defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
               element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_input_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_input_filter__result.txt
@@ -30,7 +30,7 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
-              semantic_model_origin=SemanticModelReference(
+              defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
               element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__accumulate_last_2_months_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__accumulate_last_2_months_metric__result.txt
@@ -30,7 +30,7 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
-              semantic_model_origin=SemanticModelReference(
+              defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
               element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_different_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_different_parent_time_grains__result.txt
@@ -49,7 +49,7 @@ FilterSpecResolutionLookUp(
                       time_granularity=MONTH,
                     ): (
                       LinkableDimension(
-                        semantic_model_origin=SemanticModelReference(
+                        defined_in_semantic_model=SemanticModelReference(
                           semantic_model_name='monthly_measures_source',
                         ),
                         element_name='metric_time',
@@ -94,7 +94,7 @@ FilterSpecResolutionLookUp(
                       time_granularity=YEAR,
                     ): (
                       LinkableDimension(
-                        semantic_model_origin=SemanticModelReference(
+                        defined_in_semantic_model=SemanticModelReference(
                           semantic_model_name='yearly_measure_source',
                         ),
                         element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_same_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_same_parent_time_grains__result.txt
@@ -30,7 +30,7 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
-              semantic_model_origin=SemanticModelReference(
+              defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
               element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_different_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_different_time_grains__result.txt
@@ -51,7 +51,7 @@ FilterSpecResolutionLookUp(
                       time_granularity=MONTH,
                     ): (
                       LinkableDimension(
-                        semantic_model_origin=SemanticModelReference(
+                        defined_in_semantic_model=SemanticModelReference(
                           semantic_model_name='monthly_measures_source',
                         ),
                         element_name='metric_time',
@@ -94,7 +94,7 @@ FilterSpecResolutionLookUp(
                       time_granularity=YEAR,
                     ): (
                       LinkableDimension(
-                        semantic_model_origin=SemanticModelReference(
+                        defined_in_semantic_model=SemanticModelReference(
                           semantic_model_name='yearly_measure_source',
                         ),
                         element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_same_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_same_time_grains__result.txt
@@ -33,7 +33,7 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
-              semantic_model_origin=SemanticModelReference(
+              defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
               element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__simple_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__simple_metric__result.txt
@@ -30,7 +30,7 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
-              semantic_model_origin=SemanticModelReference(
+              defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
               element_name='metric_time',

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -608,10 +608,10 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                     )
                 else:
                     assert (
-                        linkable_dimension.semantic_model_origin
+                        linkable_dimension.defined_in_semantic_model
                     ), "Only metric_time can have no semantic_model_origin."
                     semantic_model = self._semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
-                        linkable_dimension.semantic_model_origin
+                        linkable_dimension.defined_in_semantic_model
                     )
                     assert semantic_model
                     dimensions.append(
@@ -662,7 +662,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         ) in path_key_to_linkable_entities.items():
             for linkable_entity in linkable_entity_tuple:
                 semantic_model = self._semantic_manifest_lookup.semantic_model_lookup.get_by_reference(
-                    linkable_entity.semantic_model_origin
+                    linkable_entity.defined_in_semantic_model
                 )
                 assert semantic_model
                 entities.append(

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -202,7 +202,7 @@ def test_filter_with_where_constraint_node(
             ),
             linkable_elements=(
                 LinkableDimension(
-                    semantic_model_origin=SemanticModelReference("bookings_source"),
+                    defined_in_semantic_model=SemanticModelReference("bookings_source"),
                     element_name="ds",
                     dimension_type=DimensionType.TIME,
                     entity_links=(EntityReference(element_name="booking"),),

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -38,7 +38,7 @@
                     <!--     ),                                                           -->
                     <!--     linkable_elements=(                                          -->
                     <!--       LinkableDimension(                                         -->
-                    <!--         semantic_model_origin=SemanticModelReference(            -->
+                    <!--         defined_in_semantic_model=SemanticModelReference(        -->
                     <!--           semantic_model_name='listings_latest',                 -->
                     <!--         ),                                                       -->
                     <!--         element_name='country_latest',                           -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
@@ -43,7 +43,7 @@
                     <!--     ),                                                           -->
                     <!--     linkable_elements=(                                          -->
                     <!--       LinkableDimension(                                         -->
-                    <!--         semantic_model_origin=SemanticModelReference(            -->
+                    <!--         defined_in_semantic_model=SemanticModelReference(        -->
                     <!--           semantic_model_name='listings_latest',                 -->
                     <!--         ),                                                       -->
                     <!--         element_name='country_latest',                           -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -17,7 +17,7 @@
             <!--         ),                                                                     -->
             <!--         linkable_elements=(                                                    -->
             <!--           LinkableDimension(                                                   -->
-            <!--             semantic_model_origin=SemanticModelReference(                      -->
+            <!--             defined_in_semantic_model=SemanticModelReference(                  -->
             <!--               semantic_model_name='bookings_source',                           -->
             <!--             ),                                                                 -->
             <!--             element_name='metric_time',                                        -->
@@ -49,7 +49,7 @@
                     <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
                     <!--     linkable_elements=(                                                                    -->
                     <!--       LinkableDimension(                                                                   -->
-                    <!--         semantic_model_origin=SemanticModelReference(                                      -->
+                    <!--         defined_in_semantic_model=SemanticModelReference(                                  -->
                     <!--           semantic_model_name='bookings_source',                                           -->
                     <!--         ),                                                                                 -->
                     <!--         element_name='metric_time',                                                        -->
@@ -96,7 +96,7 @@
                                 <!--     ),                                                          -->
                                 <!--     linkable_elements=(                                         -->
                                 <!--       LinkableDimension(                                        -->
-                                <!--         semantic_model_origin=SemanticModelReference(           -->
+                                <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                 <!--           semantic_model_name='bookings_source',                -->
                                 <!--         ),                                                      -->
                                 <!--         element_name='metric_time',                             -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -27,7 +27,7 @@
                     <!--         ),                                                           -->
                     <!--         linkable_elements=(                                          -->
                     <!--           LinkableDimension(                                         -->
-                    <!--             semantic_model_origin=SemanticModelReference(            -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
                     <!--               semantic_model_name='listings_latest',                 -->
                     <!--             ),                                                       -->
                     <!--             element_name='is_lux_latest',                            -->
@@ -80,7 +80,7 @@
                                 <!--     ),                                                           -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
-                                <!--         semantic_model_origin=SemanticModelReference(            -->
+                                <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                 <!--           semantic_model_name='listings_latest',                 -->
                                 <!--         ),                                                       -->
                                 <!--         element_name='is_lux_latest',                            -->
@@ -192,7 +192,7 @@
                     <!--         ),                                                           -->
                     <!--         linkable_elements=(                                          -->
                     <!--           LinkableDimension(                                         -->
-                    <!--             semantic_model_origin=SemanticModelReference(            -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
                     <!--               semantic_model_name='listings_latest',                 -->
                     <!--             ),                                                       -->
                     <!--             element_name='is_lux_latest',                            -->
@@ -245,7 +245,7 @@
                                 <!--     ),                                                           -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
-                                <!--         semantic_model_origin=SemanticModelReference(            -->
+                                <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                 <!--           semantic_model_name='listings_latest',                 -->
                                 <!--         ),                                                       -->
                                 <!--         element_name='is_lux_latest',                            -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -27,7 +27,7 @@
                     <!--         ),                                                           -->
                     <!--         linkable_elements=(                                          -->
                     <!--           LinkableDimension(                                         -->
-                    <!--             semantic_model_origin=SemanticModelReference(            -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
                     <!--               semantic_model_name='bookings_source',                 -->
                     <!--             ),                                                       -->
                     <!--             element_name='is_instant',                               -->
@@ -71,7 +71,7 @@
                                 <!--     ),                                                           -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
-                                <!--         semantic_model_origin=SemanticModelReference(            -->
+                                <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                 <!--           semantic_model_name='bookings_source',                 -->
                                 <!--         ),                                                       -->
                                 <!--         element_name='is_instant',                               -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -17,7 +17,7 @@
             <!--         ),                                                                     -->
             <!--         linkable_elements=(                                                    -->
             <!--           LinkableDimension(                                                   -->
-            <!--             semantic_model_origin=SemanticModelReference(                      -->
+            <!--             defined_in_semantic_model=SemanticModelReference(                  -->
             <!--               semantic_model_name='bookings_source',                           -->
             <!--             ),                                                                 -->
             <!--             element_name='metric_time',                                        -->
@@ -52,7 +52,7 @@
                 <!--         ),                                                          -->
                 <!--         linkable_elements=(                                         -->
                 <!--           LinkableDimension(                                        -->
-                <!--             semantic_model_origin=SemanticModelReference(           -->
+                <!--             defined_in_semantic_model=SemanticModelReference(       -->
                 <!--               semantic_model_name='bookings_source',                -->
                 <!--             ),                                                      -->
                 <!--             element_name='metric_time',                             -->
@@ -90,7 +90,7 @@
                             <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
                             <!--     linkable_elements=(                                                                    -->
                             <!--       LinkableDimension(                                                                   -->
-                            <!--         semantic_model_origin=SemanticModelReference(                                      -->
+                            <!--         defined_in_semantic_model=SemanticModelReference(                                  -->
                             <!--           semantic_model_name='bookings_source',                                           -->
                             <!--         ),                                                                                 -->
                             <!--         element_name='metric_time',                                                        -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -17,7 +17,7 @@
             <!--         ),                                                                     -->
             <!--         linkable_elements=(                                                    -->
             <!--           LinkableDimension(                                                   -->
-            <!--             semantic_model_origin=SemanticModelReference(                      -->
+            <!--             defined_in_semantic_model=SemanticModelReference(                  -->
             <!--               semantic_model_name='bookings_source',                           -->
             <!--             ),                                                                 -->
             <!--             element_name='metric_time',                                        -->
@@ -55,7 +55,7 @@
                     <!--         ),                                                             -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
-                    <!--             semantic_model_origin=SemanticModelReference(              -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(          -->
                     <!--               semantic_model_name='bookings_source',                   -->
                     <!--             ),                                                         -->
                     <!--             element_name='metric_time',                                -->
@@ -97,7 +97,7 @@
                                 <!--     ),                                                          -->
                                 <!--     linkable_elements=(                                         -->
                                 <!--       LinkableDimension(                                        -->
-                                <!--         semantic_model_origin=SemanticModelReference(           -->
+                                <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                 <!--           semantic_model_name='bookings_source',                -->
                                 <!--         ),                                                      -->
                                 <!--         element_name='metric_time',                             -->
@@ -167,7 +167,7 @@
                     <!--         ),                                                          -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
-                    <!--             semantic_model_origin=SemanticModelReference(           -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='bookings_source',                -->
                     <!--             ),                                                      -->
                     <!--             element_name='metric_time',                             -->
@@ -208,7 +208,7 @@
                                 <!--     ),                                                          -->
                                 <!--     linkable_elements=(                                         -->
                                 <!--       LinkableDimension(                                        -->
-                                <!--         semantic_model_origin=SemanticModelReference(           -->
+                                <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                 <!--           semantic_model_name='bookings_source',                -->
                                 <!--         ),                                                      -->
                                 <!--         element_name='metric_time',                             -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -20,7 +20,7 @@
             <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
-            <!--             semantic_model_origin=SemanticModelReference(            -->
+            <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='listings_latest',                 -->
             <!--             ),                                                       -->
             <!--             element_name='country_latest',                           -->
@@ -75,7 +75,7 @@
                         <!--     ),                                                           -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
-                        <!--         semantic_model_origin=SemanticModelReference(            -->
+                        <!--         defined_in_semantic_model=SemanticModelReference(        -->
                         <!--           semantic_model_name='listings_latest',                 -->
                         <!--         ),                                                       -->
                         <!--         element_name='country_latest',                           -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -17,7 +17,7 @@
             <!--         ),                                                                     -->
             <!--         linkable_elements=(                                                    -->
             <!--           LinkableDimension(                                                   -->
-            <!--             semantic_model_origin=SemanticModelReference(                      -->
+            <!--             defined_in_semantic_model=SemanticModelReference(                  -->
             <!--               semantic_model_name='bookings_source',                           -->
             <!--             ),                                                                 -->
             <!--             element_name='metric_time',                                        -->
@@ -57,7 +57,7 @@
                         <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
                         <!--     linkable_elements=(                                                                    -->
                         <!--       LinkableDimension(                                                                   -->
-                        <!--         semantic_model_origin=SemanticModelReference(                                      -->
+                        <!--         defined_in_semantic_model=SemanticModelReference(                                  -->
                         <!--           semantic_model_name='bookings_source',                                           -->
                         <!--         ),                                                                                 -->
                         <!--         element_name='metric_time',                                                        -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -20,7 +20,7 @@
             <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
-            <!--             semantic_model_origin=SemanticModelReference(            -->
+            <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='listings_latest',                 -->
             <!--             ),                                                       -->
             <!--             element_name='country_latest',                           -->
@@ -65,7 +65,7 @@
                     <!--     ),                                                           -->
                     <!--     linkable_elements=(                                          -->
                     <!--       LinkableDimension(                                         -->
-                    <!--         semantic_model_origin=SemanticModelReference(            -->
+                    <!--         defined_in_semantic_model=SemanticModelReference(        -->
                     <!--           semantic_model_name='listings_latest',                 -->
                     <!--         ),                                                       -->
                     <!--         element_name='country_latest',                           -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -59,7 +59,7 @@
                             <!--     ),                                                           -->
                             <!--     linkable_elements=(                                          -->
                             <!--       LinkableDimension(                                         -->
-                            <!--         semantic_model_origin=SemanticModelReference(            -->
+                            <!--         defined_in_semantic_model=SemanticModelReference(        -->
                             <!--           semantic_model_name='bookings_source',                 -->
                             <!--         ),                                                       -->
                             <!--         element_name='is_instant',                               -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -59,7 +59,7 @@
                             <!--     ),                                                           -->
                             <!--     linkable_elements=(                                          -->
                             <!--       LinkableDimension(                                         -->
-                            <!--         semantic_model_origin=SemanticModelReference(            -->
+                            <!--         defined_in_semantic_model=SemanticModelReference(        -->
                             <!--           semantic_model_name='bookings_source',                 -->
                             <!--         ),                                                       -->
                             <!--         element_name='is_instant',                               -->


### PR DESCRIPTION
LinkableElements have a commonality, which is that they always have
either a semantic model where they are defined, or they are virtual
constructs (either metric queries or virtual dimensions, such as
metric_time).

In order to do predicate pushdown evaluation against source nodes,
we require the linkable element to have a singular semantic model origin.
That may be a virtual model, as in the case of metric_time or metric
elements, or it may be a concrete model, as in the case of all other
entities and dimensions.

This change provides that accessor. It is separated out for ease of
review due to the need to rename the existing `semantic_model_origin`
property. We could not re-use it, as dataclasses do not allow a mixture
of @property decorated functions and simple properties. This has the
added benefit of differentiating between the semantic model origin,
which may be virtual, and the semantic model containing the element
definition.