### PR TITLE
Update tests to use common engine fixture

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -47,3 +47,9 @@ ignore_missing_imports = True
 
 [mypy-update_checker]
 ignore_missing_imports = True
+
+# Seems to be pulled in from pytest:
+# ../site-packages/_pytest/compat.py:20: error: Skipping analyzing "py": module is installed, but missing library
+# stubs or py.typed marker
+[mypy-py]
+ignore_missing_imports = True


### PR DESCRIPTION
There's a fixture (poorly named, unfortunately) that contains Metricflow-engine related objects for a given manifest. This PR migrates a few tests to use that fixture.