### PR TITLE
Upgrade DSI to acquire sub-daily granularity options

### DIFF
--- a/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
+++ b/dbt-metricflow/dbt_metricflow/cli/dbt_connectors/adapter_backed_client.py
@@ -4,7 +4,7 @@ import enum
 import logging
 import time
 
-from dbt.adapters.base.impl import BaseAdapter
+from dbt.adapters.base import BaseAdapter
 from dbt_common.exceptions.base import DbtDatabaseError
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from metricflow_semantics.errors.error_classes import SqlBindParametersNotSupportedError

--- a/dbt-metricflow/extra-hatch-configuration/requirements-cli.txt
+++ b/dbt-metricflow/extra-hatch-configuration/requirements-cli.txt
@@ -1,5 +1,5 @@
 # Internal dependencies
-dbt-core>=1.8.0, <1.9.0
+dbt-core @ git+https://github.com/dbt-labs/dbt-core@e53420c1d073dc81609ae7aa84cef6ee09650576#subdirectory=core
 
 # dsi version should be fixed by MetricFlow/dbt-core, not set here
 dbt-semantic-interfaces

--- a/extra-hatch-configuration/requirements.txt
+++ b/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.3
-dbt-semantic-interfaces>=0.5.1, <0.6.0
+dbt-semantic-interfaces==0.6.0.dev2
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <1.11.0
 tabulate>=0.8.9

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,4 +1,4 @@
-dbt-semantic-interfaces>=0.5.1, <0.6.0
+dbt-semantic-interfaces==0.6.0.dev2
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow-semantics/metricflow_semantics/time/dateutil_adjuster.py
+++ b/metricflow-semantics/metricflow_semantics/time/dateutil_adjuster.py
@@ -22,7 +22,20 @@ class DateutilTimePeriodAdjuster(TimePeriodAdjuster):
 
     def _relative_delta_for_window(self, time_granularity: TimeGranularity, count: int) -> relativedelta:
         """Relative-delta to cover time windows specified at different grains."""
-        if time_granularity is TimeGranularity.DAY:
+        if time_granularity is TimeGranularity.NANOSECOND:
+            # TODO: figure out a workaround when enabling time constraints
+            raise ValueError("`relativedelta` does not support nanoseconds.")
+        elif time_granularity is TimeGranularity.MICROSECOND:
+            return relativedelta(microseconds=count)
+        elif time_granularity is TimeGranularity.MILLISECOND:
+            return relativedelta(microseconds=count * 1000)
+        elif time_granularity is TimeGranularity.SECOND:
+            return relativedelta(seconds=count)
+        elif time_granularity is TimeGranularity.MINUTE:
+            return relativedelta(minutes=count)
+        elif time_granularity is TimeGranularity.HOUR:
+            return relativedelta(hours=count)
+        elif time_granularity is TimeGranularity.DAY:
             return relativedelta(days=count)
         elif time_granularity is TimeGranularity.WEEK:
             return relativedelta(weeks=count)
@@ -53,8 +66,18 @@ class DateutilTimePeriodAdjuster(TimePeriodAdjuster):
     def adjust_to_start_of_period(
         self, time_granularity: TimeGranularity, date_to_adjust: datetime.datetime
     ) -> datetime.datetime:
-        if time_granularity is TimeGranularity.DAY:
+        # TODO: update these options once time constraints support a full timestamp
+        if (
+            time_granularity is TimeGranularity.NANOSECOND
+            or time_granularity is TimeGranularity.MICROSECOND
+            or time_granularity is TimeGranularity.MILLISECOND
+            or time_granularity is TimeGranularity.SECOND
+            or time_granularity is TimeGranularity.MINUTE
+            or time_granularity is TimeGranularity.HOUR
+            or time_granularity is TimeGranularity.DAY
+        ):
             return date_to_adjust
+
         elif time_granularity is TimeGranularity.WEEK:
             return date_to_adjust + relativedelta(weekday=dateutil.relativedelta.MO(-1))
         elif time_granularity is TimeGranularity.MONTH:
@@ -77,8 +100,18 @@ class DateutilTimePeriodAdjuster(TimePeriodAdjuster):
     def adjust_to_end_of_period(
         self, time_granularity: TimeGranularity, date_to_adjust: datetime.datetime
     ) -> datetime.datetime:
-        if time_granularity is TimeGranularity.DAY:
+        # TODO: update these options once time constraints support a full timestamp
+        if (
+            time_granularity is TimeGranularity.NANOSECOND
+            or time_granularity is TimeGranularity.MICROSECOND
+            or time_granularity is TimeGranularity.MILLISECOND
+            or time_granularity is TimeGranularity.SECOND
+            or time_granularity is TimeGranularity.MINUTE
+            or time_granularity is TimeGranularity.HOUR
+            or time_granularity is TimeGranularity.DAY
+        ):
             return date_to_adjust
