### PR TITLE
Update workflows to support Python 3.12

### DIFF
--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -46,10 +46,10 @@ jobs:
       - name: Check-out the repo
         uses: actions/checkout@v3
 
-      - name: Test w/ Python 3.11
+      - name: Test w/ Python 3.12
         uses: ./.github/actions/run-mf-tests
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           make-target: "test-postgresql"
 
   metricflow-unit-tests:


### PR DESCRIPTION
### Description

Now that all packages support Python 3.12, the workflows can be updated to run tests using Python 3.12.
<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
