### PR TITLE
Update dbt-metricflow version to 0.7.0

### DIFF
--- a/dbt-metricflow/extra-hatch-configuration/requirements-metricflow.txt
+++ b/dbt-metricflow/extra-hatch-configuration/requirements-metricflow.txt
@@ -1,1 +1,1 @@
-metricflow>=0.206.0.dev3, <0.207.0
+metricflow>=0.206.0, <0.207.0

--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dbt-metricflow"
-version = "0.6.0"
+version = "0.7.0"
 description = "Execute commands against the MetricFlow semantic layer with dbt."
 readme = "README.md"
 requires-python = ">=3.8,<3.13"


### PR DESCRIPTION
With the release of MetricFlow 0.206.0 we can update dbt-metricflow
to reflect that dependency change and deploy the new version.

Note our build reshuffling incidentally renamed the extras to full
package names, so `pip install dbt-metricflow[postgres]` must now be
`pip install dbt-metricflow[dbt-postgres]`, which, while more typing,
does seem like an improvement since it's more obvious which package
the extra command actually installs.

To test the build, I ran the following from repo root:

```
$ cd dbt-metricflow
$ hatch build
```

From there, I created a clean venv and ran variations on pip install
commands from the local builds  and fired up the MetricFlow CLI. For example:

```
$ python -m pip install "$HOME/sources/metricflow/dbt-metricflow/dist/dbt_metricflow-0.7.0-py3-none-any.whl[dbt-postgres]"
...
$ mf --version
mf, version 0.7.0
$ mf query --metrics order_cost --group-by metric_time --order metric_time --where "{{ TimeDimension('metric_time', 'day') }} > '2017-01-01'" --limit 5
✔ Success - query completed after 0.31 seconds
metric_time__day       order_cost
-------------------  ------------
2017-01-02T00:00:00        285.24
2017-01-03T00:00:00        328.94
2017-01-04T00:00:00        294.73
2017-01-05T00:00:00        340.78
2017-01-06T00:00:00        329.86
```
