### PR TITLE
Fix funky test

### DIFF
--- a/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
@@ -16,7 +16,7 @@ from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.specs.spec_classes import EntityReference, MetricSpec, TimeDimensionSpec
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
-from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_MONTH
+from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_MONTH
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
@@ -211,7 +211,7 @@ def test_cumulative_metric_no_window_with_time_constraint(
         MetricFlowQuerySpec(
             metric_specs=(MetricSpec(element_name="revenue_all_time"),),
             dimension_specs=(),
-            time_dimension_specs=(MTD_SPEC_MONTH,),
+            time_dimension_specs=(MTD_SPEC_DAY,),
             time_range_constraint=TimeRangeConstraint(
                 start_time=as_datetime("2020-01-01"), end_time=as_datetime("2020-01-01")
             ),

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,26 +1,26 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
+  subq_10.metric_time__day
   , subq_10.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
+    subq_9.metric_time__day
     , SUM(subq_9.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__month
+      subq_8.metric_time__day
       , subq_8.txn_revenue
     FROM (
-      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__month
+        subq_7.metric_time__day
         , subq_7.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
+          subq_5.metric_time__day AS metric_time__day
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -43,8 +43,8 @@ FROM (
           , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
           , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
           , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
           , subq_4.metric_time__quarter AS metric_time__quarter
           , subq_4.metric_time__year AS metric_time__year
           , subq_4.metric_time__extract_year AS metric_time__extract_year
@@ -59,11 +59,9 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATETIME_TRUNC(subq_6.ds, month) AS metric_time__month
+            subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
           WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-          GROUP BY
-            metric_time__month
         ) subq_5
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
@@ -177,11 +175,11 @@ FROM (
           WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
         ) subq_4
         ON
-          (subq_4.metric_time__month <= subq_5.metric_time__month)
+          (subq_4.metric_time__day <= subq_5.metric_time__day)
       ) subq_7
     ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
   ) subq_9
   GROUP BY
-    metric_time__month
+    metric_time__day
 ) subq_10

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,32 +1,30 @@
 -- Join Self Over Time Range
--- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day']
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
+  subq_14.metric_time__day AS metric_time__day
   , SUM(subq_13.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
-    DATETIME_TRUNC(ds, month) AS metric_time__month
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_15
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-  GROUP BY
-    metric_time__month
 ) subq_14
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
   SELECT
-    DATETIME_TRUNC(created_at, month) AS metric_time__month
+    DATETIME_TRUNC(created_at, day) AS metric_time__day
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATETIME_TRUNC(created_at, day) BETWEEN '2000-01-01' AND '2020-01-01'
 ) subq_13
 ON
-  (subq_13.metric_time__month <= subq_14.metric_time__month)
-WHERE subq_14.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_13.metric_time__day <= subq_14.metric_time__day)
+WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  metric_time__month
+  metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,26 +1,26 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
+  subq_10.metric_time__day
   , subq_10.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
+    subq_9.metric_time__day
     , SUM(subq_9.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__month
+      subq_8.metric_time__day
       , subq_8.txn_revenue
     FROM (
-      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__month
+        subq_7.metric_time__day
         , subq_7.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
+          subq_5.metric_time__day AS metric_time__day
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -43,8 +43,8 @@ FROM (
           , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
           , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
           , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
           , subq_4.metric_time__quarter AS metric_time__quarter
           , subq_4.metric_time__year AS metric_time__year
           , subq_4.metric_time__extract_year AS metric_time__extract_year
@@ -59,11 +59,9 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
+            subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
           WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-          GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
         ) subq_5
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
@@ -177,11 +175,11 @@ FROM (
           WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
         ) subq_4
         ON
-          (subq_4.metric_time__month <= subq_5.metric_time__month)
+          (subq_4.metric_time__day <= subq_5.metric_time__day)
       ) subq_7
     ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
   ) subq_9
   GROUP BY
-    subq_9.metric_time__month
+    subq_9.metric_time__day
 ) subq_10

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,32 +1,30 @@
 -- Join Self Over Time Range
--- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day']
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
+  subq_14.metric_time__day AS metric_time__day
   , SUM(subq_13.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
-    DATE_TRUNC('month', ds) AS metric_time__month
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_15
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-  GROUP BY
-    DATE_TRUNC('month', ds)
 ) subq_14
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
   SELECT
