### PR TITLE
Enable DataflowPlanOptimizers for query rendering tests

### DIFF
--- a/tests_metricflow/query_rendering/test_conversion_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_conversion_metric_rendering.py
@@ -11,7 +11,7 @@ from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfi
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from tests_metricflow.query_rendering.compare_rendered_query import convert_and_check
+from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
 
 @pytest.mark.sql_engine_snapshot
@@ -32,14 +32,14 @@ def test_conversion_metric(
             where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
         ),
     )
-    dataflow_plan = dataflow_plan_builder.build_plan(parsed_query.query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=parsed_query.query_spec,
     )
 
 
@@ -61,14 +61,14 @@ def test_conversion_metric_with_window(
             where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
         ),
     )
-    dataflow_plan = dataflow_plan_builder.build_plan(parsed_query.query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=parsed_query.query_spec,
     )
 
 
@@ -90,14 +90,14 @@ def test_conversion_metric_with_categorical_filter(
             where_sql_template=("{{ Dimension('visit__referrer_id') }} = 'ref_id_01'")
         ),
     )
-    dataflow_plan = dataflow_plan_builder.build_plan(parsed_query.query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=parsed_query.query_spec,
     )
 
 
@@ -121,14 +121,14 @@ def test_conversion_metric_with_time_constraint(
         time_constraint_start=datetime.datetime(2020, 1, 1),
         time_constraint_end=datetime.datetime(2020, 1, 2),
     )
-    dataflow_plan = dataflow_plan_builder.build_plan(parsed_query.query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=parsed_query.query_spec,
     )
 
 
@@ -155,12 +155,12 @@ def test_conversion_metric_with_window_and_time_constraint(
         time_constraint_start=datetime.datetime(2020, 1, 1),
         time_constraint_end=datetime.datetime(2020, 1, 2),
     )
-    dataflow_plan = dataflow_plan_builder.build_plan(parsed_query.query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=parsed_query.query_spec,
     )

