### PR TITLE
Remove `SQLAlchemy` dependency

### DIFF
--- a/extra-hatch-configuration/requirements-sql-client-packages.txt
+++ b/extra-hatch-configuration/requirements-sql-client-packages.txt
@@ -1,4 +1,0 @@
-# These are currently separate for ease of removal, but due to the way Python
-# handles import statements they are required in all test environments
-SQLAlchemy>=1.4.42, <1.5.0
-sqlalchemy2-stubs>=0.0.2a21, <0.0.3

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,7 +5,6 @@ disallow_any_explicit = True
 disallow_untyped_defs = True
 warn_redundant_casts = True
 namespace_packages = True
-plugins = sqlalchemy.ext.mypy.plugin
 
 
 # Overrides for missing imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,6 @@ dev-packages = [
   "metricflow-semantics/extra-hatch-configuration/requirements-dev-packages.txt",
   "dbt-metricflow/extra-hatch-configuration/requirements-cli.txt"
 ]
-sql-client-packages = [
-  "extra-hatch-configuration/requirements-sql-client-packages.txt"
-]
 trino-sql-client-packages = [
   "extra-hatch-configuration/requirements-trino-sql-client-packages.txt"
 ]
@@ -96,7 +93,6 @@ run = "run-coverage --no-cov"
 
 features = [
   "dev-packages",
-  "sql-client-packages",
   "dbt-duckdb",
 ]
 
@@ -119,7 +115,6 @@ description = "Dev environment for working with Postgres adapter"
 
 features = [
   "dev-packages",
-  "sql-client-packages",
   "dbt-postgres",
 ]
 
@@ -136,7 +131,6 @@ description = "Dev environment for working with the BigQuery adapter"
 
 features = [
   "dev-packages",
-  "sql-client-packages",
   "dbt-bigquery",
 ]
 
@@ -151,7 +145,6 @@ description = "Dev environment for working with the Databricks adapter"
 
 features = [
   "dev-packages",
-  "sql-client-packages",
   "dbt-databricks",
 ]
 
@@ -165,7 +158,6 @@ description = "Dev environment for working with the Redshift adapter"
 
 features = [
   "dev-packages",
-  "sql-client-packages",
   "dbt-redshift"
 ]
 
@@ -179,7 +171,6 @@ description = "Dev environment for working with Snowflake adapter"
 
 features = [
   "dev-packages",
-  "sql-client-packages",
   "dbt-snowflake",
 ]
 
@@ -195,7 +186,6 @@ description = "Dev environment for working with the Trino adapter"
 
 features = [
   "dev-packages",
-  "sql-client-packages",
   "trino-sql-client-packages",
   "dbt-trino"
 ]

