### PR TITLE
Add Support for Python 3.12

### DIFF
--- a/.changes/unreleased/Features-20240530-190900.yaml
+++ b/.changes/unreleased/Features-20240530-190900.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for Python 3.12
+time: 2024-05-30T19:09:00.228097-07:00
+custom:
+  Author: plypaul
+  Issue: "1065"

--- a/metricflow-semantics/pyproject.toml
+++ b/metricflow-semantics/pyproject.toml
@@ -7,7 +7,7 @@ name = "metricflow-semantics"
 version = "0.1.0"
 description = "Modules for semantic understanding of a MetricFlow query."
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8,<3.13"
 license = "BUSL-1.1"
 authors = [
   { name = "dbt Labs", email = "info@dbtlabs.com" },
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "metricflow"
 version = "0.206.0.dev2"
 description = "Translates a simple metric definition into reusable SQL and executes it against the SQL engine of your choice."
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8,<3.13"
 license = "BUSL-1.1"
 keywords = []
 authors = [
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
Resolves #1065 


### Description

This adds support for Python 3.12. Once this is merged, the plan is to:

* Increment the version of MF and publish it.
* Update `dbt-metricflow` to use that new version since CI depends on that package.
* Update CI to add tests for Python 3.12.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