--- a/tests_metricflow/query_rendering/test_derived_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_derived_metric_rendering.py
@@ -28,7 +28,7 @@ from metricflow_semantics.test_helpers.metric_time_dimension import (
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from tests_metricflow.query_rendering.compare_rendered_query import convert_and_check
+from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
 
 @pytest.mark.sql_engine_snapshot
@@ -39,19 +39,18 @@ def test_derived_metric(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="non_referred_bookings_pct"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="non_referred_bookings_pct"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -63,19 +62,18 @@ def test_nested_derived_metric(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="instant_plus_non_referred_bookings_pct"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="instant_plus_non_referred_bookings_pct"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -87,19 +85,18 @@ def test_derived_metric_with_offset_window(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -123,14 +120,14 @@ def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D103
             )
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -142,19 +139,18 @@ def test_derived_metric_with_offset_to_grain(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_growth_since_start_of_month"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_growth_since_start_of_month"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -166,19 +162,18 @@ def test_derived_metric_with_offset_window_and_offset_to_grain(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_month_start_compared_to_1_month_prior"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_month_start_compared_to_1_month_prior"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -190,19 +185,18 @@ def test_derived_offset_metric_with_one_input_metric(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_5_day_lag"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_5_day_lag"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -214,19 +208,18 @@ def test_derived_metric_with_offset_window_and_granularity(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks"),),
-            time_dimension_specs=(MTD_SPEC_QUARTER,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks"),),
+        time_dimension_specs=(MTD_SPEC_QUARTER,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -238,19 +231,18 @@ def test_derived_metric_with_month_dimension_and_offset_window(  # noqa: D103
     extended_date_dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = extended_date_dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_last_month"),),
-            time_dimension_specs=(MTD_SPEC_MONTH,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_last_month"),),
+        time_dimension_specs=(MTD_SPEC_MONTH,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=extended_date_dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=extended_date_dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -262,19 +254,18 @@ def test_derived_metric_with_offset_to_grain_and_granularity(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_growth_since_start_of_month"),),
-            time_dimension_specs=(MTD_SPEC_WEEK,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_growth_since_start_of_month"),),
+        time_dimension_specs=(MTD_SPEC_WEEK,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -286,19 +277,18 @@ def test_derived_metric_with_offset_window_and_offset_to_grain_and_granularity( 
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_month_start_compared_to_1_month_prior"),),
-            time_dimension_specs=(MTD_SPEC_YEAR,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_month_start_compared_to_1_month_prior"),),
+        time_dimension_specs=(MTD_SPEC_YEAR,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -310,19 +300,18 @@ def test_derived_offset_cumulative_metric(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="every_2_days_bookers_2_days_ago"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="every_2_days_bookers_2_days_ago"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -335,19 +324,18 @@ def test_nested_offsets(  # noqa: D103
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        query_spec=MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_offset_twice"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_offset_twice"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -360,19 +348,18 @@ def test_nested_derived_metric_with_offset_multiple_input_metrics(  # noqa: D103
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        query_spec=MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="booking_fees_since_start_of_month"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="booking_fees_since_start_of_month"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -397,14 +384,14 @@ def test_nested_offsets_with_where_constraint(  # noqa: D103
             )
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -417,22 +404,21 @@ def test_nested_offsets_with_time_constraint(  # noqa: D103
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        query_spec=MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_offset_twice"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-            time_range_constraint=TimeRangeConstraint(
-                start_time=datetime.datetime(2020, 1, 12), end_time=datetime.datetime(2020, 1, 13)
-            ),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_offset_twice"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
+        time_range_constraint=TimeRangeConstraint(
+            start_time=datetime.datetime(2020, 1, 12), end_time=datetime.datetime(2020, 1, 13)
+        ),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -445,21 +431,21 @@ def test_time_offset_metric_with_time_constraint(  # noqa: D103
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        query_spec=MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_5_day_lag"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-            time_range_constraint=TimeRangeConstraint(
-                start_time=datetime.datetime(2019, 12, 19), end_time=datetime.datetime(2020, 1, 2)
-            ),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_5_day_lag"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
+        time_range_constraint=TimeRangeConstraint(
+            start_time=datetime.datetime(2019, 12, 19), end_time=datetime.datetime(2020, 1, 2)
+        ),
     )
-    convert_and_check(
+
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -475,14 +461,14 @@ def test_nested_filters(
 ) -> None:
     """Tests derived metric rendering for a nested derived metric with filters on the outer metric spec."""
     query_spec = query_parser.parse_and_validate_query(metric_names=("instant_lux_booking_value_rate",)).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec=query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -495,22 +481,21 @@ def test_cumulative_time_offset_metric_with_time_constraint(  # noqa: D103
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        query_spec=MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="every_2_days_bookers_2_days_ago"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-            time_range_constraint=TimeRangeConstraint(
-                start_time=datetime.datetime(2019, 12, 19), end_time=datetime.datetime(2020, 1, 2)
-            ),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="every_2_days_bookers_2_days_ago"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
+        time_range_constraint=TimeRangeConstraint(
+            start_time=datetime.datetime(2019, 12, 19), end_time=datetime.datetime(2020, 1, 2)
+        ),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -534,13 +519,13 @@ def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(
         where_constraint_str="{{ Dimension('booking__is_instant') }}",
     ).query_spec
 
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -560,13 +545,13 @@ def test_offset_window_with_agg_time_dim(  # noqa: D103
         group_by_names=("booking__ds__day",),
     ).query_spec
 
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -586,13 +571,13 @@ def test_offset_to_grain_with_agg_time_dim(  # noqa: D103
         group_by_names=("booking__ds__day",),
     ).query_spec
 
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -612,13 +597,13 @@ def test_derived_offset_metric_with_agg_time_dim(  # noqa: D103
         group_by_names=("booking__ds__day",),
     ).query_spec
 
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -631,22 +616,21 @@ def test_multi_metric_fill_null(  # noqa: D103
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        query_spec=MetricFlowQuerySpec(
-            metric_specs=(
-                MetricSpec(element_name="twice_bookings_fill_nulls_with_0_without_time_spine"),
-                MetricSpec(element_name="listings"),
-            ),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(
+            MetricSpec(element_name="twice_bookings_fill_nulls_with_0_without_time_spine"),
+            MetricSpec(element_name="listings"),
+        ),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -659,19 +643,18 @@ def test_nested_fill_nulls_without_time_spine(  # noqa: D103
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        query_spec=MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="nested_fill_nulls_without_time_spine"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="nested_fill_nulls_without_time_spine"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -684,22 +667,21 @@ def test_nested_fill_nulls_without_time_spine_multi_metric(  # noqa: D103
     sql_client: SqlClient,
     create_source_tables: bool,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        query_spec=MetricFlowQuerySpec(
-            metric_specs=(
-                MetricSpec(element_name="nested_fill_nulls_without_time_spine"),
-                MetricSpec(element_name="listings"),
-            ),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(
+            MetricSpec(element_name="nested_fill_nulls_without_time_spine"),
+            MetricSpec(element_name="listings"),
+        ),
+        time_dimension_specs=(MTD_SPEC_DAY,),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -718,14 +700,14 @@ def test_offset_window_metric_multiple_granularities(
         metric_names=("booking_fees_last_week_per_booker_this_week",),
         group_by_names=("metric_time__day", "metric_time__month", "metric_time__year"),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -744,14 +726,14 @@ def test_offset_to_grain_metric_multiple_granularities(
         metric_names=("bookings_at_start_of_month",),
         group_by_names=("metric_time__day", "metric_time__month", "metric_time__year"),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -773,14 +755,14 @@ def test_offset_window_metric_filter_and_query_have_different_granularities(
             where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -802,12 +784,12 @@ def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
             where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )

--- a/tests_metricflow/query_rendering/test_fill_nulls_with_rendering.py
+++ b/tests_metricflow/query_rendering/test_fill_nulls_with_rendering.py
@@ -24,7 +24,7 @@ from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilde
 from metricflow.dataset.dataset_classes import DataSet
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from tests_metricflow.query_rendering.compare_rendered_query import convert_and_check
+from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
 
 @pytest.mark.sql_engine_snapshot
@@ -35,19 +35,18 @@ def test_simple_fill_nulls_with_0_metric_time(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_fill_nulls_with_0"),),
-            time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_fill_nulls_with_0"),),
+        time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -59,19 +58,18 @@ def test_simple_fill_nulls_with_0_month(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_fill_nulls_with_0"),),
-            time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.MONTH),),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_fill_nulls_with_0"),),
+        time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.MONTH),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -83,21 +81,18 @@ def test_simple_fill_nulls_with_0_with_non_metric_time(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_fill_nulls_with_0"),),
-            time_dimension_specs=(
-                TimeDimensionSpec(element_name="paid_at", entity_links=(EntityReference("booking"),)),
-            ),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_fill_nulls_with_0"),),
+        time_dimension_specs=(TimeDimensionSpec(element_name="paid_at", entity_links=(EntityReference("booking"),)),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -109,19 +104,18 @@ def test_simple_fill_nulls_with_0_with_categorical_dimension(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_fill_nulls_with_0"),),
-            dimension_specs=(DimensionSpec(element_name="is_instant", entity_links=(EntityReference("booking"),)),),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_fill_nulls_with_0"),),
+        dimension_specs=(DimensionSpec(element_name="is_instant", entity_links=(EntityReference("booking"),)),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -133,19 +127,18 @@ def test_simple_fill_nulls_without_time_spine(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_fill_nulls_with_0_without_time_spine"),),
-            time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_fill_nulls_with_0_without_time_spine"),),
+        time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -157,19 +150,18 @@ def test_cumulative_fill_nulls(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="every_two_days_bookers_fill_nulls_with_0"),),
-            time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="every_two_days_bookers_fill_nulls_with_0"),),
+        time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -181,19 +173,18 @@ def test_derived_fill_nulls_for_one_input_metric(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks_fill_nulls_with_0_for_non_offset"),),
-            time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks_fill_nulls_with_0_for_non_offset"),),
+        time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -215,12 +206,12 @@ def test_join_to_time_spine_with_filters(  # noqa: D103
         time_constraint_start=datetime.datetime(2020, 1, 3),
         time_constraint_end=datetime.datetime(2020, 1, 5),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )

--- a/tests_metricflow/query_rendering/test_granularity_date_part_rendering.py
+++ b/tests_metricflow/query_rendering/test_granularity_date_part_rendering.py
@@ -20,7 +20,7 @@ from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilde
 from metricflow.dataset.dataset_classes import DataSet
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from tests_metricflow.query_rendering.compare_rendered_query import convert_and_check
+from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
 
 @pytest.mark.sql_engine_snapshot
@@ -31,21 +31,20 @@ def test_simple_query_with_date_part(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings"),),
-            time_dimension_specs=(
-                DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.DOW),
-            ),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings"),),
+        time_dimension_specs=(
+            DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.DOW),
+        ),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -57,26 +56,25 @@ def test_simple_query_with_multiple_date_parts(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings"),),
-            time_dimension_specs=(
-                DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.DAY),
-                DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.DOW),
-                DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.DOY),
-                DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.MONTH),
-                DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.QUARTER),
-                DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.YEAR),
-            ),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings"),),
+        time_dimension_specs=(
+            DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.DAY),
+            DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.DOW),
+            DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.DOY),
+            DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.MONTH),
+            DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.QUARTER),
+            DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.YEAR),
+        ),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -88,19 +86,18 @@ def test_offset_window_with_date_part(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks"),),
-            time_dimension_specs=(
-                DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.DOW),
-            ),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_growth_2_weeks"),),
+        time_dimension_specs=(
+            DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY, date_part=DatePart.DOW),
+        ),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )

--- a/tests_metricflow/query_rendering/test_metric_filter_rendering.py
+++ b/tests_metricflow/query_rendering/test_metric_filter_rendering.py
@@ -226,6 +226,7 @@ def test_distinct_values_query_with_metric_filter(
         sql_client=sql_client,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=query_spec,
+        is_distinct_values_plan=True,
     )
 
 

--- a/tests_metricflow/query_rendering/test_metric_filter_rendering.py
+++ b/tests_metricflow/query_rendering/test_metric_filter_rendering.py
@@ -9,7 +9,7 @@ from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfi
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from tests_metricflow.query_rendering.compare_rendered_query import convert_and_check
+from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
 
 @pytest.mark.sql_engine_snapshot
@@ -28,14 +28,14 @@ def test_query_with_simple_metric_in_where_filter(
             where_sql_template="{{ Metric('bookings', ['listing']) }} > 2",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -53,14 +53,14 @@ def test_metric_with_metric_in_where_filter(
         metric_names=("active_listings",),
         group_by_names=("metric_time__day",),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -80,14 +80,14 @@ def test_query_with_derived_metric_in_where_filter(
             where_sql_template="{{ Metric('views_times_booking_value', ['listing']) }} > 1",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -107,14 +107,14 @@ def test_query_with_ratio_metric_in_where_filter(
             where_sql_template="{{ Metric('bookings_per_booker', ['listing']) }} > 1",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -137,14 +137,14 @@ def test_query_with_cumulative_metric_in_where_filter(
             where_sql_template="{{ Metric('revenue_all_time', ['user']) }} > 1",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -164,14 +164,14 @@ def test_query_with_multiple_metrics_in_filter(
             where_sql_template="{{ Metric('bookings', ['listing']) }} > 2 AND {{ Metric('bookers', ['listing']) }} > 1",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -191,14 +191,14 @@ def test_filter_by_metric_in_same_semantic_model_as_queried_metric(
             where_sql_template="{{ Metric('booking_value', ['guest']) }} > 1.00",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -218,14 +218,14 @@ def test_distinct_values_query_with_metric_filter(
             where_sql_template="{{ Metric('bookings', ['listing']) }} > 2",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -245,14 +245,14 @@ def test_metric_filtered_by_itself(
             where_sql_template="{{ Metric('bookers', ['listing']) }} > 1.00",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -271,14 +271,14 @@ def test_group_by_has_local_entity_prefix(  # noqa: D103
             where_sql_template="{{ Metric('average_booking_value', ['listing__user']) }} > 1",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -297,14 +297,14 @@ def test_filter_with_conversion_metric(  # noqa: D103
             where_sql_template="{{ Metric('visit_buy_conversion_rate', ['user']) }} > 2",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -324,14 +324,14 @@ def test_inner_query_single_hop(
             where_sql_template="{{ Metric('paraguayan_customers', ['customer_id__customer_third_hop_id']) }} > 0",
         ),
     ).query_spec
-    dataflow_plan = multihop_dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=multihop_dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=multihop_dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -351,12 +351,12 @@ def test_inner_query_multi_hop(
             where_sql_template="{{ Metric('txn_count', ['account_id__customer_id__customer_third_hop_id']) }} > 2",
         ),
     ).query_spec
-    dataflow_plan = multihop_dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=multihop_dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=multihop_dataflow_plan_builder,
+        query_spec=query_spec,
     )

--- a/tests_metricflow/query_rendering/test_predicate_pushdown_rendering.py
+++ b/tests_metricflow/query_rendering/test_predicate_pushdown_rendering.py
@@ -7,10 +7,9 @@ from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.dataflow.optimizer.predicate_pushdown_optimizer import PredicatePushdownOptimizer
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from tests_metricflow.query_rendering.compare_rendered_query import convert_and_check
+from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
 
 @pytest.mark.sql_engine_snapshot
@@ -30,16 +29,14 @@ def test_single_categorical_dimension_pushdown(
             where_sql_template="{{ Dimension('booking__is_instant') }}",
         ),
     )
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        parsed_query.query_spec, optimizers=(PredicatePushdownOptimizer(),)
-    )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=parsed_query.query_spec,
     )
 
 
@@ -60,14 +57,14 @@ def test_multiple_categorical_dimension_pushdown(
             where_sql_template="{{ Dimension('listing__is_lux_latest') }} OR {{ Dimension('listing__capacity_latest') }} > 4",
         ),
     )
-    dataflow_plan = dataflow_plan_builder.build_plan(parsed_query.query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=parsed_query.query_spec,
     )
 
 
@@ -94,14 +91,14 @@ def test_different_filters_on_same_measure_source_categorical_dimension(
         metric_names=("instant_booking_fraction_of_max_value",),
         group_by_names=("metric_time",),
     )
-    dataflow_plan = dataflow_plan_builder.build_plan(parsed_query.query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=parsed_query.query_spec,
     )
 
 
@@ -128,12 +125,12 @@ def test_skipped_pushdown(
             where_sql_template="{{ Dimension('booking__is_instant') }} OR {{ Dimension('listing__is_lux_latest') }}",
         ),
     )
-    dataflow_plan = dataflow_plan_builder.build_plan(parsed_query.query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=parsed_query.query_spec,
     )

--- a/tests_metricflow/query_rendering/test_query_rendering.py
+++ b/tests_metricflow/query_rendering/test_query_rendering.py
@@ -180,6 +180,7 @@ def test_distinct_values(
         sql_client=sql_client,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=query_spec,
+        is_distinct_values_plan=True,
     )
 
 
@@ -458,6 +459,7 @@ def test_min_max_only_categorical(
         sql_client=sql_client,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=query_spec,
+        is_distinct_values_plan=True,
     )
 
 
@@ -488,6 +490,7 @@ def test_min_max_only_time(
         sql_client=sql_client,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=query_spec,
+        is_distinct_values_plan=True,
     )
 
 
@@ -518,6 +521,7 @@ def test_min_max_only_time_quarter(
         sql_client=sql_client,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=query_spec,
+        is_distinct_values_plan=True,
     )
 
 
@@ -542,6 +546,7 @@ def test_min_max_metric_time(
         sql_client=sql_client,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=query_spec,
+        is_distinct_values_plan=True,
     )
 
 
@@ -566,4 +571,5 @@ def test_min_max_metric_time_week(
         sql_client=sql_client,
         dataflow_plan_builder=dataflow_plan_builder,
         query_spec=query_spec,
+        is_distinct_values_plan=True,
     )

--- a/tests_metricflow/query_rendering/test_query_rendering.py
+++ b/tests_metricflow/query_rendering/test_query_rendering.py
@@ -31,7 +31,7 @@ from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilde
 from metricflow.dataset.dataset_classes import DataSet
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from tests_metricflow.query_rendering.compare_rendered_query import convert_and_check
+from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
 
 @pytest.mark.sql_engine_snapshot
@@ -43,27 +43,26 @@ def test_multihop_node(
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan where there is a join between 1 measure and 2 dimensions."""
-    dataflow_plan = multihop_dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="txn_count"),),
-            dimension_specs=(
-                DimensionSpec(
-                    element_name="customer_name",
-                    entity_links=(
-                        EntityReference(element_name="account_id"),
-                        EntityReference(element_name="customer_id"),
-                    ),
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="txn_count"),),
+        dimension_specs=(
+            DimensionSpec(
+                element_name="customer_name",
+                entity_links=(
+                    EntityReference(element_name="account_id"),
+                    EntityReference(element_name="customer_id"),
                 ),
             ),
-        )
+        ),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=multihop_dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=multihop_dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -84,14 +83,14 @@ def test_filter_with_where_constraint_on_join_dim(
             where_sql_template="{{ Dimension('listing__country_latest') }} = 'us'",
         ),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -104,24 +103,23 @@ def test_partitioned_join(
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan where there's a join on a partitioned dimension."""
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="identity_verifications"),),
-            dimension_specs=(
-                DimensionSpec(
-                    element_name="home_state",
-                    entity_links=(EntityReference(element_name="user"),),
-                ),
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="identity_verifications"),),
+        dimension_specs=(
+            DimensionSpec(
+                element_name="home_state",
+                entity_links=(EntityReference(element_name="user"),),
             ),
-        )
+        ),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -134,25 +132,24 @@ def test_limit_rows(
     sql_client: SqlClient,
 ) -> None:
     """Tests a plan with a limit to the number of rows returned."""
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings"),),
-            time_dimension_specs=(
-                TimeDimensionSpec(
-                    element_name="ds",
-                    entity_links=(),
-                ),
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings"),),
+        time_dimension_specs=(
+            TimeDimensionSpec(
+                element_name="ds",
+                entity_links=(),
             ),
-            limit=1,
-        )
+        ),
+        limit=1,
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -175,14 +172,14 @@ def test_distinct_values(
         ),
         limit=100,
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -194,24 +191,23 @@ def test_local_dimension_using_local_entity(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="listings"),),
-            dimension_specs=(
-                DimensionSpec(
-                    element_name="country_latest",
-                    entity_links=(EntityReference(element_name="listing"),),
-                ),
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="listings"),),
+        dimension_specs=(
+            DimensionSpec(
+                element_name="country_latest",
+                entity_links=(EntityReference(element_name="listing"),),
             ),
-        )
+        ),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -228,14 +224,14 @@ def test_measure_constraint(  # noqa: D103
         metric_names=("lux_booking_value_rate_expr",),
         group_by_names=(MTD_SPEC_DAY.qualified_name,),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -252,14 +248,14 @@ def test_measure_constraint_with_reused_measure(  # noqa: D103
         metric_names=("instant_booking_value_ratio",),
         group_by_names=(MTD_SPEC_DAY.qualified_name,),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -277,14 +273,13 @@ def test_measure_constraint_with_single_expr_and_alias(  # noqa: D103
         group_by_names=(MTD_SPEC_DAY.qualified_name,),
     ).query_spec
 
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
-
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -306,14 +301,14 @@ def test_join_to_scd_dimension(
             where_sql_template="{{ Dimension('listing__capacity') }} > 2",
         ),
     ).query_spec
-    dataflow_plan = scd_dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=scd_dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=scd_dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -326,20 +321,19 @@ def test_multi_hop_through_scd_dimension(
     sql_client: SqlClient,
 ) -> None:
     """Tests conversion of a plan using a dimension that is reached through an SCD table."""
-    dataflow_plan = scd_dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-            dimension_specs=(DimensionSpec.from_name(name="listing__user__home_state_latest"),),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
+        dimension_specs=(DimensionSpec.from_name(name="listing__user__home_state_latest"),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=scd_dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=scd_dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -352,20 +346,19 @@ def test_multi_hop_to_scd_dimension(
     sql_client: SqlClient,
 ) -> None:
     """Tests conversion of a plan using an SCD dimension that is reached through another table."""
-    dataflow_plan = scd_dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings"),),
-            time_dimension_specs=(MTD_SPEC_DAY,),
-            dimension_specs=(DimensionSpec.from_name(name="listing__lux_listing__is_confirmed_lux"),),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings"),),
+        time_dimension_specs=(MTD_SPEC_DAY,),
+        dimension_specs=(DimensionSpec.from_name(name="listing__lux_listing__is_confirmed_lux"),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=scd_dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=scd_dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -377,21 +370,20 @@ def test_multiple_metrics_no_dimensions(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings"), MetricSpec(element_name="listings")),
-            time_range_constraint=TimeRangeConstraint(
-                start_time=as_datetime("2020-01-01"), end_time=as_datetime("2020-01-01")
-            ),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings"), MetricSpec(element_name="listings")),
+        time_range_constraint=TimeRangeConstraint(
+            start_time=as_datetime("2020-01-01"), end_time=as_datetime("2020-01-01")
+        ),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -403,18 +395,17 @@ def test_metric_with_measures_from_multiple_sources_no_dimensions(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_per_listing"),),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_per_listing"),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -426,19 +417,18 @@ def test_common_semantic_model(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings"), MetricSpec(element_name="booking_value")),
-            dimension_specs=(DataSet.metric_time_dimension_spec(TimeGranularity.DAY),),
-        ),
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings"), MetricSpec(element_name="booking_value")),
+        dimension_specs=(DataSet.metric_time_dimension_spec(TimeGranularity.DAY),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -451,24 +441,23 @@ def test_min_max_only_categorical(
     sql_client: SqlClient,
 ) -> None:
     """Tests a min max only query with a categorical dimension."""
-    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
-        query_spec=MetricFlowQuerySpec(
-            dimension_specs=(
-                DimensionSpec(
-                    element_name="country_latest",
-                    entity_links=(EntityReference(element_name="listing"),),
-                ),
+    query_spec = MetricFlowQuerySpec(
+        dimension_specs=(
+            DimensionSpec(
+                element_name="country_latest",
+                entity_links=(EntityReference(element_name="listing"),),
             ),
-            min_max_only=True,
         ),
+        min_max_only=True,
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -481,25 +470,24 @@ def test_min_max_only_time(
     sql_client: SqlClient,
 ) -> None:
     """Tests a min max only query with a time dimension."""
-    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
-        query_spec=MetricFlowQuerySpec(
-            time_dimension_specs=(
-                TimeDimensionSpec(
-                    element_name="paid_at",
-                    entity_links=(EntityReference("booking"),),
-                    time_granularity=TimeGranularity.DAY,
-                ),
+    query_spec = MetricFlowQuerySpec(
+        time_dimension_specs=(
+            TimeDimensionSpec(
+                element_name="paid_at",
+                entity_links=(EntityReference("booking"),),
+                time_granularity=TimeGranularity.DAY,
             ),
-            min_max_only=True,
         ),
+        min_max_only=True,
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -512,25 +500,24 @@ def test_min_max_only_time_quarter(
     sql_client: SqlClient,
 ) -> None:
     """Tests a min max only query with a time dimension and non-default granularity."""
-    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
-        query_spec=MetricFlowQuerySpec(
-            time_dimension_specs=(
-                TimeDimensionSpec(
-                    element_name="paid_at",
-                    entity_links=(EntityReference("booking"),),
-                    time_granularity=TimeGranularity.QUARTER,
-                ),
+    query_spec = MetricFlowQuerySpec(
+        time_dimension_specs=(
+            TimeDimensionSpec(
+                element_name="paid_at",
+                entity_links=(EntityReference("booking"),),
+                time_granularity=TimeGranularity.QUARTER,
             ),
-            min_max_only=True,
         ),
+        min_max_only=True,
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -543,19 +530,18 @@ def test_min_max_metric_time(
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
 ) -> None:
     """Tests a plan to get the min & max distinct values of metric_time."""
-    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
-        query_spec=MetricFlowQuerySpec(
-            time_dimension_specs=(MTD_SPEC_DAY,),
-            min_max_only=True,
-        )
+    query_spec = MetricFlowQuerySpec(
+        time_dimension_specs=(MTD_SPEC_DAY,),
+        min_max_only=True,
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -568,17 +554,16 @@ def test_min_max_metric_time_week(
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
 ) -> None:
     """Tests a plan to get the min & max distinct values of metric_time with non-default granularity."""
-    dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(
-        query_spec=MetricFlowQuerySpec(
-            time_dimension_specs=(MTD_SPEC_WEEK,),
-            min_max_only=True,
-        )
+    query_spec = MetricFlowQuerySpec(
+        time_dimension_specs=(MTD_SPEC_WEEK,),
+        min_max_only=True,
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )

--- a/tests_metricflow/query_rendering/test_time_spine_join_rendering.py
+++ b/tests_metricflow/query_rendering/test_time_spine_join_rendering.py
@@ -23,7 +23,7 @@ from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilde
 from metricflow.dataset.dataset_classes import DataSet
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from tests_metricflow.query_rendering.compare_rendered_query import convert_and_check
+from tests_metricflow.query_rendering.compare_rendered_query import render_and_check
 
 
 @pytest.mark.sql_engine_snapshot
@@ -34,19 +34,18 @@ def test_simple_join_to_time_spine(  # noqa: D103
     dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
     sql_client: SqlClient,
 ) -> None:
-    dataflow_plan = dataflow_plan_builder.build_plan(
-        MetricFlowQuerySpec(
-            metric_specs=(MetricSpec(element_name="bookings_join_to_time_spine"),),
-            time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
-        )
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="bookings_join_to_time_spine"),),
+        time_dimension_specs=(DataSet.metric_time_dimension_spec(time_granularity=TimeGranularity.DAY),),
     )
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -65,14 +64,14 @@ def test_simple_join_to_time_spine_with_filter(
         group_by_names=("metric_time__day",),
         where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -91,14 +90,14 @@ def test_simple_join_to_time_spine_with_queried_filter(
         group_by_names=("metric_time__day", "booking__is_instant"),
         where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -117,14 +116,14 @@ def test_join_to_time_spine_with_time_constraint(
         time_constraint_start=datetime.datetime(2020, 1, 3),
         time_constraint_end=datetime.datetime(2020, 1, 5),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )
 
 
@@ -144,12 +143,12 @@ def test_join_to_time_spine_with_queried_time_constraint(
         time_constraint_start=datetime.datetime(2020, 1, 3),
         time_constraint_end=datetime.datetime(2020, 1, 5),
     ).query_spec
-    dataflow_plan = dataflow_plan_builder.build_plan(query_spec)
 
-    convert_and_check(
+    render_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
-        node=dataflow_plan.sink_node,
+        dataflow_plan_builder=dataflow_plan_builder,
+        query_spec=query_spec,
     )

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
-          (subq_31.ds__day <= subq_34.ds__day)
+          (subq_35.ds__day <= subq_38.ds__day)
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
-    subq_27.visit__referrer_id = subq_38.visit__referrer_id
+    subq_31.visit__referrer_id = subq_42.visit__referrer_id
   GROUP BY
     visit__referrer_id
-) subq_39
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day) AS metric_time__day
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_35.metric_time__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
           (
-            subq_31.ds__day <= subq_34.ds__day
+            subq_35.ds__day <= subq_38.ds__day
           ) AND (
-            subq_31.ds__day > DATE_SUB(CAST(subq_34.ds__day AS DATETIME), INTERVAL 7 day)
+            subq_35.ds__day > DATE_SUB(CAST(subq_38.ds__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
     (
-      subq_27.visit__referrer_id = subq_38.visit__referrer_id
+      subq_31.visit__referrer_id = subq_42.visit__referrer_id
     ) AND (
-      subq_27.metric_time__day = subq_38.metric_time__day
+      subq_31.metric_time__day = subq_42.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_39
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
-          (subq_31.ds__day <= subq_34.ds__day)
+          (subq_35.ds__day <= subq_38.ds__day)
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
-    subq_27.visit__referrer_id = subq_38.visit__referrer_id
+    subq_31.visit__referrer_id = subq_42.visit__referrer_id
   GROUP BY
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day) AS metric_time__day
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_35.metric_time__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
           (
-            subq_31.ds__day <= subq_34.ds__day
+            subq_35.ds__day <= subq_38.ds__day
           ) AND (
-            subq_31.ds__day > DATEADD(day, -7, subq_34.ds__day)
+            subq_35.ds__day > DATEADD(day, -7, subq_38.ds__day)
           )
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
     (
-      subq_27.visit__referrer_id = subq_38.visit__referrer_id
+      subq_31.visit__referrer_id = subq_42.visit__referrer_id
     ) AND (
-      subq_27.metric_time__day = subq_38.metric_time__day
+      subq_31.metric_time__day = subq_42.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day)
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
-          (subq_31.ds__day <= subq_34.ds__day)
+          (subq_35.ds__day <= subq_38.ds__day)
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
-    subq_27.visit__referrer_id = subq_38.visit__referrer_id
+    subq_31.visit__referrer_id = subq_42.visit__referrer_id
   GROUP BY
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day) AS metric_time__day
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_35.metric_time__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
           (
-            subq_31.ds__day <= subq_34.ds__day
+            subq_35.ds__day <= subq_38.ds__day
           ) AND (
-            subq_31.ds__day > subq_34.ds__day - INTERVAL 7 day
+            subq_35.ds__day > subq_38.ds__day - INTERVAL 7 day
           )
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
     (
-      subq_27.visit__referrer_id = subq_38.visit__referrer_id
+      subq_31.visit__referrer_id = subq_42.visit__referrer_id
     ) AND (
-      subq_27.metric_time__day = subq_38.metric_time__day
+      subq_31.metric_time__day = subq_42.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day)
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
-          (subq_31.ds__day <= subq_34.ds__day)
+          (subq_35.ds__day <= subq_38.ds__day)
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
-    subq_27.visit__referrer_id = subq_38.visit__referrer_id
+    subq_31.visit__referrer_id = subq_42.visit__referrer_id
   GROUP BY
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day) AS metric_time__day
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_35.metric_time__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
           (
-            subq_31.ds__day <= subq_34.ds__day
+            subq_35.ds__day <= subq_38.ds__day
           ) AND (
-            subq_31.ds__day > subq_34.ds__day - MAKE_INTERVAL(days => 7)
+            subq_35.ds__day > subq_38.ds__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
     (
-      subq_27.visit__referrer_id = subq_38.visit__referrer_id
+      subq_31.visit__referrer_id = subq_42.visit__referrer_id
     ) AND (
-      subq_27.metric_time__day = subq_38.metric_time__day
+      subq_31.metric_time__day = subq_42.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day)
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
-          (subq_31.ds__day <= subq_34.ds__day)
+          (subq_35.ds__day <= subq_38.ds__day)
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
-    subq_27.visit__referrer_id = subq_38.visit__referrer_id
+    subq_31.visit__referrer_id = subq_42.visit__referrer_id
   GROUP BY
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day) AS metric_time__day
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_35.metric_time__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
           (
-            subq_31.ds__day <= subq_34.ds__day
+            subq_35.ds__day <= subq_38.ds__day
           ) AND (
-            subq_31.ds__day > DATEADD(day, -7, subq_34.ds__day)
+            subq_35.ds__day > DATEADD(day, -7, subq_38.ds__day)
           )
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
     (
-      subq_27.visit__referrer_id = subq_38.visit__referrer_id
+      subq_31.visit__referrer_id = subq_42.visit__referrer_id
     ) AND (
-      subq_27.metric_time__day = subq_38.metric_time__day
+      subq_31.metric_time__day = subq_42.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day)
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
-          (subq_31.ds__day <= subq_34.ds__day)
+          (subq_35.ds__day <= subq_38.ds__day)
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
-    subq_27.visit__referrer_id = subq_38.visit__referrer_id
+    subq_31.visit__referrer_id = subq_42.visit__referrer_id
   GROUP BY
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day) AS metric_time__day
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_35.metric_time__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
           (
-            subq_31.ds__day <= subq_34.ds__day
+            subq_35.ds__day <= subq_38.ds__day
           ) AND (
-            subq_31.ds__day > DATEADD(day, -7, subq_34.ds__day)
+            subq_35.ds__day > DATEADD(day, -7, subq_38.ds__day)
           )
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
     (
-      subq_27.visit__referrer_id = subq_38.visit__referrer_id
+      subq_31.visit__referrer_id = subq_42.visit__referrer_id
     ) AND (
-      subq_27.metric_time__day = subq_38.metric_time__day
+      subq_31.metric_time__day = subq_42.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day)
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -24,11 +24,11 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +39,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +85,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +96,19 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
-          (subq_31.ds__day <= subq_34.ds__day)
+          (subq_35.ds__day <= subq_38.ds__day)
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
-    subq_27.visit__referrer_id = subq_38.visit__referrer_id
+    subq_31.visit__referrer_id = subq_42.visit__referrer_id
   GROUP BY
-    COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day) AS metric_time__day
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_27.visits) AS visits
-    , MAX(subq_38.buys) AS buys
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day) AS metric_time__day
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_31.visits) AS visits
+    , MAX(subq_42.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -28,12 +28,12 @@ FROM (
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-    ) subq_25
+    ) subq_29
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_27
+  ) subq_31
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +45,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_31.visits) OVER (
+        FIRST_VALUE(subq_35.visits) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_35.visit__referrer_id) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_35.ds__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_35.metric_time__day) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_31.user) OVER (
+        , FIRST_VALUE(subq_35.user) OVER (
           PARTITION BY
-            subq_34.user
-            , subq_34.ds__day
-            , subq_34.mf_internal_uuid
-          ORDER BY subq_31.ds__day DESC
+            subq_38.user
+            , subq_38.ds__day
+            , subq_38.mf_internal_uuid
+          ORDER BY subq_35.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_34.mf_internal_uuid AS mf_internal_uuid
-        , subq_34.buys AS buys
+        , subq_38.mf_internal_uuid AS mf_internal_uuid
+        , subq_38.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +100,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-      ) subq_31
+      ) subq_35
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +111,29 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_34
+      ) subq_38
       ON
         (
-          subq_31.user = subq_34.user
+          subq_35.user = subq_38.user
         ) AND (
           (
-            subq_31.ds__day <= subq_34.ds__day
+            subq_35.ds__day <= subq_38.ds__day
           ) AND (
-            subq_31.ds__day > DATE_ADD('day', -7, subq_34.ds__day)
+            subq_35.ds__day > DATE_ADD('day', -7, subq_38.ds__day)
           )
         )
-    ) subq_35
+    ) subq_39
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_38
+  ) subq_42
   ON
     (
-      subq_27.visit__referrer_id = subq_38.visit__referrer_id
+      subq_31.visit__referrer_id = subq_42.visit__referrer_id
     ) AND (
-      subq_27.metric_time__day = subq_38.metric_time__day
+      subq_31.metric_time__day = subq_42.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_38.metric_time__day)
-    , COALESCE(subq_27.visit__referrer_id, subq_38.visit__referrer_id)
-) subq_39
+    COALESCE(subq_31.metric_time__day, subq_42.metric_time__day)
+    , COALESCE(subq_31.visit__referrer_id, subq_42.visit__referrer_id)
+) subq_43

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
-  , SUM(subq_13.bookings_monthly) AS trailing_3_months_bookings
+  subq_16.metric_time__month AS metric_time__month
+  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATETIME_TRUNC(ds, month) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     metric_time__month
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATETIME_TRUNC(ds, month) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__month <= subq_14.metric_time__month
+    subq_15.metric_time__month <= subq_16.metric_time__month
   ) AND (
-    subq_13.metric_time__month > DATE_SUB(CAST(subq_14.metric_time__month AS DATETIME), INTERVAL 3 month)
+    subq_15.metric_time__month > DATE_SUB(CAST(subq_16.metric_time__month AS DATETIME), INTERVAL 3 month)
   )
-WHERE subq_14.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
   metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS revenue_all_time
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATETIME_TRUNC(created_at, day) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
-  (subq_13.metric_time__day <= subq_14.metric_time__day)
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_15.metric_time__day <= subq_16.metric_time__day)
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS trailing_2_months_revenue
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATETIME_TRUNC(created_at, day) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__day <= subq_14.metric_time__day
+    subq_15.metric_time__day <= subq_16.metric_time__day
   ) AND (
-    subq_13.metric_time__day > DATE_SUB(CAST(subq_14.metric_time__day AS DATETIME), INTERVAL 2 month)
+    subq_15.metric_time__day > DATE_SUB(CAST(subq_16.metric_time__day AS DATETIME), INTERVAL 2 month)
   )
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
-  , SUM(subq_13.bookings_monthly) AS trailing_3_months_bookings
+  subq_16.metric_time__month AS metric_time__month
+  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__month <= subq_14.metric_time__month
+    subq_15.metric_time__month <= subq_16.metric_time__month
   ) AND (
-    subq_13.metric_time__month > DATEADD(month, -3, subq_14.metric_time__month)
+    subq_15.metric_time__month > DATEADD(month, -3, subq_16.metric_time__month)
   )
-WHERE subq_14.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
-  subq_14.metric_time__month
+  subq_16.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS revenue_all_time
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
-  (subq_13.metric_time__day <= subq_14.metric_time__day)
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_15.metric_time__day <= subq_16.metric_time__day)
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS trailing_2_months_revenue
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__day <= subq_14.metric_time__day
+    subq_15.metric_time__day <= subq_16.metric_time__day
   ) AND (
-    subq_13.metric_time__day > DATEADD(month, -2, subq_14.metric_time__day)
+    subq_15.metric_time__day > DATEADD(month, -2, subq_16.metric_time__day)
   )
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
-  , SUM(subq_13.bookings_monthly) AS trailing_3_months_bookings
+  subq_16.metric_time__month AS metric_time__month
+  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__month <= subq_14.metric_time__month
+    subq_15.metric_time__month <= subq_16.metric_time__month
   ) AND (
-    subq_13.metric_time__month > subq_14.metric_time__month - INTERVAL 3 month
+    subq_15.metric_time__month > subq_16.metric_time__month - INTERVAL 3 month
   )
-WHERE subq_14.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
-  subq_14.metric_time__month
+  subq_16.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS revenue_all_time
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
-  (subq_13.metric_time__day <= subq_14.metric_time__day)
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_15.metric_time__day <= subq_16.metric_time__day)
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS trailing_2_months_revenue
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__day <= subq_14.metric_time__day
+    subq_15.metric_time__day <= subq_16.metric_time__day
   ) AND (
-    subq_13.metric_time__day > subq_14.metric_time__day - INTERVAL 2 month
+    subq_15.metric_time__day > subq_16.metric_time__day - INTERVAL 2 month
   )
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
-  , SUM(subq_13.bookings_monthly) AS trailing_3_months_bookings
+  subq_16.metric_time__month AS metric_time__month
+  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__month <= subq_14.metric_time__month
+    subq_15.metric_time__month <= subq_16.metric_time__month
   ) AND (
-    subq_13.metric_time__month > subq_14.metric_time__month - MAKE_INTERVAL(months => 3)
+    subq_15.metric_time__month > subq_16.metric_time__month - MAKE_INTERVAL(months => 3)
   )
-WHERE subq_14.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
-  subq_14.metric_time__month
+  subq_16.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS revenue_all_time
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
-  (subq_13.metric_time__day <= subq_14.metric_time__day)
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_15.metric_time__day <= subq_16.metric_time__day)
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS trailing_2_months_revenue
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__day <= subq_14.metric_time__day
+    subq_15.metric_time__day <= subq_16.metric_time__day
   ) AND (
-    subq_13.metric_time__day > subq_14.metric_time__day - MAKE_INTERVAL(months => 2)
+    subq_15.metric_time__day > subq_16.metric_time__day - MAKE_INTERVAL(months => 2)
   )
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
-  , SUM(subq_13.bookings_monthly) AS trailing_3_months_bookings
+  subq_16.metric_time__month AS metric_time__month
+  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__month <= subq_14.metric_time__month
+    subq_15.metric_time__month <= subq_16.metric_time__month
   ) AND (
-    subq_13.metric_time__month > DATEADD(month, -3, subq_14.metric_time__month)
+    subq_15.metric_time__month > DATEADD(month, -3, subq_16.metric_time__month)
   )
-WHERE subq_14.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
-  subq_14.metric_time__month
+  subq_16.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS revenue_all_time
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
-  (subq_13.metric_time__day <= subq_14.metric_time__day)
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_15.metric_time__day <= subq_16.metric_time__day)
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS trailing_2_months_revenue
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__day <= subq_14.metric_time__day
+    subq_15.metric_time__day <= subq_16.metric_time__day
   ) AND (
-    subq_13.metric_time__day > DATEADD(month, -2, subq_14.metric_time__day)
+    subq_15.metric_time__day > DATEADD(month, -2, subq_16.metric_time__day)
   )
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
-  , SUM(subq_13.bookings_monthly) AS trailing_3_months_bookings
+  subq_16.metric_time__month AS metric_time__month
+  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-03-05' AND '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN '2019-12-05' AND '2021-01-04'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__month <= subq_14.metric_time__month
+    subq_15.metric_time__month <= subq_16.metric_time__month
   ) AND (
-    subq_13.metric_time__month > DATEADD(month, -3, subq_14.metric_time__month)
+    subq_15.metric_time__month > DATEADD(month, -3, subq_16.metric_time__month)
   )