--- a/tests_metricflow/fixtures/connection_url.py
+++ b/tests_metricflow/fixtures/connection_url.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import urllib.parse
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class UrlQueryField:
+    """Field name / values specified in the query part of a URL."""
+
+    field_name: str
+    values: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SqlEngineConnectionParameterSet:
+    """Describes how to connect to a SQL engine."""
+
+    url_str: str
+    dialect: str
+    query_fields: Tuple[UrlQueryField, ...]
+    driver: Optional[str]
+    username: Optional[str]
+    password: Optional[str]
+    hostname: Optional[str]
+    port: Optional[int]
+    database: Optional[str]
+
+    # Custom-handling for Databricks.
+    http_path: Optional[str]
+
+    @staticmethod
+    def create_from_url(url_str: str) -> SqlEngineConnectionParameterSet:
+        """The URL roughly follows the format used by SQLAlchemy.
+
+        * This implementation is used to avoid having to specify SQLAlchemy as a dependency.
+        * Databricks has a URL with a semicolon that separates an additional parameter. e.g.
+          `databricks://host:port/database;http_path=a/b/c`. Need additional context for why this is done.
+        """
+        url_seperator = ";"
+        url_split = url_str.split(url_seperator)
+        if len(url_split) > 2:
+            raise ValueError(f"Expected at most 1 {repr(url_seperator)} in {url_str}")
+
+        parsed_url = urllib.parse.urlparse(url_split[0])
+        url_extra = url_split[1] if len(url_split) > 1 else None
+
+        dialect_driver = parsed_url.scheme.split("+")
+        if len(dialect_driver) > 2:
+            raise ValueError(f"Expected at most one + in {repr(parsed_url.scheme)}")
+        dialect = dialect_driver[0]
+        driver = dialect_driver[1] if len(dialect_driver) > 1 else None
+
+        # redshift://../dbname -> /dbname -> dbname
+        database = parsed_url.path.lstrip("/")
+
+        query_fields = tuple(
+            UrlQueryField(field_name, tuple(values))
+            for field_name, values in urllib.parse.parse_qs(parsed_url.query).items()
+        )
+
+        http_path = None
+        if url_extra is not None:
+            field_name_value_seperator = "="
+            url_extra_split = url_extra.split(field_name_value_seperator)
+            if len(field_name_value_seperator) == 2:
+                field_name = url_extra_split[0]
+                value = url_split[1]
+                if field_name.lower() == "http_path":
+                    http_path = value
+
+        return SqlEngineConnectionParameterSet(
+            url_str=url_str,
+            dialect=dialect,
+            driver=driver,
+            username=parsed_url.username,
+            password=parsed_url.password,
+            hostname=parsed_url.hostname,
+            port=parsed_url.port,
+            database=database,
+            query_fields=query_fields,
+            http_path=http_path,
+        )
+
+    def get_query_field_values(self, field_name: str) -> Sequence[str]:
+        """In the URL query, return the values for the field with the given name.
+
+        Returns an empty sequence if the field name is not specified.
+        """
+        for field in self.query_fields:
+            if field.field_name == field_name:
+                return field.values
+        return ()

--- a/tests_metricflow/fixtures/connection_url.py
+++ b/tests_metricflow/fixtures/connection_url.py
@@ -36,12 +36,14 @@ class SqlEngineConnectionParameterSet:
 
         * This implementation is used to avoid having to specify SQLAlchemy as a dependency.
         * Databricks has a URL with a semicolon that separates an additional parameter. e.g.