-    DATE_TRUNC('month', created_at) AS metric_time__month
+    DATE_TRUNC('day', created_at) AS metric_time__day
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
 ) subq_13
 ON
-  (subq_13.metric_time__month <= subq_14.metric_time__month)
-WHERE subq_14.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_13.metric_time__day <= subq_14.metric_time__day)
+WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__month
+  subq_14.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,26 +1,26 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
+  subq_10.metric_time__day
   , subq_10.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
+    subq_9.metric_time__day
     , SUM(subq_9.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__month
+      subq_8.metric_time__day
       , subq_8.txn_revenue
     FROM (
-      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__month
+        subq_7.metric_time__day
         , subq_7.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
+          subq_5.metric_time__day AS metric_time__day
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -43,8 +43,8 @@ FROM (
           , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
           , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
           , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
           , subq_4.metric_time__quarter AS metric_time__quarter
           , subq_4.metric_time__year AS metric_time__year
           , subq_4.metric_time__extract_year AS metric_time__extract_year
@@ -59,11 +59,9 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
+            subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
           WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-          GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
         ) subq_5
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
@@ -177,11 +175,11 @@ FROM (
           WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
         ) subq_4
         ON
-          (subq_4.metric_time__month <= subq_5.metric_time__month)
+          (subq_4.metric_time__day <= subq_5.metric_time__day)
       ) subq_7
     ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
   ) subq_9
   GROUP BY
-    subq_9.metric_time__month
+    subq_9.metric_time__day
 ) subq_10

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,32 +1,30 @@
 -- Join Self Over Time Range
--- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day']
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
+  subq_14.metric_time__day AS metric_time__day
   , SUM(subq_13.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
-    DATE_TRUNC('month', ds) AS metric_time__month
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_15
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-  GROUP BY
-    DATE_TRUNC('month', ds)
 ) subq_14
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
   SELECT
-    DATE_TRUNC('month', created_at) AS metric_time__month
+    DATE_TRUNC('day', created_at) AS metric_time__day
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
 ) subq_13
 ON
-  (subq_13.metric_time__month <= subq_14.metric_time__month)
-WHERE subq_14.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_13.metric_time__day <= subq_14.metric_time__day)
+WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__month
+  subq_14.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,26 +1,26 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
+  subq_10.metric_time__day
   , subq_10.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
+    subq_9.metric_time__day
     , SUM(subq_9.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__month
+      subq_8.metric_time__day
       , subq_8.txn_revenue
     FROM (
-      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__month
+        subq_7.metric_time__day
         , subq_7.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
+          subq_5.metric_time__day AS metric_time__day
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -43,8 +43,8 @@ FROM (
           , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
           , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
           , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
           , subq_4.metric_time__quarter AS metric_time__quarter
           , subq_4.metric_time__year AS metric_time__year
           , subq_4.metric_time__extract_year AS metric_time__extract_year
@@ -59,11 +59,9 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
+            subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
           WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-          GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
         ) subq_5
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
@@ -177,11 +175,11 @@ FROM (
           WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
         ) subq_4
         ON
-          (subq_4.metric_time__month <= subq_5.metric_time__month)
+          (subq_4.metric_time__day <= subq_5.metric_time__day)
       ) subq_7
     ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
   ) subq_9
   GROUP BY
-    subq_9.metric_time__month
+    subq_9.metric_time__day
 ) subq_10

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,32 +1,30 @@
 -- Join Self Over Time Range
--- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day']
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
+  subq_14.metric_time__day AS metric_time__day
   , SUM(subq_13.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
-    DATE_TRUNC('month', ds) AS metric_time__month
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_15
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-  GROUP BY
-    DATE_TRUNC('month', ds)
 ) subq_14
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
   SELECT
-    DATE_TRUNC('month', created_at) AS metric_time__month
+    DATE_TRUNC('day', created_at) AS metric_time__day
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
 ) subq_13
 ON
-  (subq_13.metric_time__month <= subq_14.metric_time__month)
-WHERE subq_14.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_13.metric_time__day <= subq_14.metric_time__day)
+WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__month
+  subq_14.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,26 +1,26 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
+  subq_10.metric_time__day
   , subq_10.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
