### PR TITLE
Update `SqlWindowFunction` enum

### DIFF
--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -944,8 +944,9 @@ class SqlWindowFunction(Enum):
     Values are the SQL string to be used in rendering.
     """
 
-    FIRST_VALUE = "first_value"
-    ROW_NUMBER = "row_number"
+    FIRST_VALUE = "FIRST_VALUE"
+    LAST_VALUE = "LAST_VALUE"
+    AVERAGE = "AVG"
 
 
 @dataclass(frozen=True)

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0.sql
@@ -139,7 +139,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_7.visit__referrer_id) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -171,7 +171,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -67,7 +67,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -75,7 +75,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -184,7 +184,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -192,7 +192,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -200,7 +200,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -39,7 +39,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -47,7 +47,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -55,7 +55,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -63,7 +63,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -185,7 +185,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -193,7 +193,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -201,7 +201,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -209,7 +209,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_13.metric_time__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -217,7 +217,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -45,7 +45,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -69,7 +69,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_31.metric_time__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0.sql
@@ -139,7 +139,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_7.visit__referrer_id) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -171,7 +171,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -67,7 +67,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -75,7 +75,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -184,7 +184,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -192,7 +192,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -200,7 +200,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -39,7 +39,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -47,7 +47,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -55,7 +55,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -63,7 +63,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -185,7 +185,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -193,7 +193,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -201,7 +201,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -209,7 +209,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_13.metric_time__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -217,7 +217,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -45,7 +45,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -69,7 +69,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_31.metric_time__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0.sql
@@ -139,7 +139,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_7.visit__referrer_id) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -171,7 +171,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -67,7 +67,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -75,7 +75,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -184,7 +184,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -192,7 +192,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -200,7 +200,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -39,7 +39,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -47,7 +47,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -55,7 +55,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -63,7 +63,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -185,7 +185,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -193,7 +193,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -201,7 +201,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -209,7 +209,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_13.metric_time__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -217,7 +217,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -45,7 +45,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -69,7 +69,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_31.metric_time__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0.sql
@@ -139,7 +139,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_7.visit__referrer_id) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -171,7 +171,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -67,7 +67,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -75,7 +75,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -184,7 +184,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -192,7 +192,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -200,7 +200,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -39,7 +39,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -47,7 +47,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -55,7 +55,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -63,7 +63,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -185,7 +185,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -193,7 +193,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -201,7 +201,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -209,7 +209,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_13.metric_time__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -217,7 +217,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -45,7 +45,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -69,7 +69,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_31.metric_time__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0.sql
@@ -139,7 +139,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_7.visit__referrer_id) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -171,7 +171,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -67,7 +67,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -75,7 +75,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -184,7 +184,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -192,7 +192,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -200,7 +200,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -39,7 +39,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -47,7 +47,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -55,7 +55,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -63,7 +63,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -185,7 +185,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -193,7 +193,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -201,7 +201,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -209,7 +209,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_13.metric_time__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -217,7 +217,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -45,7 +45,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -69,7 +69,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_31.metric_time__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0.sql
@@ -139,7 +139,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_7.visit__referrer_id) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -171,7 +171,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -67,7 +67,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -75,7 +75,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -184,7 +184,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -192,7 +192,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -200,7 +200,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -39,7 +39,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -47,7 +47,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -55,7 +55,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -63,7 +63,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -185,7 +185,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -193,7 +193,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -201,7 +201,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -209,7 +209,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_13.metric_time__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -217,7 +217,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -45,7 +45,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -69,7 +69,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_31.metric_time__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0.sql
@@ -139,7 +139,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_7.visit__referrer_id) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -171,7 +171,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -43,7 +43,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -67,7 +67,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -75,7 +75,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0.sql
@@ -176,7 +176,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -184,7 +184,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -192,7 +192,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -200,7 +200,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -39,7 +39,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -47,7 +47,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -55,7 +55,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -63,7 +63,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window__plan0.sql
@@ -130,7 +130,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_7.visits) OVER (
+            FIRST_VALUE(subq_7.visits) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -138,7 +138,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_7.ds__day) OVER (
+            , FIRST_VALUE(subq_7.ds__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -146,7 +146,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_7.metric_time__day) OVER (
+            , FIRST_VALUE(subq_7.metric_time__day) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day
@@ -154,7 +154,7 @@ FROM (
               ORDER BY subq_7.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_7.user) OVER (
+            , FIRST_VALUE(subq_7.user) OVER (
               PARTITION BY
                 subq_10.user
                 , subq_10.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window__plan0_optimized.sql
@@ -37,7 +37,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_23.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -45,7 +45,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_23.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
             subq_26.user
             , subq_26.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0.sql
@@ -185,7 +185,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_13.visits) OVER (
+            FIRST_VALUE(subq_13.visits) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -193,7 +193,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_13.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_13.visit__referrer_id) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -201,7 +201,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_13.ds__day) OVER (
+            , FIRST_VALUE(subq_13.ds__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -209,7 +209,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_13.metric_time__day) OVER (
+            , FIRST_VALUE(subq_13.metric_time__day) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day
@@ -217,7 +217,7 @@ FROM (
               ORDER BY subq_13.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_13.user) OVER (
+            , FIRST_VALUE(subq_13.user) OVER (
               PARTITION BY
                 subq_16.user
                 , subq_16.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -45,7 +45,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_31.visits) OVER (
+        FIRST_VALUE(subq_31.visits) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -53,7 +53,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_31.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_31.visit__referrer_id) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -61,7 +61,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_31.ds__day) OVER (
+        , FIRST_VALUE(subq_31.ds__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -69,7 +69,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_31.metric_time__day) OVER (
+        , FIRST_VALUE(subq_31.metric_time__day) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_31.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_31.user) OVER (
+        , FIRST_VALUE(subq_31.user) OVER (
           PARTITION BY
             subq_34.user
             , subq_34.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_count_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -148,7 +148,7 @@ FROM (
           FROM (
             -- Dedupe the fanout with mf_internal_uuid in the conversion data set
             SELECT DISTINCT
-              first_value(subq_9.visits) OVER (
+              FIRST_VALUE(subq_9.visits) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -156,7 +156,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS visits
-              , first_value(subq_9.ds__day) OVER (
+              , FIRST_VALUE(subq_9.ds__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -164,7 +164,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS ds__day
-              , first_value(subq_9.metric_time__day) OVER (
+              , FIRST_VALUE(subq_9.metric_time__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -172,7 +172,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS metric_time__day
-              , first_value(subq_9.user) OVER (
+              , FIRST_VALUE(subq_9.user) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -50,7 +50,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_30.visits) OVER (
+          FIRST_VALUE(subq_30.visits) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -58,7 +58,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_30.ds__day) OVER (
+          , FIRST_VALUE(subq_30.ds__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -66,7 +66,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(subq_30.metric_time__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -74,7 +74,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , first_value(subq_30.user) OVER (
+          , FIRST_VALUE(subq_30.user) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate__plan0.sql
@@ -123,7 +123,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -131,7 +131,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -43,7 +43,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_constant_properties__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_constant_properties__plan0.sql
@@ -132,7 +132,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -141,7 +141,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -150,7 +150,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -159,7 +159,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -168,7 +168,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -177,7 +177,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , first_value(subq_6.session) OVER (
+            , FIRST_VALUE(subq_6.session) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -50,7 +50,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -68,7 +68,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -86,7 +86,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , first_value(subq_21.session) OVER (
+        , FIRST_VALUE(subq_21.session) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_window__plan0.sql
@@ -131,7 +131,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_window__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -49,7 +49,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -57,7 +57,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -65,7 +65,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -73,7 +73,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_count_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -148,7 +148,7 @@ FROM (
           FROM (
             -- Dedupe the fanout with mf_internal_uuid in the conversion data set
             SELECT DISTINCT
-              first_value(subq_9.visits) OVER (
+              FIRST_VALUE(subq_9.visits) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -156,7 +156,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS visits
-              , first_value(subq_9.ds__day) OVER (
+              , FIRST_VALUE(subq_9.ds__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -164,7 +164,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS ds__day
-              , first_value(subq_9.metric_time__day) OVER (
+              , FIRST_VALUE(subq_9.metric_time__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -172,7 +172,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS metric_time__day
-              , first_value(subq_9.user) OVER (
+              , FIRST_VALUE(subq_9.user) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -50,7 +50,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_30.visits) OVER (
+          FIRST_VALUE(subq_30.visits) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -58,7 +58,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_30.ds__day) OVER (
+          , FIRST_VALUE(subq_30.ds__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -66,7 +66,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(subq_30.metric_time__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -74,7 +74,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , first_value(subq_30.user) OVER (
+          , FIRST_VALUE(subq_30.user) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate__plan0.sql
@@ -123,7 +123,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -131,7 +131,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -43,7 +43,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_constant_properties__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_constant_properties__plan0.sql
@@ -132,7 +132,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -141,7 +141,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -150,7 +150,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -159,7 +159,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -168,7 +168,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -177,7 +177,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , first_value(subq_6.session) OVER (
+            , FIRST_VALUE(subq_6.session) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -50,7 +50,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -68,7 +68,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -86,7 +86,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , first_value(subq_21.session) OVER (
+        , FIRST_VALUE(subq_21.session) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_window__plan0.sql
@@ -131,7 +131,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_window__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -49,7 +49,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -57,7 +57,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -65,7 +65,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -73,7 +73,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_count_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -148,7 +148,7 @@ FROM (
           FROM (
             -- Dedupe the fanout with mf_internal_uuid in the conversion data set
             SELECT DISTINCT
-              first_value(subq_9.visits) OVER (
+              FIRST_VALUE(subq_9.visits) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -156,7 +156,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS visits
-              , first_value(subq_9.ds__day) OVER (
+              , FIRST_VALUE(subq_9.ds__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -164,7 +164,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS ds__day
-              , first_value(subq_9.metric_time__day) OVER (
+              , FIRST_VALUE(subq_9.metric_time__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -172,7 +172,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS metric_time__day
-              , first_value(subq_9.user) OVER (
+              , FIRST_VALUE(subq_9.user) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -50,7 +50,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_30.visits) OVER (
+          FIRST_VALUE(subq_30.visits) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -58,7 +58,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_30.ds__day) OVER (
+          , FIRST_VALUE(subq_30.ds__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -66,7 +66,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(subq_30.metric_time__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -74,7 +74,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , first_value(subq_30.user) OVER (
+          , FIRST_VALUE(subq_30.user) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate__plan0.sql
@@ -123,7 +123,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -131,7 +131,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -43,7 +43,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_constant_properties__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_constant_properties__plan0.sql
@@ -132,7 +132,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -141,7 +141,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -150,7 +150,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -159,7 +159,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -168,7 +168,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -177,7 +177,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , first_value(subq_6.session) OVER (
+            , FIRST_VALUE(subq_6.session) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -50,7 +50,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -68,7 +68,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -86,7 +86,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , first_value(subq_21.session) OVER (
+        , FIRST_VALUE(subq_21.session) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_window__plan0.sql
@@ -131,7 +131,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_window__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -49,7 +49,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -57,7 +57,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -65,7 +65,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -73,7 +73,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_count_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -148,7 +148,7 @@ FROM (
           FROM (
             -- Dedupe the fanout with mf_internal_uuid in the conversion data set
             SELECT DISTINCT
-              first_value(subq_9.visits) OVER (
+              FIRST_VALUE(subq_9.visits) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -156,7 +156,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS visits
-              , first_value(subq_9.ds__day) OVER (
+              , FIRST_VALUE(subq_9.ds__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -164,7 +164,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS ds__day
-              , first_value(subq_9.metric_time__day) OVER (
+              , FIRST_VALUE(subq_9.metric_time__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -172,7 +172,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS metric_time__day
-              , first_value(subq_9.user) OVER (
+              , FIRST_VALUE(subq_9.user) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -50,7 +50,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_30.visits) OVER (
+          FIRST_VALUE(subq_30.visits) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -58,7 +58,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_30.ds__day) OVER (
+          , FIRST_VALUE(subq_30.ds__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -66,7 +66,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(subq_30.metric_time__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -74,7 +74,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , first_value(subq_30.user) OVER (
+          , FIRST_VALUE(subq_30.user) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate__plan0.sql
@@ -123,7 +123,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -131,7 +131,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -43,7 +43,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_constant_properties__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_constant_properties__plan0.sql
@@ -132,7 +132,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -141,7 +141,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -150,7 +150,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -159,7 +159,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -168,7 +168,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -177,7 +177,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , first_value(subq_6.session) OVER (
+            , FIRST_VALUE(subq_6.session) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -50,7 +50,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -68,7 +68,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -86,7 +86,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , first_value(subq_21.session) OVER (
+        , FIRST_VALUE(subq_21.session) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_window__plan0.sql
@@ -131,7 +131,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_window__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -49,7 +49,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -57,7 +57,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -65,7 +65,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -73,7 +73,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_count_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -148,7 +148,7 @@ FROM (
           FROM (
             -- Dedupe the fanout with mf_internal_uuid in the conversion data set
             SELECT DISTINCT
-              first_value(subq_9.visits) OVER (
+              FIRST_VALUE(subq_9.visits) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -156,7 +156,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS visits
-              , first_value(subq_9.ds__day) OVER (
+              , FIRST_VALUE(subq_9.ds__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -164,7 +164,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS ds__day
-              , first_value(subq_9.metric_time__day) OVER (
+              , FIRST_VALUE(subq_9.metric_time__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -172,7 +172,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS metric_time__day
-              , first_value(subq_9.user) OVER (
+              , FIRST_VALUE(subq_9.user) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -50,7 +50,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_30.visits) OVER (
+          FIRST_VALUE(subq_30.visits) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -58,7 +58,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_30.ds__day) OVER (
+          , FIRST_VALUE(subq_30.ds__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -66,7 +66,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(subq_30.metric_time__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -74,7 +74,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , first_value(subq_30.user) OVER (
+          , FIRST_VALUE(subq_30.user) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate__plan0.sql
@@ -123,7 +123,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -131,7 +131,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -43,7 +43,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_constant_properties__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_constant_properties__plan0.sql
@@ -132,7 +132,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -141,7 +141,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -150,7 +150,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -159,7 +159,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -168,7 +168,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -177,7 +177,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , first_value(subq_6.session) OVER (
+            , FIRST_VALUE(subq_6.session) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -50,7 +50,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -68,7 +68,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -86,7 +86,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , first_value(subq_21.session) OVER (
+        , FIRST_VALUE(subq_21.session) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_window__plan0.sql
@@ -131,7 +131,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_window__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -49,7 +49,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -57,7 +57,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -65,7 +65,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -73,7 +73,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_count_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -148,7 +148,7 @@ FROM (
           FROM (
             -- Dedupe the fanout with mf_internal_uuid in the conversion data set
             SELECT DISTINCT
-              first_value(subq_9.visits) OVER (
+              FIRST_VALUE(subq_9.visits) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -156,7 +156,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS visits
-              , first_value(subq_9.ds__day) OVER (
+              , FIRST_VALUE(subq_9.ds__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -164,7 +164,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS ds__day
-              , first_value(subq_9.metric_time__day) OVER (
+              , FIRST_VALUE(subq_9.metric_time__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -172,7 +172,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS metric_time__day
-              , first_value(subq_9.user) OVER (
+              , FIRST_VALUE(subq_9.user) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -50,7 +50,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_30.visits) OVER (
+          FIRST_VALUE(subq_30.visits) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -58,7 +58,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_30.ds__day) OVER (
+          , FIRST_VALUE(subq_30.ds__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -66,7 +66,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(subq_30.metric_time__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -74,7 +74,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , first_value(subq_30.user) OVER (
+          , FIRST_VALUE(subq_30.user) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate__plan0.sql
@@ -123,7 +123,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -131,7 +131,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -43,7 +43,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_constant_properties__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_constant_properties__plan0.sql
@@ -132,7 +132,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -141,7 +141,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -150,7 +150,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -159,7 +159,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -168,7 +168,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -177,7 +177,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , first_value(subq_6.session) OVER (
+            , FIRST_VALUE(subq_6.session) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -50,7 +50,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -68,7 +68,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -86,7 +86,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , first_value(subq_21.session) OVER (
+        , FIRST_VALUE(subq_21.session) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_window__plan0.sql
@@ -131,7 +131,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_window__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -49,7 +49,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -57,7 +57,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -65,7 +65,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -73,7 +73,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_count_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_count_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.sql
@@ -148,7 +148,7 @@ FROM (
           FROM (
             -- Dedupe the fanout with mf_internal_uuid in the conversion data set
             SELECT DISTINCT
-              first_value(subq_9.visits) OVER (
+              FIRST_VALUE(subq_9.visits) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -156,7 +156,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS visits
-              , first_value(subq_9.ds__day) OVER (
+              , FIRST_VALUE(subq_9.ds__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -164,7 +164,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS ds__day
-              , first_value(subq_9.metric_time__day) OVER (
+              , FIRST_VALUE(subq_9.metric_time__day) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day
@@ -172,7 +172,7 @@ FROM (
                 ORDER BY subq_9.ds__day DESC
                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
               ) AS metric_time__day
-              , first_value(subq_9.user) OVER (
+              , FIRST_VALUE(subq_9.user) OVER (
                 PARTITION BY
                   subq_12.user
                   , subq_12.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -50,7 +50,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_30.visits) OVER (
+          FIRST_VALUE(subq_30.visits) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -58,7 +58,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_30.ds__day) OVER (
+          , FIRST_VALUE(subq_30.ds__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -66,7 +66,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(subq_30.metric_time__day) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day
@@ -74,7 +74,7 @@ FROM (
             ORDER BY subq_30.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , first_value(subq_30.user) OVER (
+          , FIRST_VALUE(subq_30.user) OVER (
             PARTITION BY
               subq_33.user
               , subq_33.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate__plan0.sql
@@ -123,7 +123,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -131,7 +131,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -43,7 +43,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -51,7 +51,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_constant_properties__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_constant_properties__plan0.sql
@@ -132,7 +132,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -141,7 +141,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -150,7 +150,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -159,7 +159,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -168,7 +168,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -177,7 +177,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS user
-            , first_value(subq_6.session) OVER (
+            , FIRST_VALUE(subq_6.session) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -50,7 +50,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -59,7 +59,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -68,7 +68,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -77,7 +77,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -86,7 +86,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , first_value(subq_21.session) OVER (
+        , FIRST_VALUE(subq_21.session) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_no_group_by__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_no_group_by__plan0.sql
@@ -114,7 +114,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -122,7 +122,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -130,7 +130,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -20,7 +20,7 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      first_value(subq_21.visits) OVER (
+      FIRST_VALUE(subq_21.visits) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -28,7 +28,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , first_value(subq_21.ds__day) OVER (
+      , FIRST_VALUE(subq_21.ds__day) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day
@@ -36,7 +36,7 @@ CROSS JOIN (
         ORDER BY subq_21.ds__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS ds__day
-      , first_value(subq_21.user) OVER (
+      , FIRST_VALUE(subq_21.user) OVER (
         PARTITION BY
           subq_24.user
           , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_window__plan0.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_window__plan0.sql
@@ -131,7 +131,7 @@ FROM (
         FROM (
           -- Dedupe the fanout with mf_internal_uuid in the conversion data set
           SELECT DISTINCT
-            first_value(subq_6.visits) OVER (
+            FIRST_VALUE(subq_6.visits) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -139,7 +139,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visits
-            , first_value(subq_6.visit__referrer_id) OVER (
+            , FIRST_VALUE(subq_6.visit__referrer_id) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -147,7 +147,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS visit__referrer_id
-            , first_value(subq_6.ds__day) OVER (
+            , FIRST_VALUE(subq_6.ds__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -155,7 +155,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS ds__day
-            , first_value(subq_6.metric_time__day) OVER (
+            , FIRST_VALUE(subq_6.metric_time__day) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day
@@ -163,7 +163,7 @@ FROM (
               ORDER BY subq_6.ds__day DESC
               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
             ) AS metric_time__day
-            , first_value(subq_6.user) OVER (
+            , FIRST_VALUE(subq_6.user) OVER (
               PARTITION BY
                 subq_9.user
                 , subq_9.ds__day

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_window__plan0_optimized.sql
@@ -41,7 +41,7 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        first_value(subq_21.visits) OVER (
+        FIRST_VALUE(subq_21.visits) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -49,7 +49,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , first_value(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -57,7 +57,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , first_value(subq_21.ds__day) OVER (
+        , FIRST_VALUE(subq_21.ds__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -65,7 +65,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , first_value(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(subq_21.metric_time__day) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day
@@ -73,7 +73,7 @@ FROM (
           ORDER BY subq_21.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , first_value(subq_21.user) OVER (
+        , FIRST_VALUE(subq_21.user) OVER (
           PARTITION BY
             subq_24.user
             , subq_24.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0.sql
@@ -293,7 +293,7 @@ FROM (
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          first_value(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_24.visits) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -301,7 +301,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , first_value(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_24.ds__day) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -309,7 +309,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , first_value(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_24.user) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -52,7 +52,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_49.visits) OVER (
+          FIRST_VALUE(subq_49.visits) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -60,7 +60,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_49.ds__day) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -68,7 +68,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_49.user) OVER (
+          , FIRST_VALUE(subq_49.user) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0.sql
@@ -293,7 +293,7 @@ FROM (
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          first_value(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_24.visits) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -301,7 +301,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , first_value(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_24.ds__day) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -309,7 +309,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , first_value(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_24.user) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -52,7 +52,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_49.visits) OVER (
+          FIRST_VALUE(subq_49.visits) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -60,7 +60,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_49.ds__day) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -68,7 +68,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_49.user) OVER (
+          , FIRST_VALUE(subq_49.user) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0.sql
@@ -293,7 +293,7 @@ FROM (
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          first_value(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_24.visits) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -301,7 +301,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , first_value(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_24.ds__day) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -309,7 +309,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , first_value(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_24.user) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -52,7 +52,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_49.visits) OVER (
+          FIRST_VALUE(subq_49.visits) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -60,7 +60,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_49.ds__day) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -68,7 +68,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_49.user) OVER (
+          , FIRST_VALUE(subq_49.user) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0.sql
@@ -293,7 +293,7 @@ FROM (
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          first_value(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_24.visits) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -301,7 +301,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , first_value(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_24.ds__day) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -309,7 +309,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , first_value(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_24.user) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -52,7 +52,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_49.visits) OVER (
+          FIRST_VALUE(subq_49.visits) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -60,7 +60,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_49.ds__day) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -68,7 +68,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_49.user) OVER (
+          , FIRST_VALUE(subq_49.user) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0.sql
@@ -293,7 +293,7 @@ FROM (
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          first_value(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_24.visits) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -301,7 +301,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , first_value(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_24.ds__day) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -309,7 +309,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , first_value(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_24.user) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -52,7 +52,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_49.visits) OVER (
+          FIRST_VALUE(subq_49.visits) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -60,7 +60,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_49.ds__day) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -68,7 +68,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_49.user) OVER (
+          , FIRST_VALUE(subq_49.user) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0.sql
@@ -293,7 +293,7 @@ FROM (
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          first_value(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_24.visits) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -301,7 +301,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , first_value(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_24.ds__day) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -309,7 +309,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , first_value(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_24.user) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -52,7 +52,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_49.visits) OVER (
+          FIRST_VALUE(subq_49.visits) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -60,7 +60,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_49.ds__day) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -68,7 +68,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_49.user) OVER (
+          , FIRST_VALUE(subq_49.user) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0.sql
@@ -293,7 +293,7 @@ FROM (
                       FROM (
                         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
                         SELECT DISTINCT
-                          first_value(subq_24.visits) OVER (
+                          FIRST_VALUE(subq_24.visits) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -301,7 +301,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS visits
-                          , first_value(subq_24.ds__day) OVER (
+                          , FIRST_VALUE(subq_24.ds__day) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day
@@ -309,7 +309,7 @@ FROM (
                             ORDER BY subq_24.ds__day DESC
                             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                           ) AS ds__day
-                          , first_value(subq_24.user) OVER (
+                          , FIRST_VALUE(subq_24.user) OVER (
                             PARTITION BY
                               subq_27.user
                               , subq_27.ds__day

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0_optimized.sql
@@ -52,7 +52,7 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          first_value(subq_49.visits) OVER (
+          FIRST_VALUE(subq_49.visits) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -60,7 +60,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , first_value(subq_49.ds__day) OVER (
+          , FIRST_VALUE(subq_49.ds__day) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day
@@ -68,7 +68,7 @@ FROM (
             ORDER BY subq_49.ds__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS ds__day
-          , first_value(subq_49.user) OVER (
+          , FIRST_VALUE(subq_49.user) OVER (
             PARTITION BY
               subq_52.user
               , subq_52.ds__day

--- a/tests_metricflow/snapshots/test_sql_expr_render.py/str/test_window_function_expr__rendered_sql.txt
+++ b/tests_metricflow/snapshots/test_sql_expr_render.py/str/test_window_function_expr__rendered_sql.txt
@@ -1,27 +1,27 @@
 -- Window function with 0 PARTITION BY items(s)
-first_value(a.col0) OVER ()
+FIRST_VALUE(a.col0) OVER ()
 
 -- Window function with 1 PARTITION BY items(s)
-first_value(a.col0) OVER (PARTITION BY b.col0)
+FIRST_VALUE(a.col0) OVER (PARTITION BY b.col0)
 
 -- Window function with 2 PARTITION BY items(s)
-first_value(a.col0) OVER (
+FIRST_VALUE(a.col0) OVER (
   PARTITION BY
     b.col0
     , b.col1
 )
 
 -- Window function with 0 ORDER BY items(s)
-first_value(a.col0) OVER ()
+FIRST_VALUE(a.col0) OVER ()
 
 -- Window function with 1 ORDER BY items(s)
-first_value(a.col0) OVER (
+FIRST_VALUE(a.col0) OVER (
   ORDER BY a.col0 DESC NULLS FIRST
   ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
 )
 
 -- Window function with 2 ORDER BY items(s)
-first_value(a.col0) OVER (
+FIRST_VALUE(a.col0) OVER (
   ORDER BY
     a.col0 DESC NULLS FIRST
     , b.col0 ASC NULLS LAST
@@ -29,7 +29,7 @@ first_value(a.col0) OVER (
 )
 
 -- Window function with PARTITION BY and ORDER BY items
-first_value(a.col0) OVER (
+FIRST_VALUE(a.col0) OVER (
   PARTITION BY
     b.col0
     , b.col1


### PR DESCRIPTION
Update `SqlWindowFunction` enum in a few ways:
- Add `AVERAGE` & `LAST_VALUE` for cumulative metrics with non-default granularities.
- Remove `ROW_NUMBER` since it isn't used anywhere.
- Update values to be uppercase for consistency with our other SQL rendering practices.

All snapshot updates are just upper-casing from `first_value` to `FIRST_VALUE`.