-          `databricks://host:port/database;http_path=a/b/c`. Need additional context for why this is done.
+          `databricks://host:port/database;http_path=a/b/c`. From @tlento: "Our original Databricks client was built
+          before they added an officially supported SQLAlchemy client, so we used the JDBC connection URI.
+          https://docs.databricks.com/en/integrations/jdbc/authentication.html"
         """
-        url_seperator = ";"
-        url_split = url_str.split(url_seperator)
+        url_separator = ";"
+        url_split = url_str.split(url_separator)
         if len(url_split) > 2:
-            raise ValueError(f"Expected at most 1 {repr(url_seperator)} in {url_str}")
+            raise ValueError(f"Expected at most 1 {repr(url_separator)} in {url_str}")
 
         parsed_url = urllib.parse.urlparse(url_split[0])
         url_extra = url_split[1] if len(url_split) > 1 else None
@@ -62,9 +64,9 @@ class SqlEngineConnectionParameterSet:
 
         http_path = None
         if url_extra is not None:
-            field_name_value_seperator = "="
-            url_extra_split = url_extra.split(field_name_value_seperator)
-            if len(field_name_value_seperator) == 2:
+            field_name_value_separator = "="
+            url_extra_split = url_extra.split(field_name_value_separator)
+            if len(field_name_value_separator) == 2:
                 field_name = url_extra_split[0]
                 value = url_split[1]
                 if field_name.lower() == "http_path":

--- a/tests_metricflow/fixtures/setup_fixtures.py
+++ b/tests_metricflow/fixtures/setup_fixtures.py
@@ -16,10 +16,8 @@ from metricflow_semantics.test_helpers.snapshot_helpers import (
     add_display_snapshots_cli_flag,
     add_overwrite_snapshots_cli_flag,
 )
-from sqlalchemy.engine import make_url
 
 from tests_metricflow import TESTS_METRICFLOW_DIRECTORY_ANCHOR
-from tests_metricflow.fixtures.sql_clients.common_client import SqlDialect
 from tests_metricflow.snapshots import METRICFLOW_SNAPSHOT_DIRECTORY_ANCHOR
 from tests_metricflow.table_snapshot.table_snapshots import SqlTableSnapshotHash, SqlTableSnapshotRepository
 
@@ -152,14 +150,6 @@ def mf_test_configuration(  # noqa: D103
         snapshot_directory=METRICFLOW_SNAPSHOT_DIRECTORY_ANCHOR.directory,
         tests_directory=TESTS_METRICFLOW_DIRECTORY_ANCHOR.directory,
     )
-
-
-def dialect_from_url(url: str) -> SqlDialect:
-    """Return the SQL dialect specified in the URL in the configuration."""
-    dialect_protocol = make_url(url.split(";")[0]).drivername.split("+")
-    if len(dialect_protocol) > 2:
-        raise ValueError(f"Invalid # of +'s in {url}")
-    return SqlDialect(dialect_protocol[0])
 
 
 def dbt_project_dir() -> str:

--- a/tests_metricflow/fixtures/setup_fixtures.py
+++ b/tests_metricflow/fixtures/setup_fixtures.py
@@ -82,7 +82,6 @@ def check_sql_engine_snapshot_marker(request: FixtureRequest) -> None:
 @pytest.fixture(scope="session")
 def mf_test_configuration(  # noqa: D103
     request: FixtureRequest,
-    disable_sql_alchemy_deprecation_warning: None,
     source_table_snapshot_repository: SqlTableSnapshotRepository,
 ) -> MetricFlowTestConfiguration:
     engine_url = os.environ.get("MF_SQL_ENGINE_URL")

--- a/tests_metricflow/fixtures/sql_client_fixtures.py
+++ b/tests_metricflow/fixtures/sql_client_fixtures.py
@@ -7,8 +7,6 @@ import warnings
 from typing import Generator
 
 import pytest
-import sqlalchemy
-import sqlalchemy.util
 from _pytest.fixtures import FixtureRequest
 from dbt.adapters.factory import get_adapter_by_type
 from dbt.cli.main import dbtRunner
@@ -257,10 +255,3 @@ def warn_user_about_slow_tests_without_parallelism(  # noqa: D103
             f'Consider using the pytest-xdist option "-n <number of workers>" to parallelize execution and speed '
             f"up the session."
         )
-
-
-@pytest.fixture(scope="session", autouse=True)
-def disable_sql_alchemy_deprecation_warning() -> None:
-    """Since MF is tied to using SQLAlchemy 1.x.x due to the Snowflake connector, silence 2.0 deprecation warnings."""
-    # Seeing 'error: Module has no attribute "SILENCE_UBER_WARNING"' in the type checker, but this seems to work.
-    sqlalchemy.util.deprecations.SILENCE_UBER_WARNING = True  # type:ignore

--- a/tests_metricflow/fixtures/sql_client_fixtures.py
+++ b/tests_metricflow/fixtures/sql_client_fixtures.py
@@ -57,8 +57,6 @@ def __configure_test_env_from_url(url: str, password: str, schema: str) -> SqlEn
     the parsed URL object so that individual engine configurations can override the environment variables
     as needed to match their dbt profile configuration.
     """
-    # parsed_url = sqlalchemy.engine.make_url(url)
-
     connection_parameters = SqlEngineConnectionParameterSet.create_from_url(url)
     if connection_parameters.dialect != "duckdb":
         assert connection_parameters.hostname, "Engine host is not set in engine connection URL!"


### PR DESCRIPTION
### Description

The `SQLAlchemy` dependency is only needed because we need to parse the URL for the SQL engine configuration. Since it's relatively straightforward to parse, this PR uses built-in `urllib` to do the parsing and removes the `SQLAlchemy` dependency.

<!--- 
  Before requesting review, please make sure you have:
  1. read [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md),
  2. signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
  3. run `changie new` to [create a changelog entry](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
-->