-WHERE subq_14.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
+WHERE subq_16.metric_time__month BETWEEN '2020-03-05' AND '2021-01-04'
 GROUP BY
-  subq_14.metric_time__month
+  subq_16.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS revenue_all_time
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
-  (subq_13.metric_time__day <= subq_14.metric_time__day)
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_15.metric_time__day <= subq_16.metric_time__day)
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS trailing_2_months_revenue
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2019-11-01' AND '2020-01-01'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__day <= subq_14.metric_time__day
+    subq_15.metric_time__day <= subq_16.metric_time__day
   ) AND (
-    subq_13.metric_time__day > DATEADD(month, -2, subq_14.metric_time__day)
+    subq_15.metric_time__day > DATEADD(month, -2, subq_16.metric_time__day)
   )
-WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
+WHERE subq_16.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_month__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_month__plan0_optimized.sql
@@ -4,17 +4,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
-  , SUM(subq_13.bookings_monthly) AS trailing_3_months_bookings
+  subq_16.metric_time__month AS metric_time__month
+  , SUM(subq_15.bookings_monthly) AS trailing_3_months_bookings
 FROM (
   -- Time Spine
   SELECT
     DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN timestamp '2020-03-05' AND timestamp '2021-01-04'
   GROUP BY
     DATE_TRUNC('month', ds)
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'bookings_monthly_source'
   -- Metric Time Dimension 'monthly_ds'
@@ -24,13 +24,13 @@ INNER JOIN (
     , bookings_monthly
   FROM ***************************.fct_bookings_extended_monthly bookings_monthly_source_src_16000
   WHERE DATE_TRUNC('month', ds) BETWEEN timestamp '2019-12-05' AND timestamp '2021-01-04'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__month <= subq_14.metric_time__month
+    subq_15.metric_time__month <= subq_16.metric_time__month
   ) AND (
-    subq_13.metric_time__month > DATE_ADD('month', -3, subq_14.metric_time__month)
+    subq_15.metric_time__month > DATE_ADD('month', -3, subq_16.metric_time__month)
   )
-WHERE subq_14.metric_time__month BETWEEN timestamp '2020-03-05' AND timestamp '2021-01-04'
+WHERE subq_16.metric_time__month BETWEEN timestamp '2020-03-05' AND timestamp '2021-01-04'
 GROUP BY
-  subq_14.metric_time__month
+  subq_16.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS revenue_all_time
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,9 +22,9 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN timestamp '2000-01-01' AND timestamp '2020-01-01'
-) subq_13
+) subq_15
 ON
-  (subq_13.metric_time__day <= subq_14.metric_time__day)
-WHERE subq_14.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+  (subq_15.metric_time__day <= subq_16.metric_time__day)
+WHERE subq_16.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_time_constraint__plan0_optimized.sql
@@ -4,15 +4,15 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__day AS metric_time__day
-  , SUM(subq_13.txn_revenue) AS trailing_2_months_revenue
+  subq_16.metric_time__day AS metric_time__day
+  , SUM(subq_15.txn_revenue) AS trailing_2_months_revenue
 FROM (
   -- Time Spine
   SELECT
     ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_15
+  FROM ***************************.mf_time_spine subq_17
   WHERE ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-) subq_14
+) subq_16
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
@@ -22,13 +22,13 @@ INNER JOIN (
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN timestamp '2019-11-01' AND timestamp '2020-01-01'
-) subq_13
+) subq_15
 ON
   (
-    subq_13.metric_time__day <= subq_14.metric_time__day
+    subq_15.metric_time__day <= subq_16.metric_time__day
   ) AND (
-    subq_13.metric_time__day > DATE_ADD('month', -2, subq_14.metric_time__day)
+    subq_15.metric_time__day > DATE_ADD('month', -2, subq_16.metric_time__day)
   )
-WHERE subq_14.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+WHERE subq_16.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
 GROUP BY
-  subq_14.metric_time__day
+  subq_16.metric_time__day

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_54.average_booking_value) AS average_booking_value
-      , MAX(subq_67.bookings) AS bookings
-      , MAX(subq_75.booking_value) AS booking_value
+      MAX(subq_60.average_booking_value) AS average_booking_value
+      , MAX(subq_73.bookings) AS bookings
+      , MAX(subq_81.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_45.booking__is_instant AS booking__is_instant
+          subq_51.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_45.average_booking_value AS average_booking_value
+          , subq_51.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_43
+          ) subq_49
           WHERE booking__is_instant
-        ) subq_45
+        ) subq_51
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_45.listing = listings_latest_src_28000.listing_id
-      ) subq_50
+          subq_51.listing = listings_latest_src_28000.listing_id
+      ) subq_56
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_54
+    ) subq_60
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_58.booking__is_instant AS booking__is_instant
+          subq_64.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_58.bookings AS bookings
+          , subq_64.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_56
+          ) subq_62
           WHERE booking__is_instant
-        ) subq_58
+        ) subq_64
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_58.listing = listings_latest_src_28000.listing_id
-      ) subq_63
+          subq_64.listing = listings_latest_src_28000.listing_id
+      ) subq_69
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_67
+    ) subq_73
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_69
+        ) subq_75
         WHERE booking__is_instant
-      ) subq_71
+      ) subq_77
       WHERE booking__is_instant
-    ) subq_75
-  ) subq_76
-) subq_77
+    ) subq_81
+  ) subq_82
+) subq_83

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_54.average_booking_value) AS average_booking_value
-      , MAX(subq_67.bookings) AS bookings
-      , MAX(subq_75.booking_value) AS booking_value
+      MAX(subq_60.average_booking_value) AS average_booking_value
+      , MAX(subq_73.bookings) AS bookings
+      , MAX(subq_81.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_45.booking__is_instant AS booking__is_instant
+          subq_51.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_45.average_booking_value AS average_booking_value
+          , subq_51.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_43
+          ) subq_49
           WHERE booking__is_instant
-        ) subq_45
+        ) subq_51
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_45.listing = listings_latest_src_28000.listing_id
-      ) subq_50
+          subq_51.listing = listings_latest_src_28000.listing_id
+      ) subq_56
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_54
+    ) subq_60
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_58.booking__is_instant AS booking__is_instant
+          subq_64.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_58.bookings AS bookings
+          , subq_64.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_56
+          ) subq_62
           WHERE booking__is_instant
-        ) subq_58
+        ) subq_64
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_58.listing = listings_latest_src_28000.listing_id
-      ) subq_63
+          subq_64.listing = listings_latest_src_28000.listing_id
+      ) subq_69
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_67
+    ) subq_73
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_69
+        ) subq_75
         WHERE booking__is_instant
-      ) subq_71
+      ) subq_77
       WHERE booking__is_instant
-    ) subq_75
-  ) subq_76
-) subq_77
+    ) subq_81
+  ) subq_82
+) subq_83

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_54.average_booking_value) AS average_booking_value
-      , MAX(subq_67.bookings) AS bookings
-      , MAX(subq_75.booking_value) AS booking_value
+      MAX(subq_60.average_booking_value) AS average_booking_value
+      , MAX(subq_73.bookings) AS bookings
+      , MAX(subq_81.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_45.booking__is_instant AS booking__is_instant
+          subq_51.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_45.average_booking_value AS average_booking_value
+          , subq_51.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_43
+          ) subq_49
           WHERE booking__is_instant
-        ) subq_45
+        ) subq_51
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_45.listing = listings_latest_src_28000.listing_id
-      ) subq_50
+          subq_51.listing = listings_latest_src_28000.listing_id
+      ) subq_56
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_54
+    ) subq_60
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_58.booking__is_instant AS booking__is_instant
+          subq_64.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_58.bookings AS bookings
+          , subq_64.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_56
+          ) subq_62
           WHERE booking__is_instant
-        ) subq_58
+        ) subq_64
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_58.listing = listings_latest_src_28000.listing_id
-      ) subq_63
+          subq_64.listing = listings_latest_src_28000.listing_id
+      ) subq_69
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_67
+    ) subq_73
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_69
+        ) subq_75
         WHERE booking__is_instant
-      ) subq_71
+      ) subq_77
       WHERE booking__is_instant
-    ) subq_75
-  ) subq_76
-) subq_77
+    ) subq_81
+  ) subq_82
+) subq_83

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_54.average_booking_value) AS average_booking_value
-      , MAX(subq_67.bookings) AS bookings
-      , MAX(subq_75.booking_value) AS booking_value
+      MAX(subq_60.average_booking_value) AS average_booking_value
+      , MAX(subq_73.bookings) AS bookings
+      , MAX(subq_81.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_45.booking__is_instant AS booking__is_instant
+          subq_51.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_45.average_booking_value AS average_booking_value
+          , subq_51.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_43
+          ) subq_49
           WHERE booking__is_instant
-        ) subq_45
+        ) subq_51
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_45.listing = listings_latest_src_28000.listing_id
-      ) subq_50
+          subq_51.listing = listings_latest_src_28000.listing_id
+      ) subq_56
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_54
+    ) subq_60
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_58.booking__is_instant AS booking__is_instant
+          subq_64.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_58.bookings AS bookings
+          , subq_64.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_56
+          ) subq_62
           WHERE booking__is_instant
-        ) subq_58
+        ) subq_64
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_58.listing = listings_latest_src_28000.listing_id
-      ) subq_63
+          subq_64.listing = listings_latest_src_28000.listing_id
+      ) subq_69
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_67
+    ) subq_73
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_69
+        ) subq_75
         WHERE booking__is_instant
-      ) subq_71
+      ) subq_77
       WHERE booking__is_instant
-    ) subq_75
-  ) subq_76
-) subq_77
+    ) subq_81
+  ) subq_82
+) subq_83

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_54.average_booking_value) AS average_booking_value
-      , MAX(subq_67.bookings) AS bookings
-      , MAX(subq_75.booking_value) AS booking_value
+      MAX(subq_60.average_booking_value) AS average_booking_value
+      , MAX(subq_73.bookings) AS bookings
+      , MAX(subq_81.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_45.booking__is_instant AS booking__is_instant
+          subq_51.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_45.average_booking_value AS average_booking_value
+          , subq_51.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_43
+          ) subq_49
           WHERE booking__is_instant
-        ) subq_45
+        ) subq_51
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_45.listing = listings_latest_src_28000.listing_id
-      ) subq_50
+          subq_51.listing = listings_latest_src_28000.listing_id
+      ) subq_56
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_54
+    ) subq_60
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_58.booking__is_instant AS booking__is_instant
+          subq_64.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_58.bookings AS bookings
+          , subq_64.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_56
+          ) subq_62
           WHERE booking__is_instant
