### PR TITLE
Fix warnings that appear when running `pytest`

### DIFF
--- a/metricflow-semantics/extra-hatch-configuration/requirements-dev-packages.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements-dev-packages.txt
@@ -1,9 +1,9 @@
 # Developer tools
 mypy>=1.7.0, <1.8.0
 pre-commit>=3.2.2, <3.3.0
-pytest-mock>=3.7.0, <3.8.0
-pytest-xdist>=3.2.1, <3.3.0
-pytest>=7.1.1, < 7.2.0
+pytest-mock>=3.14.0, <3.15.0
+pytest-xdist>=3.6.0, <3.7.0
+pytest>=8.0.0, < 9.0.0
 PyYAML>=6.0, <7.0.0
 tabulate>=0.8.9
 types-PyYAML

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,4 +1,4 @@
 dbt-semantic-interfaces>=0.5.1, <0.6.0
 graphviz>=0.18.2, <0.21
-python-dateutil>=2.8.2, <2.9.0
+python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,10 @@ line-length = 120
 # output of pytest noisy. Since no action is going to be taken, hide those
 # warnings.
 filterwarnings = [
-  "ignore:Deprecated call to.*",
-  "ignore:pkg_resources is deprecated as an API"
+  "ignore::DeprecationWarning:dbt_common.*:",
+  "ignore::DeprecationWarning:halo.*:",
+  # `protobuff` issue: https://github.com/protocolbuffers/protobuf/issues/15077
+  # protobuff is specified by `dbt-core`
+  'ignore:.*Type google.*:DeprecationWarning',
 ]
 python_functions = "test_* populate_source_schema"


### PR DESCRIPTION
### Description

With the update to Python 3.12, there a few deprecation warnings that have popped up. This PR updates packages and adds appropriate filters so that those warnings don't show up in test sessions.
<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