+    subq_9.metric_time__day
     , SUM(subq_9.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__month
+      subq_8.metric_time__day
       , subq_8.txn_revenue
     FROM (
-      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__month
+        subq_7.metric_time__day
         , subq_7.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
+          subq_5.metric_time__day AS metric_time__day
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -43,8 +43,8 @@ FROM (
           , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
           , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
           , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
           , subq_4.metric_time__quarter AS metric_time__quarter
           , subq_4.metric_time__year AS metric_time__year
           , subq_4.metric_time__extract_year AS metric_time__extract_year
@@ -59,11 +59,9 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
+            subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
           WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-          GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
         ) subq_5
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
@@ -177,11 +175,11 @@ FROM (
           WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
         ) subq_4
         ON
-          (subq_4.metric_time__month <= subq_5.metric_time__month)
+          (subq_4.metric_time__day <= subq_5.metric_time__day)
       ) subq_7
     ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
   ) subq_9
   GROUP BY
-    subq_9.metric_time__month
+    subq_9.metric_time__day
 ) subq_10

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,32 +1,30 @@
 -- Join Self Over Time Range
--- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day']
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
+  subq_14.metric_time__day AS metric_time__day
   , SUM(subq_13.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
-    DATE_TRUNC('month', ds) AS metric_time__month
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_15
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-  GROUP BY
-    DATE_TRUNC('month', ds)
 ) subq_14
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
   SELECT
-    DATE_TRUNC('month', created_at) AS metric_time__month
+    DATE_TRUNC('day', created_at) AS metric_time__day
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
 ) subq_13
 ON
-  (subq_13.metric_time__month <= subq_14.metric_time__month)
-WHERE subq_14.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_13.metric_time__day <= subq_14.metric_time__day)
+WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__month
+  subq_14.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,26 +1,26 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
+  subq_10.metric_time__day
   , subq_10.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
+    subq_9.metric_time__day
     , SUM(subq_9.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__month
+      subq_8.metric_time__day
       , subq_8.txn_revenue
     FROM (
-      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__month
+        subq_7.metric_time__day
         , subq_7.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
+          subq_5.metric_time__day AS metric_time__day
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -43,8 +43,8 @@ FROM (
           , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
           , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
           , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
           , subq_4.metric_time__quarter AS metric_time__quarter
           , subq_4.metric_time__year AS metric_time__year
           , subq_4.metric_time__extract_year AS metric_time__extract_year
@@ -59,11 +59,9 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
+            subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
           WHERE subq_6.ds BETWEEN '2020-01-01' AND '2020-01-01'
-          GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
         ) subq_5
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
@@ -177,11 +175,11 @@ FROM (
           WHERE subq_3.metric_time__day BETWEEN '2000-01-01' AND '2020-01-01'
         ) subq_4
         ON
-          (subq_4.metric_time__month <= subq_5.metric_time__month)
+          (subq_4.metric_time__day <= subq_5.metric_time__day)
       ) subq_7
     ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+    WHERE subq_8.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
   ) subq_9
   GROUP BY
-    subq_9.metric_time__month
+    subq_9.metric_time__day
 ) subq_10

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,32 +1,30 @@
 -- Join Self Over Time Range
--- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day']
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
+  subq_14.metric_time__day AS metric_time__day
   , SUM(subq_13.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
-    DATE_TRUNC('month', ds) AS metric_time__month
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_15
   WHERE ds BETWEEN '2020-01-01' AND '2020-01-01'
-  GROUP BY
-    DATE_TRUNC('month', ds)
 ) subq_14
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
   SELECT
-    DATE_TRUNC('month', created_at) AS metric_time__month
+    DATE_TRUNC('day', created_at) AS metric_time__day
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN '2000-01-01' AND '2020-01-01'
 ) subq_13
 ON
-  (subq_13.metric_time__month <= subq_14.metric_time__month)
-WHERE subq_14.metric_time__month BETWEEN '2020-01-01' AND '2020-01-01'
+  (subq_13.metric_time__day <= subq_14.metric_time__day)
+WHERE subq_14.metric_time__day BETWEEN '2020-01-01' AND '2020-01-01'
 GROUP BY