-        ) subq_58
+        ) subq_64
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_58.listing = listings_latest_src_28000.listing_id
-      ) subq_63
+          subq_64.listing = listings_latest_src_28000.listing_id
+      ) subq_69
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_67
+    ) subq_73
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_69
+        ) subq_75
         WHERE booking__is_instant
-      ) subq_71
+      ) subq_77
       WHERE booking__is_instant
-    ) subq_75
-  ) subq_76
-) subq_77
+    ) subq_81
+  ) subq_82
+) subq_83

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_54.average_booking_value) AS average_booking_value
-      , MAX(subq_67.bookings) AS bookings
-      , MAX(subq_75.booking_value) AS booking_value
+      MAX(subq_60.average_booking_value) AS average_booking_value
+      , MAX(subq_73.bookings) AS bookings
+      , MAX(subq_81.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_45.booking__is_instant AS booking__is_instant
+          subq_51.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_45.average_booking_value AS average_booking_value
+          , subq_51.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_43
+          ) subq_49
           WHERE booking__is_instant
-        ) subq_45
+        ) subq_51
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_45.listing = listings_latest_src_28000.listing_id
-      ) subq_50
+          subq_51.listing = listings_latest_src_28000.listing_id
+      ) subq_56
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_54
+    ) subq_60
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_58.booking__is_instant AS booking__is_instant
+          subq_64.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_58.bookings AS bookings
+          , subq_64.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_56
+          ) subq_62
           WHERE booking__is_instant
-        ) subq_58
+        ) subq_64
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_58.listing = listings_latest_src_28000.listing_id
-      ) subq_63
+          subq_64.listing = listings_latest_src_28000.listing_id
+      ) subq_69
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_67
+    ) subq_73
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_69
+        ) subq_75
         WHERE booking__is_instant
-      ) subq_71
+      ) subq_77
       WHERE booking__is_instant
-    ) subq_75
-  ) subq_76
-) subq_77
+    ) subq_81
+  ) subq_82
+) subq_83

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_54.average_booking_value) AS average_booking_value
-      , MAX(subq_67.bookings) AS bookings
-      , MAX(subq_75.booking_value) AS booking_value
+      MAX(subq_60.average_booking_value) AS average_booking_value
+      , MAX(subq_73.bookings) AS bookings
+      , MAX(subq_81.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_45.booking__is_instant AS booking__is_instant
+          subq_51.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_45.average_booking_value AS average_booking_value
+          , subq_51.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_43
+          ) subq_49
           WHERE booking__is_instant
-        ) subq_45
+        ) subq_51
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_45.listing = listings_latest_src_28000.listing_id
-      ) subq_50
+          subq_51.listing = listings_latest_src_28000.listing_id
+      ) subq_56
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_54
+    ) subq_60
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_58.booking__is_instant AS booking__is_instant
+          subq_64.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_58.bookings AS bookings
+          , subq_64.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_56
+          ) subq_62
           WHERE booking__is_instant
-        ) subq_58
+        ) subq_64
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_58.listing = listings_latest_src_28000.listing_id
-      ) subq_63
+          subq_64.listing = listings_latest_src_28000.listing_id
+      ) subq_69
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_67
+    ) subq_73
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_69
+        ) subq_75
         WHERE booking__is_instant
-      ) subq_71
+      ) subq_77
       WHERE booking__is_instant
-    ) subq_75
-  ) subq_76
-) subq_77
+    ) subq_81
+  ) subq_82
+) subq_83

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.metric_time__day AS metric_time__day
-      , subq_18.bookings AS bookings
+      subq_21.metric_time__day AS metric_time__day
+      , subq_20.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_20
+      FROM ***************************.mf_time_spine subq_22
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_19
+    ) subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_16
+      ) subq_18
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_18
+    ) subq_20
     ON
-      subq_19.metric_time__day = subq_18.metric_time__day
-  ) subq_21
+      subq_21.metric_time__day = subq_20.metric_time__day
+  ) subq_23
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_23
+) subq_25

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.metric_time__day AS metric_time__day
-      , subq_18.bookings AS bookings
+      subq_21.metric_time__day AS metric_time__day
+      , subq_20.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_20
+      FROM ***************************.mf_time_spine subq_22
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_19
+    ) subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_16
+      ) subq_18
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_18
+    ) subq_20
     ON
-      subq_19.metric_time__day = subq_18.metric_time__day
-  ) subq_21
+      subq_21.metric_time__day = subq_20.metric_time__day
+  ) subq_23
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_23
+) subq_25

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.metric_time__day AS metric_time__day
-      , subq_18.bookings AS bookings
+      subq_21.metric_time__day AS metric_time__day
+      , subq_20.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_20
+      FROM ***************************.mf_time_spine subq_22
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_19
+    ) subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_16
+      ) subq_18
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_18
+    ) subq_20
     ON
-      subq_19.metric_time__day = subq_18.metric_time__day
-  ) subq_21
+      subq_21.metric_time__day = subq_20.metric_time__day
+  ) subq_23
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_23
+) subq_25

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.metric_time__day AS metric_time__day
-      , subq_18.bookings AS bookings
+      subq_21.metric_time__day AS metric_time__day
+      , subq_20.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_20
+      FROM ***************************.mf_time_spine subq_22
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_19
+    ) subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_16
+      ) subq_18
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_18
+    ) subq_20
     ON
-      subq_19.metric_time__day = subq_18.metric_time__day
-  ) subq_21
+      subq_21.metric_time__day = subq_20.metric_time__day
+  ) subq_23
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_23
+) subq_25

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.metric_time__day AS metric_time__day
-      , subq_18.bookings AS bookings
+      subq_21.metric_time__day AS metric_time__day
+      , subq_20.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_20
+      FROM ***************************.mf_time_spine subq_22
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_19
+    ) subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_16
+      ) subq_18
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_18
+    ) subq_20
     ON
-      subq_19.metric_time__day = subq_18.metric_time__day
-  ) subq_21
+      subq_21.metric_time__day = subq_20.metric_time__day
+  ) subq_23
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_23
+) subq_25

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.metric_time__day AS metric_time__day
-      , subq_18.bookings AS bookings
+      subq_21.metric_time__day AS metric_time__day
+      , subq_20.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_20
+      FROM ***************************.mf_time_spine subq_22
       WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_19
+    ) subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-      ) subq_16
+      ) subq_18
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_18
+    ) subq_20
     ON
-      subq_19.metric_time__day = subq_18.metric_time__day
-  ) subq_21
+      subq_21.metric_time__day = subq_20.metric_time__day
+  ) subq_23
   WHERE (
     metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_23
+) subq_25

--- a/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_fill_nulls_with_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_filters__plan0_optimized.sql
@@ -11,15 +11,15 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.metric_time__day AS metric_time__day
-      , subq_18.bookings AS bookings
+      subq_21.metric_time__day AS metric_time__day
+      , subq_20.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
         ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_20
+      FROM ***************************.mf_time_spine subq_22
       WHERE ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-    ) subq_19
+    ) subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -36,17 +36,17 @@ FROM (
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-      ) subq_16
+      ) subq_18
       WHERE metric_time__day > '2020-01-01'
       GROUP BY
         metric_time__day
-    ) subq_18
+    ) subq_20
     ON
-      subq_19.metric_time__day = subq_18.metric_time__day
-  ) subq_21
+      subq_21.metric_time__day = subq_20.metric_time__day
+  ) subq_23
   WHERE (
     metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
   ) AND (
     metric_time__day > '2020-01-01'
   )
-) subq_23
+) subq_25

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_26.guest__booking_value AS guest__booking_value
-    , subq_20.bookers AS bookers
+    subq_30.guest__booking_value AS guest__booking_value
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.guest = subq_26.guest
-) subq_28
+    subq_24.guest = subq_30.guest
+) subq_32
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_57.buys AS FLOAT64) / CAST(NULLIF(subq_57.visits, 0) AS FLOAT64) AS user__visit_buy_conversion_rate
-    , subq_42.listings AS listings
+    CAST(subq_72.buys AS FLOAT64) / CAST(NULLIF(subq_72.visits, 0) AS FLOAT64) AS user__visit_buy_conversion_rate
+    , subq_57.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_42
+  ) subq_57
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_46.user, subq_56.user) AS user
-      , MAX(subq_46.visits) AS visits
-      , MAX(subq_56.buys) AS buys
+      COALESCE(subq_61.user, subq_71.user) AS user
+      , MAX(subq_61.visits) AS visits
+      , MAX(subq_71.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_45.user
+        subq_60.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_45
+      ) subq_60
       GROUP BY
         user
-    ) subq_46
+    ) subq_61
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_53.user
+        subq_68.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_49.visits) OVER (
+          FIRST_VALUE(subq_64.visits) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_64.ds__day) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_49.user) OVER (
+          , FIRST_VALUE(subq_64.user) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_52.mf_internal_uuid AS mf_internal_uuid
-          , subq_52.buys AS buys
+          , subq_67.mf_internal_uuid AS mf_internal_uuid
+          , subq_67.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_49
+        ) subq_64
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , GENERATE_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_52
+        ) subq_67
         ON
           (
-            subq_49.user = subq_52.user
+            subq_64.user = subq_67.user
           ) AND (
-            (subq_49.ds__day <= subq_52.ds__day)
+            (subq_64.ds__day <= subq_67.ds__day)
           )
-      ) subq_53
+      ) subq_68
       GROUP BY
         user
-    ) subq_56
+    ) subq_71
     ON
-      subq_46.user = subq_56.user
+      subq_61.user = subq_71.user
     GROUP BY
       user
-  ) subq_57
+  ) subq_72
   ON
-    subq_42.user = subq_57.user
-) subq_61
+    subq_57.user = subq_72.user
+) subq_76
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_41.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_30.listings AS listings
+    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_39.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_39
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listing__user
-  ) subq_41
+  ) subq_50
   ON
-    subq_30.user = subq_41.listing__user
-) subq_43
+    subq_39.user = subq_50.listing__user
+) subq_52
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_58.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_53.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_53
+    ) subq_71
     ON
       (
-        account_month_txns_src_22000.account_id = subq_53.account_id
+        account_month_txns_src_22000.account_id = subq_71.account_id
       ) AND (
-        DATETIME_TRUNC(account_month_txns_src_22000.ds_partitioned, day) = subq_53.ds_partitioned__day
+        DATETIME_TRUNC(account_month_txns_src_22000.ds_partitioned, day) = subq_71.ds_partitioned__day
       )
     GROUP BY
       account_id__customer_id__customer_third_hop_id
-  ) subq_58
+  ) subq_76
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_58.account_id__customer_id__customer_third_hop_id
-) subq_60
+    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
+) subq_78
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_37.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_30
+      ) subq_39
       WHERE customer_id__country = 'paraguay'
-    ) subq_32
+    ) subq_41
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_37
+  ) subq_46
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_37.customer_id__customer_third_hop_id
-) subq_39
+    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
+) subq_48
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_26.listing__bookers AS listing__bookers
-    , subq_20.bookers AS bookers
+    subq_30.listing__bookers AS listing__bookers
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_20.metric_time__day AS metric_time__day
-    , subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_24.metric_time__day AS metric_time__day
+    , subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_26.user__revenue_all_time AS user__revenue_all_time
-    , subq_20.listings AS listings
+    subq_30.user__revenue_all_time AS user__revenue_all_time
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.user = subq_26.user
-) subq_28
+    subq_24.user = subq_30.user
+) subq_32
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_47.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_34.listings AS listings
+    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_39.listing, subq_44.listing) AS listing
-        , MAX(subq_39.booking_value) AS booking_value
-        , MAX(subq_44.views) AS views
+        COALESCE(subq_50.listing, subq_55.listing) AS listing
+        , MAX(subq_50.booking_value) AS booking_value
+        , MAX(subq_55.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing
-      ) subq_39
+      ) subq_50
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_42
+        ) subq_53
         GROUP BY
           listing
-      ) subq_44
+      ) subq_55
       ON
-        subq_39.listing = subq_44.listing
+        subq_50.listing = subq_55.listing
       GROUP BY
         listing
-    ) subq_45
-  ) subq_47
+    ) subq_56
+  ) subq_58
   ON
-    subq_34.listing = subq_47.listing
-) subq_49
+    subq_45.listing = subq_58.listing
+) subq_60
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_36.listing__bookings AS listing__bookings
-    , subq_42.listing__bookers AS listing__bookers
-    , subq_30.listings AS listings
+    subq_44.listing__bookings AS listing__bookings
+    , subq_50.listing__bookers AS listing__bookers
+    , subq_38.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_38
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_33
+    ) subq_41
     GROUP BY
       listing
-  ) subq_36
+  ) subq_44
   ON
-    subq_30.listing = subq_36.listing
+    subq_38.listing = subq_44.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing
-  ) subq_42
+  ) subq_50
   ON
-    subq_30.listing = subq_42.listing
-) subq_44
+    subq_38.listing = subq_50.listing
+) subq_52
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_45.bookings AS FLOAT64) / CAST(NULLIF(subq_45.bookers, 0) AS FLOAT64) AS listing__bookings_per_booker
-    , subq_34.listings AS listings
+    CAST(subq_56.bookings AS FLOAT64) / CAST(NULLIF(subq_56.bookers, 0) AS FLOAT64) AS listing__bookings_per_booker
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_39.listing, subq_44.listing) AS listing
-      , MAX(subq_39.bookings) AS bookings
-      , MAX(subq_44.bookers) AS bookers
+      COALESCE(subq_50.listing, subq_55.listing) AS listing
+      , MAX(subq_50.bookings) AS bookings
+      , MAX(subq_55.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_37
+      ) subq_48
       GROUP BY
         listing
-    ) subq_39
+    ) subq_50
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing
-    ) subq_44
+    ) subq_55
     ON
-      subq_39.listing = subq_44.listing
+      subq_50.listing = subq_55.listing
     GROUP BY
       listing
-  ) subq_45
+  ) subq_56
   ON
-    subq_34.listing = subq_45.listing
-) subq_49
+    subq_45.listing = subq_56.listing
+) subq_60
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_26.guest__booking_value AS guest__booking_value
-    , subq_20.bookers AS bookers
+    subq_30.guest__booking_value AS guest__booking_value
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.guest = subq_26.guest
-) subq_28
+    subq_24.guest = subq_30.guest
+) subq_32
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_57.buys AS DOUBLE) / CAST(NULLIF(subq_57.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
-    , subq_42.listings AS listings
+    CAST(subq_72.buys AS DOUBLE) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    , subq_57.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_42
+  ) subq_57
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_46.user, subq_56.user) AS user
-      , MAX(subq_46.visits) AS visits
-      , MAX(subq_56.buys) AS buys
+      COALESCE(subq_61.user, subq_71.user) AS user
+      , MAX(subq_61.visits) AS visits
+      , MAX(subq_71.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_45.user
+        subq_60.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_45
+      ) subq_60
       GROUP BY
-        subq_45.user
-    ) subq_46
+        subq_60.user
+    ) subq_61
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_53.user
+        subq_68.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_49.visits) OVER (
+          FIRST_VALUE(subq_64.visits) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_64.ds__day) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_49.user) OVER (
+          , FIRST_VALUE(subq_64.user) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_52.mf_internal_uuid AS mf_internal_uuid
-          , subq_52.buys AS buys
+          , subq_67.mf_internal_uuid AS mf_internal_uuid
+          , subq_67.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_49
+        ) subq_64
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_52
+        ) subq_67
         ON
           (
-            subq_49.user = subq_52.user
+            subq_64.user = subq_67.user
           ) AND (
-            (subq_49.ds__day <= subq_52.ds__day)
+            (subq_64.ds__day <= subq_67.ds__day)
           )
-      ) subq_53
+      ) subq_68
       GROUP BY
-        subq_53.user
-    ) subq_56
+        subq_68.user
+    ) subq_71
     ON
-      subq_46.user = subq_56.user
+      subq_61.user = subq_71.user
     GROUP BY
-      COALESCE(subq_46.user, subq_56.user)
-  ) subq_57
+      COALESCE(subq_61.user, subq_71.user)
+  ) subq_72
   ON
-    subq_42.user = subq_57.user
-) subq_61
+    subq_57.user = subq_72.user
+) subq_76
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_41.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_30.listings AS listings
+    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_39.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_39
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_41
+  ) subq_50
   ON
-    subq_30.user = subq_41.listing__user
-) subq_43
+    subq_39.user = subq_50.listing__user
+) subq_52
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_58.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_53.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_53
+    ) subq_71
     ON
       (
-        account_month_txns_src_22000.account_id = subq_53.account_id
+        account_month_txns_src_22000.account_id = subq_71.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_53.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
       )
     GROUP BY
-      subq_53.customer_id__customer_third_hop_id
-  ) subq_58
+      subq_71.customer_id__customer_third_hop_id
+  ) subq_76
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_58.account_id__customer_id__customer_third_hop_id
-) subq_60
+    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
+) subq_78
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_37.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_30
+      ) subq_39
       WHERE customer_id__country = 'paraguay'
-    ) subq_32
+    ) subq_41
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_37
+  ) subq_46
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_37.customer_id__customer_third_hop_id
-) subq_39
+    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
+) subq_48
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_26.listing__bookers AS listing__bookers
-    , subq_20.bookers AS bookers
+    subq_30.listing__bookers AS listing__bookers
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_20.metric_time__day AS metric_time__day
-    , subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_24.metric_time__day AS metric_time__day
+    , subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_26.user__revenue_all_time AS user__revenue_all_time
-    , subq_20.listings AS listings
+    subq_30.user__revenue_all_time AS user__revenue_all_time
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.user = subq_26.user
-) subq_28
+    subq_24.user = subq_30.user
+) subq_32
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_47.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_34.listings AS listings
+    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_39.listing, subq_44.listing) AS listing
-        , MAX(subq_39.booking_value) AS booking_value
-        , MAX(subq_44.views) AS views
+        COALESCE(subq_50.listing, subq_55.listing) AS listing
+        , MAX(subq_50.booking_value) AS booking_value
+        , MAX(subq_55.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_39
+      ) subq_50
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_42
+        ) subq_53
         GROUP BY
           listing
-      ) subq_44
+      ) subq_55
       ON
-        subq_39.listing = subq_44.listing
+        subq_50.listing = subq_55.listing
       GROUP BY
-        COALESCE(subq_39.listing, subq_44.listing)
-    ) subq_45
-  ) subq_47
+        COALESCE(subq_50.listing, subq_55.listing)
+    ) subq_56
+  ) subq_58
   ON
