### PR TITLE
Mark slow tests

### DIFF
--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: ./.github/actions/run-mf-tests
         with:
           python-version: ${{ matrix.python-version }}
+          make-target: "test-include-slow"
 
   metricflow-unit-tests-postgres:
     name: MetricFlow Tests (PostgreSQL)

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ install-hatch:
 .PHONY: test
 test:
 	cd metricflow-semantics && hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW_SEMANTICS)/
+	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) -m "not slow" $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW)/
+
+.PHONY: test-slow
+test-include-slow:
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW)/
 
 .PHONY: test-postgresql

--- a/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
+++ b/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
@@ -1330,6 +1330,7 @@ def test_metric_in_metric_where_filter(
     )
 
 
+@pytest.mark.slow
 def test_all_available_metric_filters(
     dataflow_plan_builder: DataflowPlanBuilder, query_parser: MetricFlowQueryParser
 ) -> None:

--- a/tests_metricflow/fixtures/setup_fixtures.py
+++ b/tests_metricflow/fixtures/setup_fixtures.py
@@ -65,6 +65,10 @@ def pytest_configure(config: _pytest.config.Config) -> None:
         name="markers",
         line=f"{SQL_ENGINE_SNAPSHOT_MARKER_NAME}: mark tests as generating a snapshot specific to a SQL engine",
     )
+    config.addinivalue_line(
+        name="markers",
+        line="slow: mark tests as taking a long time to run.",
+    )
 
 
 def check_sql_engine_snapshot_marker(request: FixtureRequest) -> None:


### PR DESCRIPTION
### Description

This PR marks slow tests and updates the `Makefile` so that they are only run in CI.
<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