-  subq_14.metric_time__month
+  subq_14.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0.sql
@@ -1,26 +1,26 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.metric_time__month
+  subq_10.metric_time__day
   , subq_10.txn_revenue AS revenue_all_time
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.metric_time__month
+    subq_9.metric_time__day
     , SUM(subq_9.txn_revenue) AS txn_revenue
   FROM (
     -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
     SELECT
-      subq_8.metric_time__month
+      subq_8.metric_time__day
       , subq_8.txn_revenue
     FROM (
-      -- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+      -- Pass Only Elements: ['txn_revenue', 'metric_time__day']
       SELECT
-        subq_7.metric_time__month
+        subq_7.metric_time__day
         , subq_7.txn_revenue
       FROM (
         -- Join Self Over Time Range
         SELECT
-          subq_5.metric_time__month AS metric_time__month
+          subq_5.metric_time__day AS metric_time__day
           , subq_4.ds__day AS ds__day
           , subq_4.ds__week AS ds__week
           , subq_4.ds__month AS ds__month
@@ -43,8 +43,8 @@ FROM (
           , subq_4.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
           , subq_4.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
           , subq_4.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
-          , subq_4.metric_time__day AS metric_time__day
           , subq_4.metric_time__week AS metric_time__week
+          , subq_4.metric_time__month AS metric_time__month
           , subq_4.metric_time__quarter AS metric_time__quarter
           , subq_4.metric_time__year AS metric_time__year
           , subq_4.metric_time__extract_year AS metric_time__extract_year
@@ -59,11 +59,9 @@ FROM (
         FROM (
           -- Time Spine
           SELECT
-            DATE_TRUNC('month', subq_6.ds) AS metric_time__month
+            subq_6.ds AS metric_time__day
           FROM ***************************.mf_time_spine subq_6
           WHERE subq_6.ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-          GROUP BY
-            DATE_TRUNC('month', subq_6.ds)
         ) subq_5
         INNER JOIN (
           -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
@@ -177,11 +175,11 @@ FROM (
           WHERE subq_3.metric_time__day BETWEEN timestamp '2000-01-01' AND timestamp '2020-01-01'
         ) subq_4
         ON
-          (subq_4.metric_time__month <= subq_5.metric_time__month)
+          (subq_4.metric_time__day <= subq_5.metric_time__day)
       ) subq_7
     ) subq_8
-    WHERE subq_8.metric_time__month BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+    WHERE subq_8.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
   ) subq_9
   GROUP BY
-    subq_9.metric_time__month
+    subq_9.metric_time__day
 ) subq_10

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_no_window_with_time_constraint__plan0_optimized.sql
@@ -1,32 +1,30 @@
 -- Join Self Over Time Range
--- Pass Only Elements: ['txn_revenue', 'metric_time__month']
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day']
 -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-01T00:00:00]
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_14.metric_time__month AS metric_time__month
+  subq_14.metric_time__day AS metric_time__day
   , SUM(subq_13.txn_revenue) AS revenue_all_time
 FROM (
   -- Time Spine
   SELECT
-    DATE_TRUNC('month', ds) AS metric_time__month
+    ds AS metric_time__day
   FROM ***************************.mf_time_spine subq_15
   WHERE ds BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
-  GROUP BY
-    DATE_TRUNC('month', ds)
 ) subq_14
 INNER JOIN (
   -- Read Elements From Semantic Model 'revenue'
   -- Metric Time Dimension 'ds'
   -- Constrain Time Range to [2000-01-01T00:00:00, 2020-01-01T00:00:00]
   SELECT
-    DATE_TRUNC('month', created_at) AS metric_time__month
+    DATE_TRUNC('day', created_at) AS metric_time__day
     , revenue AS txn_revenue
   FROM ***************************.fct_revenue revenue_src_28000
   WHERE DATE_TRUNC('day', created_at) BETWEEN timestamp '2000-01-01' AND timestamp '2020-01-01'
 ) subq_13
 ON
-  (subq_13.metric_time__month <= subq_14.metric_time__month)
-WHERE subq_14.metric_time__month BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
+  (subq_13.metric_time__day <= subq_14.metric_time__day)
+WHERE subq_14.metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-01'
 GROUP BY
-  subq_14.metric_time__month
+  subq_14.metric_time__day


### PR DESCRIPTION
This test uses a dimension that's not allowed for the metric. Updated here to use the permitted dimension. Not an issue at this point but becomes an issue when working through enabling non-default granularities for cumulative metrics.