-    subq_34.listing = subq_47.listing
-) subq_49
+    subq_45.listing = subq_58.listing
+) subq_60
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_36.listing__bookings AS listing__bookings
-    , subq_42.listing__bookers AS listing__bookers
-    , subq_30.listings AS listings
+    subq_44.listing__bookings AS listing__bookings
+    , subq_50.listing__bookers AS listing__bookers
+    , subq_38.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_38
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_33
+    ) subq_41
     GROUP BY
       listing
-  ) subq_36
+  ) subq_44
   ON
-    subq_30.listing = subq_36.listing
+    subq_38.listing = subq_44.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_42
+  ) subq_50
   ON
-    subq_30.listing = subq_42.listing
-) subq_44
+    subq_38.listing = subq_50.listing
+) subq_52
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_45.bookings AS DOUBLE) / CAST(NULLIF(subq_45.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
-    , subq_34.listings AS listings
+    CAST(subq_56.bookings AS DOUBLE) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_39.listing, subq_44.listing) AS listing
-      , MAX(subq_39.bookings) AS bookings
-      , MAX(subq_44.bookers) AS bookers
+      COALESCE(subq_50.listing, subq_55.listing) AS listing
+      , MAX(subq_50.bookings) AS bookings
+      , MAX(subq_55.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_37
+      ) subq_48
       GROUP BY
         listing
-    ) subq_39
+    ) subq_50
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_44
+    ) subq_55
     ON
-      subq_39.listing = subq_44.listing
+      subq_50.listing = subq_55.listing
     GROUP BY
-      COALESCE(subq_39.listing, subq_44.listing)
-  ) subq_45
+      COALESCE(subq_50.listing, subq_55.listing)
+  ) subq_56
   ON
-    subq_34.listing = subq_45.listing
-) subq_49
+    subq_45.listing = subq_56.listing
+) subq_60
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_26.guest__booking_value AS guest__booking_value
-    , subq_20.bookers AS bookers
+    subq_30.guest__booking_value AS guest__booking_value
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.guest = subq_26.guest
-) subq_28
+    subq_24.guest = subq_30.guest
+) subq_32
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_57.buys AS DOUBLE) / CAST(NULLIF(subq_57.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
-    , subq_42.listings AS listings
+    CAST(subq_72.buys AS DOUBLE) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    , subq_57.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_42
+  ) subq_57
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_46.user, subq_56.user) AS user
-      , MAX(subq_46.visits) AS visits
-      , MAX(subq_56.buys) AS buys
+      COALESCE(subq_61.user, subq_71.user) AS user
+      , MAX(subq_61.visits) AS visits
+      , MAX(subq_71.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_45.user
+        subq_60.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_45
+      ) subq_60
       GROUP BY
-        subq_45.user
-    ) subq_46
+        subq_60.user
+    ) subq_61
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_53.user
+        subq_68.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_49.visits) OVER (
+          FIRST_VALUE(subq_64.visits) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_64.ds__day) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_49.user) OVER (
+          , FIRST_VALUE(subq_64.user) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_52.mf_internal_uuid AS mf_internal_uuid
-          , subq_52.buys AS buys
+          , subq_67.mf_internal_uuid AS mf_internal_uuid
+          , subq_67.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_49
+        ) subq_64
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , GEN_RANDOM_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_52
+        ) subq_67
         ON
           (
-            subq_49.user = subq_52.user
+            subq_64.user = subq_67.user
           ) AND (
-            (subq_49.ds__day <= subq_52.ds__day)
+            (subq_64.ds__day <= subq_67.ds__day)
           )
-      ) subq_53
+      ) subq_68
       GROUP BY
-        subq_53.user
-    ) subq_56
+        subq_68.user
+    ) subq_71
     ON
-      subq_46.user = subq_56.user
+      subq_61.user = subq_71.user
     GROUP BY
-      COALESCE(subq_46.user, subq_56.user)
-  ) subq_57
+      COALESCE(subq_61.user, subq_71.user)
+  ) subq_72
   ON
-    subq_42.user = subq_57.user
-) subq_61
+    subq_57.user = subq_72.user
+) subq_76
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_41.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_30.listings AS listings
+    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_39.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_39
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_41
+  ) subq_50
   ON
-    subq_30.user = subq_41.listing__user
-) subq_43
+    subq_39.user = subq_50.listing__user
+) subq_52
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_58.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_53.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_53
+    ) subq_71
     ON
       (
-        account_month_txns_src_22000.account_id = subq_53.account_id
+        account_month_txns_src_22000.account_id = subq_71.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_53.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
       )
     GROUP BY
-      subq_53.customer_id__customer_third_hop_id
-  ) subq_58
+      subq_71.customer_id__customer_third_hop_id
+  ) subq_76
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_58.account_id__customer_id__customer_third_hop_id
-) subq_60
+    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
+) subq_78
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_37.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_30
+      ) subq_39
       WHERE customer_id__country = 'paraguay'
-    ) subq_32
+    ) subq_41
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_37
+  ) subq_46
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_37.customer_id__customer_third_hop_id
-) subq_39
+    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
+) subq_48
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_26.listing__bookers AS listing__bookers
-    , subq_20.bookers AS bookers
+    subq_30.listing__bookers AS listing__bookers
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_20.metric_time__day AS metric_time__day
-    , subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_24.metric_time__day AS metric_time__day
+    , subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_26.user__revenue_all_time AS user__revenue_all_time
-    , subq_20.listings AS listings
+    subq_30.user__revenue_all_time AS user__revenue_all_time
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.user = subq_26.user
-) subq_28
+    subq_24.user = subq_30.user
+) subq_32
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_47.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_34.listings AS listings
+    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_39.listing, subq_44.listing) AS listing
-        , MAX(subq_39.booking_value) AS booking_value
-        , MAX(subq_44.views) AS views
+        COALESCE(subq_50.listing, subq_55.listing) AS listing
+        , MAX(subq_50.booking_value) AS booking_value
+        , MAX(subq_55.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_39
+      ) subq_50
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_42
+        ) subq_53
         GROUP BY
           listing
-      ) subq_44
+      ) subq_55
       ON
-        subq_39.listing = subq_44.listing
+        subq_50.listing = subq_55.listing
       GROUP BY
-        COALESCE(subq_39.listing, subq_44.listing)
-    ) subq_45
-  ) subq_47
+        COALESCE(subq_50.listing, subq_55.listing)
+    ) subq_56
+  ) subq_58
   ON
-    subq_34.listing = subq_47.listing
-) subq_49
+    subq_45.listing = subq_58.listing
+) subq_60
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_36.listing__bookings AS listing__bookings
-    , subq_42.listing__bookers AS listing__bookers
-    , subq_30.listings AS listings
+    subq_44.listing__bookings AS listing__bookings
+    , subq_50.listing__bookers AS listing__bookers
+    , subq_38.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_38
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_33
+    ) subq_41
     GROUP BY
       listing
-  ) subq_36
+  ) subq_44
   ON
-    subq_30.listing = subq_36.listing
+    subq_38.listing = subq_44.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_42
+  ) subq_50
   ON
-    subq_30.listing = subq_42.listing
-) subq_44
+    subq_38.listing = subq_50.listing
+) subq_52
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_45.bookings AS DOUBLE) / CAST(NULLIF(subq_45.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
-    , subq_34.listings AS listings
+    CAST(subq_56.bookings AS DOUBLE) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_39.listing, subq_44.listing) AS listing
-      , MAX(subq_39.bookings) AS bookings
-      , MAX(subq_44.bookers) AS bookers
+      COALESCE(subq_50.listing, subq_55.listing) AS listing
+      , MAX(subq_50.bookings) AS bookings
+      , MAX(subq_55.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_37
+      ) subq_48
       GROUP BY
         listing
-    ) subq_39
+    ) subq_50
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_44
+    ) subq_55
     ON
-      subq_39.listing = subq_44.listing
+      subq_50.listing = subq_55.listing
     GROUP BY
-      COALESCE(subq_39.listing, subq_44.listing)
-  ) subq_45
+      COALESCE(subq_50.listing, subq_55.listing)
+  ) subq_56
   ON
-    subq_34.listing = subq_45.listing
-) subq_49
+    subq_45.listing = subq_56.listing
+) subq_60
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_26.guest__booking_value AS guest__booking_value
-    , subq_20.bookers AS bookers
+    subq_30.guest__booking_value AS guest__booking_value
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.guest = subq_26.guest
-) subq_28
+    subq_24.guest = subq_30.guest
+) subq_32
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_57.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_57.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
-    , subq_42.listings AS listings
+    CAST(subq_72.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
+    , subq_57.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_42
+  ) subq_57
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_46.user, subq_56.user) AS user
-      , MAX(subq_46.visits) AS visits
-      , MAX(subq_56.buys) AS buys
+      COALESCE(subq_61.user, subq_71.user) AS user
+      , MAX(subq_61.visits) AS visits
+      , MAX(subq_71.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_45.user
+        subq_60.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_45
+      ) subq_60
       GROUP BY
-        subq_45.user
-    ) subq_46
+        subq_60.user
+    ) subq_61
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_53.user
+        subq_68.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_49.visits) OVER (
+          FIRST_VALUE(subq_64.visits) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_64.ds__day) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_49.user) OVER (
+          , FIRST_VALUE(subq_64.user) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_52.mf_internal_uuid AS mf_internal_uuid
-          , subq_52.buys AS buys
+          , subq_67.mf_internal_uuid AS mf_internal_uuid
+          , subq_67.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_49
+        ) subq_64
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , GEN_RANDOM_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_52
+        ) subq_67
         ON
           (
-            subq_49.user = subq_52.user
+            subq_64.user = subq_67.user
           ) AND (
-            (subq_49.ds__day <= subq_52.ds__day)
+            (subq_64.ds__day <= subq_67.ds__day)
           )
-      ) subq_53
+      ) subq_68
       GROUP BY
-        subq_53.user
-    ) subq_56
+        subq_68.user
+    ) subq_71
     ON
-      subq_46.user = subq_56.user
+      subq_61.user = subq_71.user
     GROUP BY
-      COALESCE(subq_46.user, subq_56.user)
-  ) subq_57
+      COALESCE(subq_61.user, subq_71.user)
+  ) subq_72
   ON
-    subq_42.user = subq_57.user
-) subq_61
+    subq_57.user = subq_72.user
+) subq_76
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_41.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_30.listings AS listings
+    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_39.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_39
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_41
+  ) subq_50
   ON
-    subq_30.user = subq_41.listing__user
-) subq_43
+    subq_39.user = subq_50.listing__user
+) subq_52
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_58.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_53.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_53
+    ) subq_71
     ON
       (
-        account_month_txns_src_22000.account_id = subq_53.account_id
+        account_month_txns_src_22000.account_id = subq_71.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_53.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
       )
     GROUP BY
-      subq_53.customer_id__customer_third_hop_id
-  ) subq_58
+      subq_71.customer_id__customer_third_hop_id
+  ) subq_76
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_58.account_id__customer_id__customer_third_hop_id
-) subq_60
+    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
+) subq_78
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_37.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_30
+      ) subq_39
       WHERE customer_id__country = 'paraguay'
-    ) subq_32
+    ) subq_41
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_37
+  ) subq_46
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_37.customer_id__customer_third_hop_id
-) subq_39
+    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
+) subq_48
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_26.listing__bookers AS listing__bookers
-    , subq_20.bookers AS bookers
+    subq_30.listing__bookers AS listing__bookers
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_20.metric_time__day AS metric_time__day
-    , subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_24.metric_time__day AS metric_time__day
+    , subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_26.user__revenue_all_time AS user__revenue_all_time
-    , subq_20.listings AS listings
+    subq_30.user__revenue_all_time AS user__revenue_all_time
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.user = subq_26.user
-) subq_28
+    subq_24.user = subq_30.user
+) subq_32
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_47.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_34.listings AS listings
+    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_39.listing, subq_44.listing) AS listing
-        , MAX(subq_39.booking_value) AS booking_value
-        , MAX(subq_44.views) AS views
+        COALESCE(subq_50.listing, subq_55.listing) AS listing
+        , MAX(subq_50.booking_value) AS booking_value
+        , MAX(subq_55.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_39
+      ) subq_50
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_42
+        ) subq_53
         GROUP BY
           listing
-      ) subq_44
+      ) subq_55
       ON
-        subq_39.listing = subq_44.listing
+        subq_50.listing = subq_55.listing
       GROUP BY
-        COALESCE(subq_39.listing, subq_44.listing)
-    ) subq_45
-  ) subq_47
+        COALESCE(subq_50.listing, subq_55.listing)
+    ) subq_56
+  ) subq_58
   ON
-    subq_34.listing = subq_47.listing
-) subq_49
+    subq_45.listing = subq_58.listing
+) subq_60
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_36.listing__bookings AS listing__bookings
-    , subq_42.listing__bookers AS listing__bookers
-    , subq_30.listings AS listings
+    subq_44.listing__bookings AS listing__bookings
+    , subq_50.listing__bookers AS listing__bookers
+    , subq_38.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_38
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_33
+    ) subq_41
     GROUP BY
       listing
-  ) subq_36
+  ) subq_44
   ON
-    subq_30.listing = subq_36.listing
+    subq_38.listing = subq_44.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_42
+  ) subq_50
   ON
-    subq_30.listing = subq_42.listing
-) subq_44
+    subq_38.listing = subq_50.listing
+) subq_52
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_45.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_45.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
-    , subq_34.listings AS listings
+    CAST(subq_56.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_39.listing, subq_44.listing) AS listing
-      , MAX(subq_39.bookings) AS bookings
-      , MAX(subq_44.bookers) AS bookers
+      COALESCE(subq_50.listing, subq_55.listing) AS listing
+      , MAX(subq_50.bookings) AS bookings
+      , MAX(subq_55.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_37
+      ) subq_48
       GROUP BY
         listing
-    ) subq_39
+    ) subq_50
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_44
+    ) subq_55
     ON
-      subq_39.listing = subq_44.listing
+      subq_50.listing = subq_55.listing
     GROUP BY
-      COALESCE(subq_39.listing, subq_44.listing)
-  ) subq_45
+      COALESCE(subq_50.listing, subq_55.listing)
+  ) subq_56
   ON
-    subq_34.listing = subq_45.listing
-) subq_49
+    subq_45.listing = subq_56.listing
+) subq_60
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_26.guest__booking_value AS guest__booking_value
-    , subq_20.bookers AS bookers
+    subq_30.guest__booking_value AS guest__booking_value
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.guest = subq_26.guest
-) subq_28
+    subq_24.guest = subq_30.guest
+) subq_32
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_57.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_57.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
-    , subq_42.listings AS listings
+    CAST(subq_72.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE PRECISION) AS user__visit_buy_conversion_rate
+    , subq_57.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_42
+  ) subq_57
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_46.user, subq_56.user) AS user
-      , MAX(subq_46.visits) AS visits
-      , MAX(subq_56.buys) AS buys
+      COALESCE(subq_61.user, subq_71.user) AS user
+      , MAX(subq_61.visits) AS visits
+      , MAX(subq_71.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_45.user
+        subq_60.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_45
+      ) subq_60
       GROUP BY
-        subq_45.user
-    ) subq_46
+        subq_60.user
+    ) subq_61
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_53.user
+        subq_68.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_49.visits) OVER (
+          FIRST_VALUE(subq_64.visits) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_64.ds__day) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_49.user) OVER (
+          , FIRST_VALUE(subq_64.user) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_52.mf_internal_uuid AS mf_internal_uuid
-          , subq_52.buys AS buys
+          , subq_67.mf_internal_uuid AS mf_internal_uuid
+          , subq_67.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_49
+        ) subq_64
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_52
+        ) subq_67
         ON
           (
-            subq_49.user = subq_52.user
+            subq_64.user = subq_67.user
           ) AND (
-            (subq_49.ds__day <= subq_52.ds__day)
+            (subq_64.ds__day <= subq_67.ds__day)
           )
-      ) subq_53
+      ) subq_68
       GROUP BY
-        subq_53.user
-    ) subq_56
+        subq_68.user
+    ) subq_71
     ON
-      subq_46.user = subq_56.user
+      subq_61.user = subq_71.user
     GROUP BY
-      COALESCE(subq_46.user, subq_56.user)
-  ) subq_57
+      COALESCE(subq_61.user, subq_71.user)
+  ) subq_72
   ON
-    subq_42.user = subq_57.user
-) subq_61
+    subq_57.user = subq_72.user
+) subq_76
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_41.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_30.listings AS listings
+    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_39.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_39
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_41
+  ) subq_50
   ON
-    subq_30.user = subq_41.listing__user
-) subq_43
+    subq_39.user = subq_50.listing__user
+) subq_52
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_58.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_53.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_53
+    ) subq_71
     ON
       (
-        account_month_txns_src_22000.account_id = subq_53.account_id
+        account_month_txns_src_22000.account_id = subq_71.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_53.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
       )
     GROUP BY
-      subq_53.customer_id__customer_third_hop_id
-  ) subq_58
+      subq_71.customer_id__customer_third_hop_id
+  ) subq_76
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_58.account_id__customer_id__customer_third_hop_id
-) subq_60
+    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
+) subq_78
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_37.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_30
+      ) subq_39
       WHERE customer_id__country = 'paraguay'
-    ) subq_32
+    ) subq_41
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_37
+  ) subq_46
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_37.customer_id__customer_third_hop_id
-) subq_39
+    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
+) subq_48
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_26.listing__bookers AS listing__bookers
-    , subq_20.bookers AS bookers
+    subq_30.listing__bookers AS listing__bookers
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_20.metric_time__day AS metric_time__day
-    , subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_24.metric_time__day AS metric_time__day
+    , subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_26.user__revenue_all_time AS user__revenue_all_time
-    , subq_20.listings AS listings
+    subq_30.user__revenue_all_time AS user__revenue_all_time
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.user = subq_26.user
-) subq_28
+    subq_24.user = subq_30.user
+) subq_32
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_47.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_34.listings AS listings
+    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_39.listing, subq_44.listing) AS listing
-        , MAX(subq_39.booking_value) AS booking_value
-        , MAX(subq_44.views) AS views
+        COALESCE(subq_50.listing, subq_55.listing) AS listing
+        , MAX(subq_50.booking_value) AS booking_value
+        , MAX(subq_55.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_39
+      ) subq_50
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_42
+        ) subq_53
         GROUP BY
           listing
-      ) subq_44
+      ) subq_55
       ON
-        subq_39.listing = subq_44.listing
+        subq_50.listing = subq_55.listing
       GROUP BY