+
         elif time_granularity is TimeGranularity.WEEK:
             return date_to_adjust + relativedelta(weekday=dateutil.relativedelta.SU(1))
         elif time_granularity is TimeGranularity.MONTH:

--- a/metricflow-semantics/metricflow_semantics/time/time_constants.py
+++ b/metricflow-semantics/metricflow_semantics/time/time_constants.py
@@ -1,15 +1,5 @@
 from __future__ import annotations
 
-from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
-
 # Python formatting string to use for converting datetime to ISO8601
 ISO8601_PYTHON_FORMAT = "%Y-%m-%d"
 ISO8601_PYTHON_TS_FORMAT = "%Y-%m-%d %H:%M:%S"
-
-SUPPORTED_GRANULARITIES = [
-    TimeGranularity.DAY,
-    TimeGranularity.WEEK,
-    TimeGranularity.MONTH,
-    TimeGranularity.QUARTER,
-    TimeGranularity.YEAR,
-]

--- a/metricflow-semantics/tests_metricflow_semantics/time/test_time_adjuster.py
+++ b/metricflow-semantics/tests_metricflow_semantics/time/test_time_adjuster.py
@@ -54,6 +54,8 @@ def test_start_and_end_periods(  # noqa: D103
     rows: List[Tuple[str, ...]] = []
     for date_time in date_times_to_check:
         for time_granularity in TimeGranularity:
+            if time_granularity.to_int() < TimeGranularity.DAY.to_int():
+                continue
             dateutil_start_of_period = dateutil_adjuster.adjust_to_start_of_period(time_granularity, date_time)
             dateutil_end_of_period = dateutil_adjuster.adjust_to_end_of_period(time_granularity, date_time)
             rows.append(

--- a/metricflow/dataset/convert_semantic_model.py
+++ b/metricflow/dataset/convert_semantic_model.py
@@ -283,7 +283,7 @@ class SemanticModelToDataSetConverter:
         time_dimension_instances: List[TimeDimensionInstance] = []
         select_columns: List[SqlSelectColumn] = []
 
-        defined_time_granularity = TimeGranularity.DAY
+        defined_time_granularity = DEFAULT_TIME_GRANULARITY
         if dimension.type_params and dimension.type_params.time_granularity:
             defined_time_granularity = dimension.type_params.time_granularity
 

--- a/metricflow/plan_conversion/time_spine.py
+++ b/metricflow/plan_conversion/time_spine.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from dbt_semantic_interfaces.protocols import SemanticManifest
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from metricflow_semantics.mf_logging.pretty_print import mf_pformat
+from metricflow_semantics.specs.spec_classes import DEFAULT_TIME_GRANULARITY
 
 from metricflow.sql.sql_table import SqlTable
 
@@ -23,7 +24,7 @@ class TimeSpineSource:
     # Name of the column in the table that contains the dates.
     time_column_name: str = "ds"
     # The time granularity of the dates in the spine table.
-    time_column_granularity: TimeGranularity = TimeGranularity.DAY
+    time_column_granularity: TimeGranularity = DEFAULT_TIME_GRANULARITY
 
     @property
     def spine_table(self) -> SqlTable:
@@ -37,10 +38,10 @@ class TimeSpineSource:
 
         if not (
             len(time_spine_table_configurations) == 1
-            and time_spine_table_configurations[0].grain == TimeGranularity.DAY
+            and time_spine_table_configurations[0].grain == DEFAULT_TIME_GRANULARITY
         ):
             raise NotImplementedError(
-                f"Only a single time spine table configuration with {TimeGranularity.DAY} is currently "
+                f"Only a single time spine table configuration with {DEFAULT_TIME_GRANULARITY} is currently "
                 f"supported. Got:\n"
                 f"{mf_pformat(time_spine_table_configurations)}"
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ features = [
   "dev-packages",
   "dbt-postgres",
 ]
+[tool.hatch.metadata]
+allow-direct-references = true
+
 
 
 # NOTE: All of the below should have their authentication credentials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,9 +146,12 @@ MF_TEST_ADAPTER_TYPE="databricks"
 [tool.hatch.envs.databricks-env]
 description = "Dev environment for working with the Databricks adapter"
 
+pre-install-commands = [
+  "pip install dbt-databricks"
+]
+
 features = [
   "dev-packages",
-  "dbt-databricks",
 ]
 
 


### PR DESCRIPTION
Primarily, this PR upgrades DSI. This is needed to get sub-daily granularity options into MF. Along the way:
- Points to the latest commit of dbt-core, which is the first commit that does not have a dependency conflict with the version of DSI we need.
- Updates various places in code affected by the upgrade.