-        COALESCE(subq_39.listing, subq_44.listing)
-    ) subq_45
-  ) subq_47
+        COALESCE(subq_50.listing, subq_55.listing)
+    ) subq_56
+  ) subq_58
   ON
-    subq_34.listing = subq_47.listing
-) subq_49
+    subq_45.listing = subq_58.listing
+) subq_60
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_36.listing__bookings AS listing__bookings
-    , subq_42.listing__bookers AS listing__bookers
-    , subq_30.listings AS listings
+    subq_44.listing__bookings AS listing__bookings
+    , subq_50.listing__bookers AS listing__bookers
+    , subq_38.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_38
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_33
+    ) subq_41
     GROUP BY
       listing
-  ) subq_36
+  ) subq_44
   ON
-    subq_30.listing = subq_36.listing
+    subq_38.listing = subq_44.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_42
+  ) subq_50
   ON
-    subq_30.listing = subq_42.listing
-) subq_44
+    subq_38.listing = subq_50.listing
+) subq_52
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_45.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_45.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
-    , subq_34.listings AS listings
+    CAST(subq_56.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_39.listing, subq_44.listing) AS listing
-      , MAX(subq_39.bookings) AS bookings
-      , MAX(subq_44.bookers) AS bookers
+      COALESCE(subq_50.listing, subq_55.listing) AS listing
+      , MAX(subq_50.bookings) AS bookings
+      , MAX(subq_55.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_37
+      ) subq_48
       GROUP BY
         listing
-    ) subq_39
+    ) subq_50
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_44
+    ) subq_55
     ON
-      subq_39.listing = subq_44.listing
+      subq_50.listing = subq_55.listing
     GROUP BY
-      COALESCE(subq_39.listing, subq_44.listing)
-  ) subq_45
+      COALESCE(subq_50.listing, subq_55.listing)
+  ) subq_56
   ON
-    subq_34.listing = subq_45.listing
-) subq_49
+    subq_45.listing = subq_56.listing
+) subq_60
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_26.guest__booking_value AS guest__booking_value
-    , subq_20.bookers AS bookers
+    subq_30.guest__booking_value AS guest__booking_value
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.guest = subq_26.guest
-) subq_28
+    subq_24.guest = subq_30.guest
+) subq_32
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_57.buys AS DOUBLE) / CAST(NULLIF(subq_57.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
-    , subq_42.listings AS listings
+    CAST(subq_72.buys AS DOUBLE) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    , subq_57.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_42
+  ) subq_57
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_46.user, subq_56.user) AS user
-      , MAX(subq_46.visits) AS visits
-      , MAX(subq_56.buys) AS buys
+      COALESCE(subq_61.user, subq_71.user) AS user
+      , MAX(subq_61.visits) AS visits
+      , MAX(subq_71.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_45.user
+        subq_60.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_45
+      ) subq_60
       GROUP BY
-        subq_45.user
-    ) subq_46
+        subq_60.user
+    ) subq_61
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_53.user
+        subq_68.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_49.visits) OVER (
+          FIRST_VALUE(subq_64.visits) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_64.ds__day) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_49.user) OVER (
+          , FIRST_VALUE(subq_64.user) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_52.mf_internal_uuid AS mf_internal_uuid
-          , subq_52.buys AS buys
+          , subq_67.mf_internal_uuid AS mf_internal_uuid
+          , subq_67.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_49
+        ) subq_64
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , UUID_STRING() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_52
+        ) subq_67
         ON
           (
-            subq_49.user = subq_52.user
+            subq_64.user = subq_67.user
           ) AND (
-            (subq_49.ds__day <= subq_52.ds__day)
+            (subq_64.ds__day <= subq_67.ds__day)
           )
-      ) subq_53
+      ) subq_68
       GROUP BY
-        subq_53.user
-    ) subq_56
+        subq_68.user
+    ) subq_71
     ON
-      subq_46.user = subq_56.user
+      subq_61.user = subq_71.user
     GROUP BY
-      COALESCE(subq_46.user, subq_56.user)
-  ) subq_57
+      COALESCE(subq_61.user, subq_71.user)
+  ) subq_72
   ON
-    subq_42.user = subq_57.user
-) subq_61
+    subq_57.user = subq_72.user
+) subq_76
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_41.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_30.listings AS listings
+    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_39.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_39
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_41
+  ) subq_50
   ON
-    subq_30.user = subq_41.listing__user
-) subq_43
+    subq_39.user = subq_50.listing__user
+) subq_52
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_58.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_53.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_53
+    ) subq_71
     ON
       (
-        account_month_txns_src_22000.account_id = subq_53.account_id
+        account_month_txns_src_22000.account_id = subq_71.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_53.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
       )
     GROUP BY
-      subq_53.customer_id__customer_third_hop_id
-  ) subq_58
+      subq_71.customer_id__customer_third_hop_id
+  ) subq_76
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_58.account_id__customer_id__customer_third_hop_id
-) subq_60
+    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
+) subq_78
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_37.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_30
+      ) subq_39
       WHERE customer_id__country = 'paraguay'
-    ) subq_32
+    ) subq_41
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_37
+  ) subq_46
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_37.customer_id__customer_third_hop_id
-) subq_39
+    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
+) subq_48
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_26.listing__bookers AS listing__bookers
-    , subq_20.bookers AS bookers
+    subq_30.listing__bookers AS listing__bookers
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_20.metric_time__day AS metric_time__day
-    , subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_24.metric_time__day AS metric_time__day
+    , subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_26.user__revenue_all_time AS user__revenue_all_time
-    , subq_20.listings AS listings
+    subq_30.user__revenue_all_time AS user__revenue_all_time
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.user = subq_26.user
-) subq_28
+    subq_24.user = subq_30.user
+) subq_32
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_47.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_34.listings AS listings
+    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_39.listing, subq_44.listing) AS listing
-        , MAX(subq_39.booking_value) AS booking_value
-        , MAX(subq_44.views) AS views
+        COALESCE(subq_50.listing, subq_55.listing) AS listing
+        , MAX(subq_50.booking_value) AS booking_value
+        , MAX(subq_55.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_39
+      ) subq_50
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_42
+        ) subq_53
         GROUP BY
           listing
-      ) subq_44
+      ) subq_55
       ON
-        subq_39.listing = subq_44.listing
+        subq_50.listing = subq_55.listing
       GROUP BY
-        COALESCE(subq_39.listing, subq_44.listing)
-    ) subq_45
-  ) subq_47
+        COALESCE(subq_50.listing, subq_55.listing)
+    ) subq_56
+  ) subq_58
   ON
-    subq_34.listing = subq_47.listing
-) subq_49
+    subq_45.listing = subq_58.listing
+) subq_60
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_36.listing__bookings AS listing__bookings
-    , subq_42.listing__bookers AS listing__bookers
-    , subq_30.listings AS listings
+    subq_44.listing__bookings AS listing__bookings
+    , subq_50.listing__bookers AS listing__bookers
+    , subq_38.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_38
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_33
+    ) subq_41
     GROUP BY
       listing
-  ) subq_36
+  ) subq_44
   ON
-    subq_30.listing = subq_36.listing
+    subq_38.listing = subq_44.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_42
+  ) subq_50
   ON
-    subq_30.listing = subq_42.listing
-) subq_44
+    subq_38.listing = subq_50.listing
+) subq_52
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_45.bookings AS DOUBLE) / CAST(NULLIF(subq_45.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
-    , subq_34.listings AS listings
+    CAST(subq_56.bookings AS DOUBLE) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_39.listing, subq_44.listing) AS listing
-      , MAX(subq_39.bookings) AS bookings
-      , MAX(subq_44.bookers) AS bookers
+      COALESCE(subq_50.listing, subq_55.listing) AS listing
+      , MAX(subq_50.bookings) AS bookings
+      , MAX(subq_55.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_37
+      ) subq_48
       GROUP BY
         listing
-    ) subq_39
+    ) subq_50
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_44
+    ) subq_55
     ON
-      subq_39.listing = subq_44.listing
+      subq_50.listing = subq_55.listing
     GROUP BY
-      COALESCE(subq_39.listing, subq_44.listing)
-  ) subq_45
+      COALESCE(subq_50.listing, subq_55.listing)
+  ) subq_56
   ON
-    subq_34.listing = subq_45.listing
-) subq_49
+    subq_45.listing = subq_56.listing
+) subq_60
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'guest__booking_value']
   SELECT
-    subq_26.guest__booking_value AS guest__booking_value
-    , subq_20.bookers AS bookers
+    subq_30.guest__booking_value AS guest__booking_value
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       guest_id AS guest
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       guest_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.guest = subq_26.guest
-) subq_28
+    subq_24.guest = subq_30.guest
+) subq_32
 WHERE guest__booking_value > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__visit_buy_conversion_rate']
   SELECT
-    CAST(subq_57.buys AS DOUBLE) / CAST(NULLIF(subq_57.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
-    , subq_42.listings AS listings
+    CAST(subq_72.buys AS DOUBLE) / CAST(NULLIF(subq_72.visits, 0) AS DOUBLE) AS user__visit_buy_conversion_rate
+    , subq_57.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,17 +18,17 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_42
+  ) subq_57
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_46.user, subq_56.user) AS user
-      , MAX(subq_46.visits) AS visits
-      , MAX(subq_56.buys) AS buys
+      COALESCE(subq_61.user, subq_71.user) AS user
+      , MAX(subq_61.visits) AS visits
+      , MAX(subq_71.buys) AS buys
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_45.user
+        subq_60.user
         , SUM(visits) AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
@@ -38,46 +38,46 @@ FROM (
           user_id AS user
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_45
+      ) subq_60
       GROUP BY
-        subq_45.user
-    ) subq_46
+        subq_60.user
+    ) subq_61
     FULL OUTER JOIN (
       -- Find conversions for user within the range of INF
       -- Pass Only Elements: ['buys', 'user']
       -- Aggregate Measures
       SELECT
-        subq_53.user
+        subq_68.user
         , SUM(buys) AS buys
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_49.visits) OVER (
+          FIRST_VALUE(subq_64.visits) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_64.ds__day) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , FIRST_VALUE(subq_49.user) OVER (
+          , FIRST_VALUE(subq_64.user) OVER (
             PARTITION BY
-              subq_52.user
-              , subq_52.ds__day
-              , subq_52.mf_internal_uuid
-            ORDER BY subq_49.ds__day DESC
+              subq_67.user
+              , subq_67.ds__day
+              , subq_67.mf_internal_uuid
+            ORDER BY subq_64.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_52.mf_internal_uuid AS mf_internal_uuid
-          , subq_52.buys AS buys
+          , subq_67.mf_internal_uuid AS mf_internal_uuid
+          , subq_67.buys AS buys
         FROM (
           -- Read Elements From Semantic Model 'visits_source'
           -- Metric Time Dimension 'ds'
@@ -87,7 +87,7 @@ FROM (
             , user_id AS user
             , 1 AS visits
           FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_49
+        ) subq_64
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -98,23 +98,23 @@ FROM (
             , 1 AS buys
             , uuid() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_52
+        ) subq_67
         ON
           (
-            subq_49.user = subq_52.user
+            subq_64.user = subq_67.user
           ) AND (
-            (subq_49.ds__day <= subq_52.ds__day)
+            (subq_64.ds__day <= subq_67.ds__day)
           )
-      ) subq_53
+      ) subq_68
       GROUP BY
-        subq_53.user
-    ) subq_56
+        subq_68.user
+    ) subq_71
     ON
-      subq_46.user = subq_56.user
+      subq_61.user = subq_71.user
     GROUP BY
-      COALESCE(subq_46.user, subq_56.user)
-  ) subq_57
+      COALESCE(subq_61.user, subq_71.user)
+  ) subq_72
   ON
-    subq_42.user = subq_57.user
-) subq_61
+    subq_57.user = subq_72.user
+) subq_76
 WHERE user__visit_buy_conversion_rate > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_group_by_has_local_entity_prefix__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_group_by_has_local_entity_prefix__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__listing__user__average_booking_value']
   SELECT
-    subq_41.listing__user__average_booking_value AS user__listing__user__average_booking_value
-    , subq_30.listings AS listings
+    subq_50.listing__user__average_booking_value AS user__listing__user__average_booking_value
+    , subq_39.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_39
   LEFT OUTER JOIN (
     -- Join Standard Outputs
     -- Pass Only Elements: ['average_booking_value', 'listing__user']
@@ -35,8 +35,8 @@ FROM (
       bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
     GROUP BY
       listings_latest_src_28000.user_id
-  ) subq_41
+  ) subq_50
   ON
-    subq_30.user = subq_41.listing__user
-) subq_43
+    subq_39.user = subq_50.listing__user
+) subq_52
 WHERE user__listing__user__average_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_multi_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_multi_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count']
   SELECT
-    subq_58.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+    subq_76.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -18,7 +18,7 @@ FROM (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['account_id__customer_id__customer_third_hop_id', 'account_id__customer_id__customer_third_hop_id__txn_count']
     SELECT
-      subq_53.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+      subq_71.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
       , SUM(account_month_txns_src_22000.txn_count) AS account_id__customer_id__customer_third_hop_id__txn_count
     FROM ***************************.account_month_txns account_month_txns_src_22000
     LEFT OUTER JOIN (
@@ -33,17 +33,17 @@ FROM (
         ***************************.customer_other_data customer_other_data_src_22000
       ON
         bridge_table_src_22000.customer_id = customer_other_data_src_22000.customer_id
-    ) subq_53
+    ) subq_71
     ON
       (
-        account_month_txns_src_22000.account_id = subq_53.account_id
+        account_month_txns_src_22000.account_id = subq_71.account_id
       ) AND (
-        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_53.ds_partitioned__day
+        DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_71.ds_partitioned__day
       )
     GROUP BY
-      subq_53.customer_id__customer_third_hop_id
-  ) subq_58
+      subq_71.customer_id__customer_third_hop_id
+  ) subq_76
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_58.account_id__customer_id__customer_third_hop_id
-) subq_60
+    third_hop_table_src_22000.customer_third_hop_id = subq_76.account_id__customer_id__customer_third_hop_id
+) subq_78
 WHERE customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count > 2

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_37.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_46.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_30
+      ) subq_39
       WHERE customer_id__country = 'paraguay'
-    ) subq_32
+    ) subq_41
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_37
+  ) subq_46
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_37.customer_id__customer_third_hop_id
-) subq_39
+    third_hop_table_src_22000.customer_third_hop_id = subq_46.customer_id__customer_third_hop_id
+) subq_48
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_filtered_by_itself__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_filtered_by_itself__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookers', 'listing__bookers']
   SELECT
-    subq_26.listing__bookers AS listing__bookers
-    , subq_20.bookers AS bookers
+    subq_30.listing__bookers AS listing__bookers
+    , subq_24.bookers AS bookers
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , guest_id AS bookers
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookers > 1.00

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_with_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_with_metric_in_where_filter__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'metric_time__day', 'listing__bookings']
   SELECT
-    subq_20.metric_time__day AS metric_time__day
-    , subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_24.metric_time__day AS metric_time__day
+    , subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -21,7 +21,7 @@ FROM (
       , listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -37,13 +37,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__revenue_all_time']
   SELECT
-    subq_26.user__revenue_all_time AS user__revenue_all_time
-    , subq_20.listings AS listings
+    subq_30.user__revenue_all_time AS user__revenue_all_time
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       user_id AS user
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'revenue'
     -- Metric Time Dimension 'ds'
@@ -32,8 +32,8 @@ FROM (
     FROM ***************************.fct_revenue revenue_src_28000
     GROUP BY
       user_id
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.user = subq_26.user
-) subq_28
+    subq_24.user = subq_30.user
+) subq_32
 WHERE user__revenue_all_time > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__views_times_booking_value']
   SELECT
-    subq_47.listing__views_times_booking_value AS listing__views_times_booking_value
-    , subq_34.listings AS listings
+    subq_58.listing__views_times_booking_value AS listing__views_times_booking_value
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Compute Metrics via Expressions
     -- Pass Only Elements: ['listing', 'listing__views_times_booking_value']
@@ -28,9 +28,9 @@ FROM (
     FROM (
       -- Combine Aggregated Outputs
       SELECT
-        COALESCE(subq_39.listing, subq_44.listing) AS listing
-        , MAX(subq_39.booking_value) AS booking_value
-        , MAX(subq_44.views) AS views
+        COALESCE(subq_50.listing, subq_55.listing) AS listing
+        , MAX(subq_50.booking_value) AS booking_value
+        , MAX(subq_55.views) AS views
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
@@ -43,7 +43,7 @@ FROM (
         FROM ***************************.fct_bookings bookings_source_src_28000
         GROUP BY
           listing_id
-      ) subq_39
+      ) subq_50
       FULL OUTER JOIN (
         -- Aggregate Measures
         -- Compute Metrics via Expressions
@@ -58,17 +58,17 @@ FROM (
             listing_id AS listing
             , 1 AS views
           FROM ***************************.fct_views views_source_src_28000
-        ) subq_42
+        ) subq_53
         GROUP BY
           listing
-      ) subq_44
+      ) subq_55
       ON
-        subq_39.listing = subq_44.listing
+        subq_50.listing = subq_55.listing
       GROUP BY
-        COALESCE(subq_39.listing, subq_44.listing)
-    ) subq_45
-  ) subq_47
+        COALESCE(subq_50.listing, subq_55.listing)
+    ) subq_56
+  ) subq_58
   ON
-    subq_34.listing = subq_47.listing
-) subq_49
+    subq_45.listing = subq_58.listing
+) subq_60
 WHERE listing__views_times_booking_value > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings', 'listing__bookers']
   SELECT
-    subq_36.listing__bookings AS listing__bookings
-    , subq_42.listing__bookers AS listing__bookers
-    , subq_30.listings AS listings
+    subq_44.listing__bookings AS listing__bookings
+    , subq_50.listing__bookers AS listing__bookers
+    , subq_38.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -19,7 +19,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_30
+  ) subq_38
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -35,12 +35,12 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_33
+    ) subq_41
     GROUP BY
       listing
-  ) subq_36
+  ) subq_44
   ON
-    subq_30.listing = subq_36.listing
+    subq_38.listing = subq_44.listing
   LEFT OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -54,8 +54,8 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       listing_id
-  ) subq_42
+  ) subq_50
   ON
-    subq_30.listing = subq_42.listing
-) subq_44
+    subq_38.listing = subq_50.listing
+) subq_52
 WHERE listing__bookings > 2 AND listing__bookers > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_45.bookings AS DOUBLE) / CAST(NULLIF(subq_45.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
-    , subq_34.listings AS listings
+    CAST(subq_56.bookings AS DOUBLE) / CAST(NULLIF(subq_56.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    , subq_45.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,13 +18,13 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_34
+  ) subq_45
   LEFT OUTER JOIN (
     -- Combine Aggregated Outputs
     SELECT
-      COALESCE(subq_39.listing, subq_44.listing) AS listing
-      , MAX(subq_39.bookings) AS bookings
-      , MAX(subq_44.bookers) AS bookers
+      COALESCE(subq_50.listing, subq_55.listing) AS listing
+      , MAX(subq_50.bookings) AS bookings
+      , MAX(subq_55.bookers) AS bookers
     FROM (
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -39,10 +39,10 @@ FROM (
           listing_id AS listing
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_37
+      ) subq_48
       GROUP BY
         listing
-    ) subq_39
+    ) subq_50
     FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
@@ -55,13 +55,13 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
       GROUP BY
         listing_id
-    ) subq_44
+    ) subq_55
     ON
-      subq_39.listing = subq_44.listing
+      subq_50.listing = subq_55.listing
     GROUP BY
-      COALESCE(subq_39.listing, subq_44.listing)
-  ) subq_45
+      COALESCE(subq_50.listing, subq_55.listing)
+  ) subq_56
   ON
-    subq_34.listing = subq_45.listing
-) subq_49
+    subq_45.listing = subq_56.listing
+) subq_60
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0_optimized.sql
@@ -8,8 +8,8 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings']
   SELECT
-    subq_26.listing__bookings AS listing__bookings
-    , subq_20.listings AS listings
+    subq_30.listing__bookings AS listing__bookings
+    , subq_24.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
@@ -18,7 +18,7 @@ FROM (
       listing_id AS listing
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_20
+  ) subq_24
   LEFT OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -34,11 +34,11 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_23
+    ) subq_27
     GROUP BY
       listing
-  ) subq_26
+  ) subq_30
   ON
-    subq_20.listing = subq_26.listing
-) subq_28
+    subq_24.listing = subq_30.listing
+) subq_32
 WHERE listing__bookings > 2

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.average_booking_value) AS average_booking_value
-    , MAX(subq_28.max_booking_value) AS max_booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.average_booking_value) AS average_booking_value
+    , MAX(subq_30.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       metric_time__day
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
     metric_time__day
-) subq_29
+) subq_31

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_16.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_16.listing__capacity_latest AS listing__capacity_latest
+    subq_18.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_18.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_16.listings AS listings
+    , subq_18.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_14.user
+      subq_16.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_14
+    ) subq_16
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_16.user = users_latest_src_28000.user_id
-) subq_20
+    subq_18.user = users_latest_src_28000.user_id
+) subq_22
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_17.booking__is_instant AS booking__is_instant
+    subq_19.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_17.bookings AS bookings
+    , subq_19.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
-  ) subq_17
+  ) subq_19
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_17.listing = listings_latest_src_28000.listing_id
-) subq_22
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.average_booking_value) AS average_booking_value
-    , MAX(subq_28.max_booking_value) AS max_booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.average_booking_value) AS average_booking_value
+    , MAX(subq_30.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_16.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_16.listing__capacity_latest AS listing__capacity_latest
+    subq_18.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_18.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_16.listings AS listings
+    , subq_18.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_14.user
+      subq_16.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_14
+    ) subq_16
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_16.user = users_latest_src_28000.user_id
-) subq_20
+    subq_18.user = users_latest_src_28000.user_id
+) subq_22
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_17.booking__is_instant AS booking__is_instant
+    subq_19.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_17.bookings AS bookings
+    , subq_19.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
-  ) subq_17
+  ) subq_19
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_17.listing = listings_latest_src_28000.listing_id
-) subq_22
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.average_booking_value) AS average_booking_value
-    , MAX(subq_28.max_booking_value) AS max_booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.average_booking_value) AS average_booking_value
+    , MAX(subq_30.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_16.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_16.listing__capacity_latest AS listing__capacity_latest
+    subq_18.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_18.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_16.listings AS listings
+    , subq_18.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_14.user
+      subq_16.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_14
+    ) subq_16
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_16.user = users_latest_src_28000.user_id
-) subq_20
+    subq_18.user = users_latest_src_28000.user_id
+) subq_22
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_17.booking__is_instant AS booking__is_instant
+    subq_19.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_17.bookings AS bookings
+    , subq_19.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
-  ) subq_17
+  ) subq_19
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_17.listing = listings_latest_src_28000.listing_id
-) subq_22
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.average_booking_value) AS average_booking_value
-    , MAX(subq_28.max_booking_value) AS max_booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.average_booking_value) AS average_booking_value
+    , MAX(subq_30.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_16.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_16.listing__capacity_latest AS listing__capacity_latest
+    subq_18.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_18.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_16.listings AS listings
+    , subq_18.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_14.user
+      subq_16.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_14
+    ) subq_16
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_16.user = users_latest_src_28000.user_id
-) subq_20
+    subq_18.user = users_latest_src_28000.user_id
+) subq_22
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_17.booking__is_instant AS booking__is_instant
+    subq_19.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_17.bookings AS bookings
+    , subq_19.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
-  ) subq_17
+  ) subq_19
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_17.listing = listings_latest_src_28000.listing_id
-) subq_22
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.average_booking_value) AS average_booking_value
-    , MAX(subq_28.max_booking_value) AS max_booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.average_booking_value) AS average_booking_value
+    , MAX(subq_30.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_16.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_16.listing__capacity_latest AS listing__capacity_latest
+    subq_18.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_18.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_16.listings AS listings
+    , subq_18.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_14.user
+      subq_16.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_14
+    ) subq_16
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_16.user = users_latest_src_28000.user_id
-) subq_20
+    subq_18.user = users_latest_src_28000.user_id
+) subq_22
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_17.booking__is_instant AS booking__is_instant
+    subq_19.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_17.bookings AS bookings
+    , subq_19.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
-  ) subq_17
+  ) subq_19
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_17.listing = listings_latest_src_28000.listing_id
-) subq_22
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.average_booking_value) AS average_booking_value
-    , MAX(subq_28.max_booking_value) AS max_booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.average_booking_value) AS average_booking_value
+    , MAX(subq_30.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_16.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_16.listing__capacity_latest AS listing__capacity_latest
+    subq_18.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_18.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_16.listings AS listings
+    , subq_18.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_14.user
+      subq_16.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_14
+    ) subq_16
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_16.user = users_latest_src_28000.user_id
-) subq_20
+    subq_18.user = users_latest_src_28000.user_id
+) subq_22
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_17.booking__is_instant AS booking__is_instant
+    subq_19.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_17.bookings AS bookings
+    , subq_19.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
-  ) subq_17
+  ) subq_19
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_17.listing = listings_latest_src_28000.listing_id
-) subq_22
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.average_booking_value) AS average_booking_value
-    , MAX(subq_28.max_booking_value) AS max_booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.average_booking_value) AS average_booking_value
+    , MAX(subq_30.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_16.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_16.listing__capacity_latest AS listing__capacity_latest
+    subq_18.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_18.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_16.listings AS listings
+    , subq_18.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_14.user
+      subq_16.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_14
+    ) subq_16
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_16.user = users_latest_src_28000.user_id
-) subq_20
+    subq_18.user = users_latest_src_28000.user_id
+) subq_22
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_17.booking__is_instant AS booking__is_instant
+    subq_19.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_17.bookings AS bookings
+    , subq_19.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
-  ) subq_17
+  ) subq_19
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_17.listing = listings_latest_src_28000.listing_id
-) subq_22
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_28.booking_value) AS booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_30.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       metric_time__day
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
     metric_time__day
-) subq_29
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_11
+    ) subq_13
     WHERE NOT booking__is_instant
-  ) subq_13
+  ) subq_15
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_17
+) subq_19

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_24.metric_time__day AS metric_time__day
-  , subq_29.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_24.bookings) AS bookings
+  subq_35.metric_time__day AS metric_time__day
+  , subq_40.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_35.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_24
+) subq_35
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,18 +29,18 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_29
+) subq_40
 ON
   (
-    subq_24.listing = subq_29.listing
+    subq_35.listing = subq_40.listing
   ) AND (
     (
-      subq_24.metric_time__day >= subq_29.window_start__day
+      subq_35.metric_time__day >= subq_40.window_start__day
     ) AND (
       (
-        subq_24.metric_time__day < subq_29.window_end__day
+        subq_35.metric_time__day < subq_40.window_end__day
       ) OR (
-        subq_29.window_end__day IS NULL
+        subq_40.window_end__day IS NULL
       )
     )
   )

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_16.bookings) AS bookings
+  subq_19.metric_time__day AS metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_19.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_16
+) subq_19
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,18 +29,18 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_21
+) subq_24
 ON
   (
-    subq_16.listing = subq_21.listing
+    subq_19.listing = subq_24.listing
   ) AND (
     (
-      subq_16.metric_time__day >= subq_21.lux_listing__window_start__day
+      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
     ) AND (
       (
-        subq_16.metric_time__day < subq_21.lux_listing__window_end__day
+        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
       ) OR (
-        subq_21.lux_listing__window_end__day IS NULL
+        subq_24.lux_listing__window_end__day IS NULL
       )
     )
   )

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATETIME_TRUNC(bridge_table_src_22000.ds_partitioned, day) = DATETIME_TRUNC(customer_table_src_22000.ds_partitioned, day)
     )
-) subq_27
+) subq_32
 ON
   (
-    account_month_txns_src_22000.account_id = subq_27.account_id
+    account_month_txns_src_22000.account_id = subq_32.account_id
   ) AND (
-    DATETIME_TRUNC(account_month_txns_src_22000.ds_partitioned, day) = subq_27.ds_partitioned__day
+    DATETIME_TRUNC(account_month_txns_src_22000.ds_partitioned, day) = subq_32.ds_partitioned__day
   )
 GROUP BY
   account_id__customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_21.bookings) AS bookings
-  , MAX(subq_27.listings) AS listings
+  MAX(subq_25.bookings) AS bookings
+  , MAX(subq_31.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_21
+) subq_25
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATETIME_TRUNC(created_at, day) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_27
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_28.booking_value) AS booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_30.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_11
+    ) subq_13
     WHERE NOT booking__is_instant
-  ) subq_13
+  ) subq_15
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_17
+) subq_19

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_24.metric_time__day AS metric_time__day
-  , subq_29.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_24.bookings) AS bookings
+  subq_35.metric_time__day AS metric_time__day
+  , subq_40.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_35.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_24
+) subq_35
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_29
+) subq_40
 ON
   (
-    subq_24.listing = subq_29.listing
+    subq_35.listing = subq_40.listing
   ) AND (
     (
-      subq_24.metric_time__day >= subq_29.window_start__day
+      subq_35.metric_time__day >= subq_40.window_start__day
     ) AND (
       (
-        subq_24.metric_time__day < subq_29.window_end__day
+        subq_35.metric_time__day < subq_40.window_end__day
       ) OR (
-        subq_29.window_end__day IS NULL
+        subq_40.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_24.metric_time__day
-  , subq_29.user__home_state_latest
+  subq_35.metric_time__day
+  , subq_40.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_16.bookings) AS bookings
+  subq_19.metric_time__day AS metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_19.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_16
+) subq_19
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_21
+) subq_24
 ON
   (
-    subq_16.listing = subq_21.listing
+    subq_19.listing = subq_24.listing
   ) AND (
     (
-      subq_16.metric_time__day >= subq_21.lux_listing__window_start__day
+      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
     ) AND (
       (
-        subq_16.metric_time__day < subq_21.lux_listing__window_end__day
+        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
       ) OR (
-        subq_21.lux_listing__window_end__day IS NULL
+        subq_24.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_16.metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux
+  subq_19.metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_27
+) subq_32
 ON
   (
-    account_month_txns_src_22000.account_id = subq_27.account_id
+    account_month_txns_src_22000.account_id = subq_32.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_27.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
   )
 GROUP BY
-  subq_27.customer_id__customer_name
+  subq_32.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_21.bookings) AS bookings
-  , MAX(subq_27.listings) AS listings
+  MAX(subq_25.bookings) AS bookings
+  , MAX(subq_31.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_21
+) subq_25
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_27
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_28.booking_value) AS booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_30.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_11
+    ) subq_13
     WHERE NOT booking__is_instant
-  ) subq_13
+  ) subq_15
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_17
+) subq_19

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_24.metric_time__day AS metric_time__day
-  , subq_29.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_24.bookings) AS bookings
+  subq_35.metric_time__day AS metric_time__day
+  , subq_40.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_35.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_24
+) subq_35
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_29
+) subq_40
 ON
   (
-    subq_24.listing = subq_29.listing
+    subq_35.listing = subq_40.listing
   ) AND (
     (
-      subq_24.metric_time__day >= subq_29.window_start__day
+      subq_35.metric_time__day >= subq_40.window_start__day
     ) AND (
       (
-        subq_24.metric_time__day < subq_29.window_end__day
+        subq_35.metric_time__day < subq_40.window_end__day
       ) OR (
-        subq_29.window_end__day IS NULL
+        subq_40.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_24.metric_time__day
-  , subq_29.user__home_state_latest
+  subq_35.metric_time__day
+  , subq_40.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_16.bookings) AS bookings
+  subq_19.metric_time__day AS metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_19.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_16
+) subq_19
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_21
+) subq_24
 ON
   (
-    subq_16.listing = subq_21.listing
+    subq_19.listing = subq_24.listing
   ) AND (
     (
-      subq_16.metric_time__day >= subq_21.lux_listing__window_start__day
+      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
     ) AND (
       (
-        subq_16.metric_time__day < subq_21.lux_listing__window_end__day
+        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
       ) OR (
-        subq_21.lux_listing__window_end__day IS NULL
+        subq_24.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_16.metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux
+  subq_19.metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_27
+) subq_32
 ON
   (
-    account_month_txns_src_22000.account_id = subq_27.account_id
+    account_month_txns_src_22000.account_id = subq_32.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_27.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
   )
 GROUP BY
-  subq_27.customer_id__customer_name
+  subq_32.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_21.bookings) AS bookings
-  , MAX(subq_27.listings) AS listings
+  MAX(subq_25.bookings) AS bookings
+  , MAX(subq_31.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_21
+) subq_25
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_27
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_28.booking_value) AS booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_30.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_11
+    ) subq_13
     WHERE NOT booking__is_instant
-  ) subq_13
+  ) subq_15
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_17
+) subq_19

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_24.metric_time__day AS metric_time__day
-  , subq_29.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_24.bookings) AS bookings
+  subq_35.metric_time__day AS metric_time__day
+  , subq_40.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_35.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_24
+) subq_35
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_29
+) subq_40
 ON
   (
-    subq_24.listing = subq_29.listing
+    subq_35.listing = subq_40.listing
   ) AND (
     (
-      subq_24.metric_time__day >= subq_29.window_start__day
+      subq_35.metric_time__day >= subq_40.window_start__day
     ) AND (
       (
-        subq_24.metric_time__day < subq_29.window_end__day
+        subq_35.metric_time__day < subq_40.window_end__day
       ) OR (
-        subq_29.window_end__day IS NULL
+        subq_40.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_24.metric_time__day
-  , subq_29.user__home_state_latest
+  subq_35.metric_time__day
+  , subq_40.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_16.bookings) AS bookings
+  subq_19.metric_time__day AS metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_19.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_16
+) subq_19
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_21
+) subq_24
 ON
   (
-    subq_16.listing = subq_21.listing
+    subq_19.listing = subq_24.listing
   ) AND (
     (
-      subq_16.metric_time__day >= subq_21.lux_listing__window_start__day
+      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
     ) AND (
       (
-        subq_16.metric_time__day < subq_21.lux_listing__window_end__day
+        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
       ) OR (
-        subq_21.lux_listing__window_end__day IS NULL
+        subq_24.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_16.metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux
+  subq_19.metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_27
+) subq_32
 ON
   (
-    account_month_txns_src_22000.account_id = subq_27.account_id
+    account_month_txns_src_22000.account_id = subq_32.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_27.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
   )
 GROUP BY
-  subq_27.customer_id__customer_name
+  subq_32.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_21.bookings) AS bookings
-  , MAX(subq_27.listings) AS listings
+  MAX(subq_25.bookings) AS bookings
+  , MAX(subq_31.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_21
+) subq_25
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_27
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_28.booking_value) AS booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_30.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_11
+    ) subq_13
     WHERE NOT booking__is_instant
-  ) subq_13
+  ) subq_15
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_17
+) subq_19

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_24.metric_time__day AS metric_time__day
-  , subq_29.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_24.bookings) AS bookings
+  subq_35.metric_time__day AS metric_time__day
+  , subq_40.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_35.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_24
+) subq_35
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_29
+) subq_40
 ON
   (
-    subq_24.listing = subq_29.listing
+    subq_35.listing = subq_40.listing
   ) AND (
     (
-      subq_24.metric_time__day >= subq_29.window_start__day
+      subq_35.metric_time__day >= subq_40.window_start__day
     ) AND (
       (
-        subq_24.metric_time__day < subq_29.window_end__day
+        subq_35.metric_time__day < subq_40.window_end__day
       ) OR (
-        subq_29.window_end__day IS NULL
+        subq_40.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_24.metric_time__day
-  , subq_29.user__home_state_latest
+  subq_35.metric_time__day
+  , subq_40.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_16.bookings) AS bookings
+  subq_19.metric_time__day AS metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_19.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_16
+) subq_19
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_21
+) subq_24
 ON
   (
-    subq_16.listing = subq_21.listing
+    subq_19.listing = subq_24.listing
   ) AND (
     (
-      subq_16.metric_time__day >= subq_21.lux_listing__window_start__day
+      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
     ) AND (
       (
-        subq_16.metric_time__day < subq_21.lux_listing__window_end__day
+        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
       ) OR (
-        subq_21.lux_listing__window_end__day IS NULL
+        subq_24.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_16.metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux
+  subq_19.metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_27
+) subq_32
 ON
   (
-    account_month_txns_src_22000.account_id = subq_27.account_id
+    account_month_txns_src_22000.account_id = subq_32.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_27.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
   )
 GROUP BY
-  subq_27.customer_id__customer_name
+  subq_32.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_21.bookings) AS bookings
-  , MAX(subq_27.listings) AS listings
+  MAX(subq_25.bookings) AS bookings
+  , MAX(subq_31.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_21
+) subq_25
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_27
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_28.booking_value) AS booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_30.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_11
+    ) subq_13
     WHERE NOT booking__is_instant
-  ) subq_13
+  ) subq_15
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_17
+) subq_19

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_24.metric_time__day AS metric_time__day
-  , subq_29.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_24.bookings) AS bookings
+  subq_35.metric_time__day AS metric_time__day
+  , subq_40.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_35.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_24
+) subq_35
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_29
+) subq_40
 ON
   (
-    subq_24.listing = subq_29.listing
+    subq_35.listing = subq_40.listing
   ) AND (
     (
-      subq_24.metric_time__day >= subq_29.window_start__day
+      subq_35.metric_time__day >= subq_40.window_start__day
     ) AND (
       (
-        subq_24.metric_time__day < subq_29.window_end__day
+        subq_35.metric_time__day < subq_40.window_end__day
       ) OR (
-        subq_29.window_end__day IS NULL
+        subq_40.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_24.metric_time__day
-  , subq_29.user__home_state_latest
+  subq_35.metric_time__day
+  , subq_40.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_16.bookings) AS bookings
+  subq_19.metric_time__day AS metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_19.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_16
+) subq_19
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_21
+) subq_24
 ON
   (
-    subq_16.listing = subq_21.listing
+    subq_19.listing = subq_24.listing
   ) AND (
     (
-      subq_16.metric_time__day >= subq_21.lux_listing__window_start__day
+      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
     ) AND (
       (
-        subq_16.metric_time__day < subq_21.lux_listing__window_end__day
+        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
       ) OR (
-        subq_21.lux_listing__window_end__day IS NULL
+        subq_24.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_16.metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux
+  subq_19.metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_27
+) subq_32
 ON
   (
-    account_month_txns_src_22000.account_id = subq_27.account_id
+    account_month_txns_src_22000.account_id = subq_32.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_27.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
   )
 GROUP BY
-  subq_27.customer_id__customer_name
+  subq_32.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_21.bookings) AS bookings
-  , MAX(subq_27.listings) AS listings
+  MAX(subq_25.bookings) AS bookings
+  , MAX(subq_31.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_21
+) subq_25
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2020-01-01' AND '2020-01-01'
-) subq_27
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , MAX(subq_23.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_28.booking_value) AS booking_value
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , MAX(subq_25.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_30.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_17
+      ) subq_19
       WHERE booking__is_instant
-    ) subq_19
+    ) subq_21
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_23
+  ) subq_25
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_28
+  ) subq_30
   ON
-    subq_23.metric_time__day = subq_28.metric_time__day
+    subq_25.metric_time__day = subq_30.metric_time__day
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_28.metric_time__day)
-) subq_29
+    COALESCE(subq_25.metric_time__day, subq_30.metric_time__day)
+) subq_31

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_11
+    ) subq_13
     WHERE NOT booking__is_instant
-  ) subq_13
+  ) subq_15
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_17
+) subq_19

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_through_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_through_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_24.metric_time__day AS metric_time__day
-  , subq_29.user__home_state_latest AS listing__user__home_state_latest
-  , SUM(subq_24.bookings) AS bookings
+  subq_35.metric_time__day AS metric_time__day
+  , subq_40.user__home_state_latest AS listing__user__home_state_latest
+  , SUM(subq_35.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_24
+) subq_35
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['user__home_state_latest', 'window_start__day', 'window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_users_latest users_latest_src_26000
   ON
     listings_src_26000.user_id = users_latest_src_26000.user_id
-) subq_29
+) subq_40
 ON
   (
-    subq_24.listing = subq_29.listing
+    subq_35.listing = subq_40.listing
   ) AND (
     (
-      subq_24.metric_time__day >= subq_29.window_start__day
+      subq_35.metric_time__day >= subq_40.window_start__day
     ) AND (
       (
-        subq_24.metric_time__day < subq_29.window_end__day
+        subq_35.metric_time__day < subq_40.window_end__day
       ) OR (
-        subq_29.window_end__day IS NULL
+        subq_40.window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_24.metric_time__day
-  , subq_29.user__home_state_latest
+  subq_35.metric_time__day
+  , subq_40.user__home_state_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_to_scd_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_to_scd_dimension__plan0_optimized.sql
@@ -3,9 +3,9 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.metric_time__day AS metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
-  , SUM(subq_16.bookings) AS bookings
+  subq_19.metric_time__day AS metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
+  , SUM(subq_19.bookings) AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -15,7 +15,7 @@ FROM (
     , listing_id AS listing
     , 1 AS bookings
   FROM ***************************.fct_bookings bookings_source_src_26000
-) subq_16
+) subq_19
 LEFT OUTER JOIN (
   -- Join Standard Outputs
   -- Pass Only Elements: ['lux_listing__is_confirmed_lux', 'lux_listing__window_start__day', 'lux_listing__window_end__day', 'listing']
@@ -29,21 +29,21 @@ LEFT OUTER JOIN (
     ***************************.dim_lux_listings lux_listings_src_26000
   ON
     lux_listing_mapping_src_26000.lux_listing_id = lux_listings_src_26000.lux_listing_id
-) subq_21
+) subq_24
 ON
   (
-    subq_16.listing = subq_21.listing
+    subq_19.listing = subq_24.listing
   ) AND (
     (
-      subq_16.metric_time__day >= subq_21.lux_listing__window_start__day
+      subq_19.metric_time__day >= subq_24.lux_listing__window_start__day
     ) AND (
       (
-        subq_16.metric_time__day < subq_21.lux_listing__window_end__day
+        subq_19.metric_time__day < subq_24.lux_listing__window_end__day
       ) OR (
-        subq_21.lux_listing__window_end__day IS NULL
+        subq_24.lux_listing__window_end__day IS NULL
       )
     )
   )
 GROUP BY
-  subq_16.metric_time__day
-  , subq_21.lux_listing__is_confirmed_lux
+  subq_19.metric_time__day
+  , subq_24.lux_listing__is_confirmed_lux

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multihop_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multihop_node__plan0_optimized.sql
@@ -3,7 +3,7 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_27.customer_id__customer_name AS account_id__customer_id__customer_name
+  subq_32.customer_id__customer_name AS account_id__customer_id__customer_name
   , SUM(account_month_txns_src_22000.txn_count) AS txn_count
 FROM ***************************.account_month_txns account_month_txns_src_22000
 LEFT OUTER JOIN (
@@ -22,12 +22,12 @@ LEFT OUTER JOIN (
     ) AND (
       DATE_TRUNC('day', bridge_table_src_22000.ds_partitioned) = DATE_TRUNC('day', customer_table_src_22000.ds_partitioned)
     )
-) subq_27
+) subq_32
 ON
   (
-    account_month_txns_src_22000.account_id = subq_27.account_id
+    account_month_txns_src_22000.account_id = subq_32.account_id
   ) AND (
-    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_27.ds_partitioned__day
+    DATE_TRUNC('day', account_month_txns_src_22000.ds_partitioned) = subq_32.ds_partitioned__day
   )
 GROUP BY
-  subq_27.customer_id__customer_name
+  subq_32.customer_id__customer_name

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multiple_metrics_no_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multiple_metrics_no_dimensions__plan0_optimized.sql
@@ -1,7 +1,7 @@
 -- Combine Aggregated Outputs
 SELECT
-  MAX(subq_21.bookings) AS bookings
-  , MAX(subq_27.listings) AS listings
+  MAX(subq_25.bookings) AS bookings
+  , MAX(subq_31.listings) AS listings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
@@ -13,7 +13,7 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-) subq_21
+) subq_25
 CROSS JOIN (
   -- Read Elements From Semantic Model 'listings_latest'
   -- Metric Time Dimension 'ds'
@@ -25,4 +25,4 @@ CROSS JOIN (
     SUM(1) AS listings
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-) subq_27
+) subq_31

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_16.metric_time__day AS metric_time__day
-    , subq_15.bookings AS bookings
+    subq_18.metric_time__day AS metric_time__day
+    , subq_17.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_17
+    FROM ***************************.mf_time_spine subq_19
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_14
+    ) subq_16
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_17
   ON
-    subq_16.metric_time__day = subq_15.metric_time__day
-  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_19
+    subq_18.metric_time__day = subq_17.metric_time__day
+  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_21

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_11
+) subq_13

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_20.ds AS metric_time__day
-    , subq_18.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_20
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_22
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_18
+  ) subq_20
   ON
-    subq_20.ds = subq_18.metric_time__day
-) subq_21
+    subq_22.ds = subq_20.metric_time__day
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.ds AS metric_time__day
-      , subq_17.booking__is_instant AS booking__is_instant
-      , subq_17.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_19
+      subq_21.ds AS metric_time__day
+      , subq_19.booking__is_instant AS booking__is_instant
+      , subq_19.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_13
+        ) subq_15
         WHERE booking__is_instant
-      ) subq_15
+      ) subq_17
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_17
+    ) subq_19
     ON
-      subq_19.ds = subq_17.metric_time__day
-  ) subq_20
+      subq_21.ds = subq_19.metric_time__day
+  ) subq_22
   WHERE booking__is_instant
-) subq_21
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_16.metric_time__day AS metric_time__day
-    , subq_15.bookings AS bookings
+    subq_18.metric_time__day AS metric_time__day
+    , subq_17.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_17
+    FROM ***************************.mf_time_spine subq_19
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_14
+    ) subq_16
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_17
   ON
-    subq_16.metric_time__day = subq_15.metric_time__day
-  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_19
+    subq_18.metric_time__day = subq_17.metric_time__day
+  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_21

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_11
+) subq_13

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_20.ds AS metric_time__day
-    , subq_18.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_20
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_22
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_18
+  ) subq_20
   ON
-    subq_20.ds = subq_18.metric_time__day
-) subq_21
+    subq_22.ds = subq_20.metric_time__day
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.ds AS metric_time__day
-      , subq_17.booking__is_instant AS booking__is_instant
-      , subq_17.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_19
+      subq_21.ds AS metric_time__day
+      , subq_19.booking__is_instant AS booking__is_instant
+      , subq_19.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_13
+        ) subq_15
         WHERE booking__is_instant
-      ) subq_15
+      ) subq_17
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_17
+    ) subq_19
     ON
-      subq_19.ds = subq_17.metric_time__day
-  ) subq_20
+      subq_21.ds = subq_19.metric_time__day
+  ) subq_22
   WHERE booking__is_instant
-) subq_21
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_16.metric_time__day AS metric_time__day
-    , subq_15.bookings AS bookings
+    subq_18.metric_time__day AS metric_time__day
+    , subq_17.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_17
+    FROM ***************************.mf_time_spine subq_19
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_14
+    ) subq_16
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_17
   ON
-    subq_16.metric_time__day = subq_15.metric_time__day
-  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_19
+    subq_18.metric_time__day = subq_17.metric_time__day
+  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_21

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_11
+) subq_13

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_20.ds AS metric_time__day
-    , subq_18.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_20
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_22
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_18
+  ) subq_20
   ON
-    subq_20.ds = subq_18.metric_time__day
-) subq_21
+    subq_22.ds = subq_20.metric_time__day
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.ds AS metric_time__day
-      , subq_17.booking__is_instant AS booking__is_instant
-      , subq_17.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_19
+      subq_21.ds AS metric_time__day
+      , subq_19.booking__is_instant AS booking__is_instant
+      , subq_19.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_13
+        ) subq_15
         WHERE booking__is_instant
-      ) subq_15
+      ) subq_17
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_17
+    ) subq_19
     ON
-      subq_19.ds = subq_17.metric_time__day
-  ) subq_20
+      subq_21.ds = subq_19.metric_time__day
+  ) subq_22
   WHERE booking__is_instant
-) subq_21
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_16.metric_time__day AS metric_time__day
-    , subq_15.bookings AS bookings
+    subq_18.metric_time__day AS metric_time__day
+    , subq_17.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_17
+    FROM ***************************.mf_time_spine subq_19
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_14
+    ) subq_16
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_17
   ON
-    subq_16.metric_time__day = subq_15.metric_time__day
-  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_19
+    subq_18.metric_time__day = subq_17.metric_time__day
+  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_21

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_11
+) subq_13

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_20.ds AS metric_time__day
-    , subq_18.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_20
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_22
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_18
+  ) subq_20
   ON
-    subq_20.ds = subq_18.metric_time__day
-) subq_21
+    subq_22.ds = subq_20.metric_time__day
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.ds AS metric_time__day
-      , subq_17.booking__is_instant AS booking__is_instant
-      , subq_17.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_19
+      subq_21.ds AS metric_time__day
+      , subq_19.booking__is_instant AS booking__is_instant
+      , subq_19.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_13
+        ) subq_15
         WHERE booking__is_instant
-      ) subq_15
+      ) subq_17
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_17
+    ) subq_19
     ON
-      subq_19.ds = subq_17.metric_time__day
-  ) subq_20
+      subq_21.ds = subq_19.metric_time__day
+  ) subq_22
   WHERE booking__is_instant
-) subq_21
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_16.metric_time__day AS metric_time__day
-    , subq_15.bookings AS bookings
+    subq_18.metric_time__day AS metric_time__day
+    , subq_17.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_17
+    FROM ***************************.mf_time_spine subq_19
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_14
+    ) subq_16
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_17
   ON
-    subq_16.metric_time__day = subq_15.metric_time__day
-  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_19
+    subq_18.metric_time__day = subq_17.metric_time__day
+  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_21

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_11
+) subq_13

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_20.ds AS metric_time__day
-    , subq_18.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_20
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_22
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_18
+  ) subq_20
   ON
-    subq_20.ds = subq_18.metric_time__day
-) subq_21
+    subq_22.ds = subq_20.metric_time__day
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.ds AS metric_time__day
-      , subq_17.booking__is_instant AS booking__is_instant
-      , subq_17.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_19
+      subq_21.ds AS metric_time__day
+      , subq_19.booking__is_instant AS booking__is_instant
+      , subq_19.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_13
+        ) subq_15
         WHERE booking__is_instant
-      ) subq_15
+      ) subq_17
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_17
+    ) subq_19
     ON
-      subq_19.ds = subq_17.metric_time__day
-  ) subq_20
+      subq_21.ds = subq_19.metric_time__day
+  ) subq_22
   WHERE booking__is_instant
-) subq_21
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_16.metric_time__day AS metric_time__day
-    , subq_15.bookings AS bookings
+    subq_18.metric_time__day AS metric_time__day
+    , subq_17.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_17
+    FROM ***************************.mf_time_spine subq_19
     WHERE ds BETWEEN '2020-01-03' AND '2020-01-05'
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-    ) subq_14
+    ) subq_16
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_17
   ON
-    subq_16.metric_time__day = subq_15.metric_time__day
-  WHERE subq_16.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_19
+    subq_18.metric_time__day = subq_17.metric_time__day
+  WHERE subq_18.metric_time__day BETWEEN '2020-01-03' AND '2020-01-05'
+) subq_21

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-03' AND '2020-01-05'
-) subq_11
+) subq_13

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_20.ds AS metric_time__day
-    , subq_18.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_20
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_22
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_18
+  ) subq_20
   ON
-    subq_20.ds = subq_18.metric_time__day
-) subq_21
+    subq_22.ds = subq_20.metric_time__day
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.ds AS metric_time__day
-      , subq_17.booking__is_instant AS booking__is_instant
-      , subq_17.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_19
+      subq_21.ds AS metric_time__day
+      , subq_19.booking__is_instant AS booking__is_instant
+      , subq_19.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_13
+        ) subq_15
         WHERE booking__is_instant
-      ) subq_15
+      ) subq_17
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_17
+    ) subq_19
     ON
-      subq_19.ds = subq_17.metric_time__day
-  ) subq_20
+      subq_21.ds = subq_19.metric_time__day
+  ) subq_22
   WHERE booking__is_instant
-) subq_21
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_queried_time_constraint__plan0_optimized.sql
@@ -6,15 +6,15 @@ FROM (
   -- Join to Time Spine Dataset
   -- Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]
   SELECT
-    subq_16.metric_time__day AS metric_time__day
-    , subq_15.bookings AS bookings
+    subq_18.metric_time__day AS metric_time__day
+    , subq_17.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
       ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_17
+    FROM ***************************.mf_time_spine subq_19
     WHERE ds BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-  ) subq_16
+  ) subq_18
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
@@ -30,11 +30,11 @@ FROM (
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
       WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-    ) subq_14
+    ) subq_16
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_17
   ON
-    subq_16.metric_time__day = subq_15.metric_time__day
-  WHERE subq_16.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-) subq_19
+    subq_18.metric_time__day = subq_17.metric_time__day
+  WHERE subq_18.metric_time__day BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
+) subq_21

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_join_to_time_spine_with_time_constraint__plan0_optimized.sql
@@ -11,4 +11,4 @@ FROM (
     SUM(1) AS bookings
   FROM ***************************.fct_bookings bookings_source_src_28000
   WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-03' AND timestamp '2020-01-05'
-) subq_11
+) subq_13

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_20.ds AS metric_time__day
-    , subq_18.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_20
+    subq_22.ds AS metric_time__day
+    , subq_20.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_22
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_13
+      ) subq_15
       WHERE booking__is_instant
-    ) subq_15
+    ) subq_17
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_18
+  ) subq_20
   ON
-    subq_20.ds = subq_18.metric_time__day
-) subq_21
+    subq_22.ds = subq_20.metric_time__day
+) subq_23

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_19.ds AS metric_time__day
-      , subq_17.booking__is_instant AS booking__is_instant
-      , subq_17.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_19
+      subq_21.ds AS metric_time__day
+      , subq_19.booking__is_instant AS booking__is_instant
+      , subq_19.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_21
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_13
+        ) subq_15
         WHERE booking__is_instant
-      ) subq_15
+      ) subq_17
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_17
+    ) subq_19
     ON
-      subq_19.ds = subq_17.metric_time__day
-  ) subq_20
+      subq_21.ds = subq_19.metric_time__day
+  ) subq_22
   WHERE booking__is_instant
-) subq_21
+) subq_23


### PR DESCRIPTION
Enable DataflowPlanOptimizers for query rendering tests

The metricflow query rendering tests do snapshot generation and comparison
for standard rendering and optimized rendering. However, these plans only
run the SqlQueryPlanOptimizers - they do not use the DataflowPlanOptimizers.

This means our optimized plans were only partially optimized. Now with
predicate pushdown it would be helpful to see the complete optimization
effect on query plan rendering to SQL.

This change makes that possible by including DataflowPlanOptimizers in
the comparison helper function. For the time being, and to minimize
thrash in snapshot plans, we only include the no-op PredicatePushdownOptimizer.
This will allow us to track the impact of enabling predicate pushdown via
that optimizer through query plan snapshot changes.

A later change will add the branch combiner and update snapshot rendering
accordingly.

Note the distinct values tests needed a quick hack to keep working, which proved less
silly than a local refactor of the helper method.

Snapshot changes should be limited to ID number updates.