### PR TITLE
Bug fix: querying multiple agg time dimensions with cumulative metrics

### DIFF
--- a/.changes/unreleased/Fixes-20240612-161605.yaml
+++ b/.changes/unreleased/Fixes-20240612-161605.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: When querying multiple agg time or metric time dimensions with a cumulative
+  metric, select all of them from the time spine table.
+time: 2024-06-12T16:16:05.678697-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1271"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1355,13 +1355,9 @@ class DataflowPlanBuilder:
         # Otherwise, the measure will be aggregated over all time.
         time_range_node: Optional[JoinOverTimeRangeNode] = None
         if cumulative and queried_agg_time_dimension_specs:
-            # Use the time dimension spec with the smallest granularity.
-            agg_time_dimension_spec_for_join = sorted(
-                queried_agg_time_dimension_specs, key=lambda spec: spec.time_granularity.to_int()
-            )[0]
             time_range_node = JoinOverTimeRangeNode(
                 parent_node=measure_recipe.source_node,
-                time_dimension_spec_for_join=agg_time_dimension_spec_for_join,
+                queried_agg_time_dimension_specs=tuple(queried_agg_time_dimension_specs),
                 window=cumulative_window,
                 grain_to_date=cumulative_grain_to_date,
                 # Note: we use the original constraint here because the JoinOverTimeRangeNode will eventually get

--- a/metricflow/dataflow/nodes/join_over_time.py
+++ b/metricflow/dataflow/nodes/join_over_time.py
@@ -19,7 +19,7 @@ class JoinOverTimeRangeNode(DataflowPlanNode):
     def __init__(
         self,
         parent_node: DataflowPlanNode,
-        time_dimension_spec_for_join: TimeDimensionSpec,
+        queried_agg_time_dimension_specs: Sequence[TimeDimensionSpec],
         window: Optional[MetricTimeWindow],
         grain_to_date: Optional[TimeGranularity],
         node_id: Optional[NodeId] = None,
@@ -34,7 +34,7 @@ class JoinOverTimeRangeNode(DataflowPlanNode):
             (eg month to day)
             node_id: Override the node ID with this value
             time_range_constraint: time range to aggregate over
-            time_dimension_spec_for_join: time dimension spec to use when joining to time spine
+            queried_agg_time_dimension_specs: time dimension specs that will be selected from time spine table
         """
         if window and grain_to_date:
             raise RuntimeError(
@@ -45,7 +45,7 @@ class JoinOverTimeRangeNode(DataflowPlanNode):
         self._grain_to_date = grain_to_date
         self._window = window
         self.time_range_constraint = time_range_constraint
-        self.time_dimension_spec_for_join = time_dimension_spec_for_join
+        self.queried_agg_time_dimension_specs = queried_agg_time_dimension_specs
 
         # Doing a list comprehension throws a type error, so doing it this way.
         parent_nodes: Sequence[DataflowPlanNode] = (self._parent_node,)
@@ -76,7 +76,17 @@ class JoinOverTimeRangeNode(DataflowPlanNode):
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
-        return super().displayed_properties
+        displayed_properties = tuple(super().displayed_properties)
+        displayed_properties += (
+            DisplayedProperty("queried_agg_time_dimension_specs", self.queried_agg_time_dimension_specs),
+        )
+        if self.window:
+            displayed_properties += (DisplayedProperty("window", self.window),)
+        if self.grain_to_date:
+            displayed_properties += (DisplayedProperty("grain_to_date", self.grain_to_date),)
+        if self.time_range_constraint:
+            displayed_properties += (DisplayedProperty("time_range_constraint", self.time_range_constraint),)
+        return displayed_properties
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
@@ -84,6 +94,7 @@ class JoinOverTimeRangeNode(DataflowPlanNode):
             and other_node.grain_to_date == self.grain_to_date
             and other_node.window == self.window
             and other_node.time_range_constraint == self.time_range_constraint
+            and other_node.queried_agg_time_dimension_specs == self.queried_agg_time_dimension_specs
         )
 
     def with_new_parents(self, new_parent_nodes: Sequence[DataflowPlanNode]) -> JoinOverTimeRangeNode:  # noqa: D102
@@ -93,5 +104,5 @@ class JoinOverTimeRangeNode(DataflowPlanNode):
             window=self.window,
             grain_to_date=self.grain_to_date,
             time_range_constraint=self.time_range_constraint,
-            time_dimension_spec_for_join=self.time_dimension_spec_for_join,
+            queried_agg_time_dimension_specs=self.queried_agg_time_dimension_specs,
         )

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -310,7 +310,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
 
         time_spine_data_set_alias = self._next_unique_table_alias()
 
-        # Assemble time_spine dataset with agg_time_dimension_instance_for_join selected.
+        # Assemble time_spine dataset with requested agg time dimension instances selected.
         time_spine_data_set = self._make_time_spine_data_set(
             agg_time_dimension_instances=requested_agg_time_dimension_instances,
             time_spine_source=self._time_spine_source,
@@ -1052,9 +1052,9 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                     spec=metric_time_dimension_spec,
                 )
             )
-            output_column_to_input_column[
-                metric_time_dimension_column_association.column_name
-            ] = matching_time_dimension_instance.associated_column.column_name
+            output_column_to_input_column[metric_time_dimension_column_association.column_name] = (
+                matching_time_dimension_instance.associated_column.column_name
+            )
 
         output_instance_set = InstanceSet(
             measure_instances=tuple(output_measure_instances),
@@ -1286,11 +1286,11 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             and len(time_spine_dataset.checked_sql_select_node.select_columns) == 1
         ), "Time spine dataset not configured properly. Expected exactly one column."
         original_time_spine_dim_instance = time_spine_dataset.instance_set.time_dimension_instances[0]
-        time_spine_column_select_expr: Union[
-            SqlColumnReferenceExpression, SqlDateTruncExpression
-        ] = SqlColumnReferenceExpression(
-            SqlColumnReference(
-                table_alias=time_spine_alias, column_name=original_time_spine_dim_instance.spec.qualified_name
+        time_spine_column_select_expr: Union[SqlColumnReferenceExpression, SqlDateTruncExpression] = (
+            SqlColumnReferenceExpression(
+                SqlColumnReference(
+                    table_alias=time_spine_alias, column_name=original_time_spine_dim_instance.spec.qualified_name
+                )
             )
         )
 

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1052,9 +1052,9 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                     spec=metric_time_dimension_spec,
                 )
             )
-            output_column_to_input_column[metric_time_dimension_column_association.column_name] = (
-                matching_time_dimension_instance.associated_column.column_name
-            )
+            output_column_to_input_column[
+                metric_time_dimension_column_association.column_name
+            ] = matching_time_dimension_instance.associated_column.column_name
 
         output_instance_set = InstanceSet(
             measure_instances=tuple(output_measure_instances),
@@ -1286,11 +1286,11 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             and len(time_spine_dataset.checked_sql_select_node.select_columns) == 1
         ), "Time spine dataset not configured properly. Expected exactly one column."
         original_time_spine_dim_instance = time_spine_dataset.instance_set.time_dimension_instances[0]
-        time_spine_column_select_expr: Union[SqlColumnReferenceExpression, SqlDateTruncExpression] = (
-            SqlColumnReferenceExpression(
-                SqlColumnReference(
-                    table_alias=time_spine_alias, column_name=original_time_spine_dim_instance.spec.qualified_name
-                )
+        time_spine_column_select_expr: Union[
+            SqlColumnReferenceExpression, SqlDateTruncExpression
+        ] = SqlColumnReferenceExpression(
+            SqlColumnReference(
+                table_alias=time_spine_alias, column_name=original_time_spine_dim_instance.spec.qualified_name
             )
         )
 

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -222,16 +222,16 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
 
     def _make_time_spine_data_set(
         self,
-        agg_time_dimension_instance: TimeDimensionInstance,
+        agg_time_dimension_instances: Tuple[TimeDimensionInstance, ...],
         time_spine_source: TimeSpineSource,
         time_range_constraint: Optional[TimeRangeConstraint] = None,
     ) -> SqlDataSet:
         """Make a time spine data set, which contains all date/time values like '2020-01-01', '2020-01-02'...
 
-        Returns a data set with a column for the agg_time_dimension requested.
+        Returns a dataset with a column selected for each agg_time_dimension requested.
         Column alias will use 'metric_time' or the agg_time_dimension name depending on which the user requested.
         """
-        time_spine_instance_set = InstanceSet(time_dimension_instances=(agg_time_dimension_instance,))
+        time_spine_instance_set = InstanceSet(time_dimension_instances=agg_time_dimension_instances)
         time_spine_table_alias = self._next_unique_table_alias()
 
         column_expr = SqlColumnReferenceExpression.from_table_and_column_names(
@@ -240,22 +240,23 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
 
         select_columns: Tuple[SqlSelectColumn, ...] = ()
         apply_group_by = False
-        column_alias = self.column_association_resolver.resolve_spec(agg_time_dimension_instance.spec).column_name
-        # If the requested granularity matches that of the time spine, do a direct select.
-        # TODO: also handle date part.
-        if agg_time_dimension_instance.spec.time_granularity == time_spine_source.time_column_granularity:
-            select_columns += (SqlSelectColumn(expr=column_expr, column_alias=column_alias),)
-        # Otherwise, apply a DATE_TRUNC() and aggregate via group_by.
-        else:
-            select_columns += (
-                SqlSelectColumn(
-                    expr=SqlDateTruncExpression(
-                        time_granularity=agg_time_dimension_instance.spec.time_granularity, arg=column_expr
+        for agg_time_dimension_instance in agg_time_dimension_instances:
+            column_alias = self.column_association_resolver.resolve_spec(agg_time_dimension_instance.spec).column_name
+            # If the requested granularity is the same as the granularity of the spine, do a direct select.
+            # TODO: also handle date part.
+            if agg_time_dimension_instance.spec.time_granularity == time_spine_source.time_column_granularity:
+                select_columns += (SqlSelectColumn(expr=column_expr, column_alias=column_alias),)
+            # If any columns have a different granularity, apply a DATE_TRUNC() and aggregate via group_by.
+            else:
+                select_columns += (
+                    SqlSelectColumn(
+                        expr=SqlDateTruncExpression(
+                            time_granularity=agg_time_dimension_instance.spec.time_granularity, arg=column_expr
+                        ),
+                        column_alias=column_alias,
                     ),
-                    column_alias=column_alias,
-                ),
-            )
-            apply_group_by = True
+                )
+                apply_group_by = True
 
         return SqlDataSet(
             instance_set=time_spine_instance_set,
@@ -290,20 +291,28 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         input_data_set = node.parent_node.accept(self)
         input_data_set_alias = self._next_unique_table_alias()
 
-        agg_time_dimension_instance: Optional[TimeDimensionInstance] = None
+        # Find requested agg_time_dimensions in parent instance set.
+        # For now, will use instance with smallest granularity in time spine join.
+        # TODO: use metric's default_grain once that property is available.
+        agg_time_dimension_instance_for_join: Optional[TimeDimensionInstance] = None
+        requested_agg_time_dimension_instances: Tuple[TimeDimensionInstance, ...] = ()
         for instance in input_data_set.instance_set.time_dimension_instances:
-            if instance.spec == node.time_dimension_spec_for_join:
-                agg_time_dimension_instance = instance
-                break
+            if instance.spec in node.queried_agg_time_dimension_specs:
+                requested_agg_time_dimension_instances += (instance,)
+                if not agg_time_dimension_instance_for_join or (
+                    instance.spec.time_granularity.to_int()
+                    < agg_time_dimension_instance_for_join.spec.time_granularity.to_int()
+                ):
+                    agg_time_dimension_instance_for_join = instance
         assert (
-            agg_time_dimension_instance
+            agg_time_dimension_instance_for_join
         ), "Specified metric time spec not found in parent data set. This should have been caught by validations."
 
         time_spine_data_set_alias = self._next_unique_table_alias()
 
-        # Assemble time_spine dataset with agg_time_dimension_instance selected.
+        # Assemble time_spine dataset with agg_time_dimension_instance_for_join selected.
         time_spine_data_set = self._make_time_spine_data_set(
-            agg_time_dimension_instance=agg_time_dimension_instance,
+            agg_time_dimension_instances=requested_agg_time_dimension_instances,
             time_spine_source=self._time_spine_source,
             time_range_constraint=node.time_range_constraint,
         )
@@ -315,21 +324,22 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                 data_set=input_data_set,
                 alias=input_data_set_alias,
                 _metric_time_column_name=input_data_set.column_association_for_time_dimension(
-                    agg_time_dimension_instance.spec
+                    agg_time_dimension_instance_for_join.spec
                 ).column_name,
             ),
             time_spine_data_set=AnnotatedSqlDataSet(
                 data_set=time_spine_data_set,
                 alias=time_spine_data_set_alias,
                 _metric_time_column_name=time_spine_data_set.column_association_for_time_dimension(
-                    agg_time_dimension_instance.spec
+                    agg_time_dimension_instance_for_join.spec
                 ).column_name,
             ),
         )
 
-        # Remove agg_time_dimension from input data set. It will be replaced with the time spine instance.
+        # Remove instances of agg_time_dimension from input data set. They'll be replaced with time spine instances.
+        agg_time_dimension_specs = tuple(dim.spec for dim in requested_agg_time_dimension_instances)
         modified_input_instance_set = input_data_set.instance_set.transform(
-            FilterElements(exclude_specs=InstanceSpecSet(time_dimension_specs=(agg_time_dimension_instance.spec,)))
+            FilterElements(exclude_specs=InstanceSpecSet(time_dimension_specs=agg_time_dimension_specs))
         )
         table_alias_to_instance_set[input_data_set_alias] = modified_input_instance_set
 
@@ -1222,7 +1232,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         # Build time spine data set using the requested agg_time_dimension name.
         time_spine_alias = self._next_unique_table_alias()
         time_spine_dataset = self._make_time_spine_data_set(
-            agg_time_dimension_instance=agg_time_dimension_instance_for_join,
+            agg_time_dimension_instances=(agg_time_dimension_instance_for_join,),
             time_spine_source=self._time_spine_source,
             time_range_constraint=node.time_range_constraint,
         )

--- a/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
@@ -317,3 +317,102 @@ def test_cumulative_metric_with_agg_time_dimension(
         sql_client=sql_client,
         node=dataflow_plan.sink_node,
     )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_cumulative_metric_with_multiple_agg_time_dimensions(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
+    sql_client: SqlClient,
+) -> None:
+    """Tests rendering a query for a cumulative metric queried with multiple agg time dimensions."""
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="trailing_2_months_revenue"),),
+            dimension_specs=(),
+            time_dimension_specs=(
+                TimeDimensionSpec(
+                    element_name="ds",
+                    entity_links=(EntityReference("revenue_instance"),),
+                    time_granularity=TimeGranularity.DAY,
+                ),
+                TimeDimensionSpec(
+                    element_name="ds",
+                    entity_links=(EntityReference("revenue_instance"),),
+                    time_granularity=TimeGranularity.MONTH,
+                ),
+            ),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_cumulative_metric_with_multiple_metric_time_dimensions(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
+    sql_client: SqlClient,
+) -> None:
+    """Tests rendering a query for a cumulative metric queried with multiple metric time dimensions."""
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="trailing_2_months_revenue"),),
+            dimension_specs=(),
+            time_dimension_specs=(MTD_SPEC_DAY, MTD_SPEC_MONTH),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_node,
+    )
+
+
+@pytest.mark.sql_engine_snapshot
+def test_cumulative_metric_with_agg_time_and_metric_time(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    mf_engine_test_fixture_mapping: Mapping[SemanticManifestSetup, MetricFlowEngineTestFixture],
+    sql_client: SqlClient,
+) -> None:
+    """Tests rendering a query for a cumulative metric queried with one agg time dimension and one metric time dimension."""
+    dataflow_plan = dataflow_plan_builder.build_plan(
+        MetricFlowQuerySpec(
+            metric_specs=(MetricSpec(element_name="trailing_2_months_revenue"),),
+            dimension_specs=(),
+            time_dimension_specs=(
+                MTD_SPEC_DAY,
+                TimeDimensionSpec(
+                    element_name="ds",
+                    entity_links=(EntityReference("revenue_instance"),),
+                    time_granularity=TimeGranularity.MONTH,
+                ),
+            ),
+        )
+    )
+
+    convert_and_check(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+        node=dataflow_plan.sink_node,
+    )

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__month
+  , subq_6.metric_time__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__month
+      , subq_4.metric_time__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_2.metric_time__day AS metric_time__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          DATETIME_TRUNC(subq_3.ds, month) AS revenue_instance__ds__month
+          , subq_3.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          revenue_instance__ds__month
+          , metric_time__day
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATETIME_TRUNC(revenue_src_28000.created_at, day) AS ds__day
+            , DATETIME_TRUNC(revenue_src_28000.created_at, isoweek) AS ds__week
+            , DATETIME_TRUNC(revenue_src_28000.created_at, month) AS ds__month
+            , DATETIME_TRUNC(revenue_src_28000.created_at, quarter) AS ds__quarter
+            , DATETIME_TRUNC(revenue_src_28000.created_at, year) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , IF(EXTRACT(dayofweek FROM revenue_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_28000.created_at) - 1) AS ds__extract_dow
+            , EXTRACT(dayofyear FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATETIME_TRUNC(revenue_src_28000.created_at, day) AS revenue_instance__ds__day
+            , DATETIME_TRUNC(revenue_src_28000.created_at, isoweek) AS revenue_instance__ds__week
+            , DATETIME_TRUNC(revenue_src_28000.created_at, month) AS revenue_instance__ds__month
+            , DATETIME_TRUNC(revenue_src_28000.created_at, quarter) AS revenue_instance__ds__quarter
+            , DATETIME_TRUNC(revenue_src_28000.created_at, year) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , IF(EXTRACT(dayofweek FROM revenue_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_28000.created_at) - 1) AS revenue_instance__ds__extract_dow
+            , EXTRACT(dayofyear FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 2 month)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    revenue_instance__ds__month
+    , metric_time__day
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , subq_9.metric_time__day AS metric_time__day
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    DATETIME_TRUNC(ds, month) AS revenue_instance__ds__month
+    , ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    revenue_instance__ds__month
+    , metric_time__day
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_9.metric_time__day
+  ) AND (
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 month)
+  )
+GROUP BY
+  revenue_instance__ds__month
+  , metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.revenue_instance__ds__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.revenue_instance__ds__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+          , DATETIME_TRUNC(subq_3.ds, month) AS revenue_instance__ds__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          revenue_instance__ds__day
+          , revenue_instance__ds__month
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATETIME_TRUNC(revenue_src_28000.created_at, day) AS ds__day
+            , DATETIME_TRUNC(revenue_src_28000.created_at, isoweek) AS ds__week
+            , DATETIME_TRUNC(revenue_src_28000.created_at, month) AS ds__month
+            , DATETIME_TRUNC(revenue_src_28000.created_at, quarter) AS ds__quarter
+            , DATETIME_TRUNC(revenue_src_28000.created_at, year) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , IF(EXTRACT(dayofweek FROM revenue_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_28000.created_at) - 1) AS ds__extract_dow
+            , EXTRACT(dayofyear FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATETIME_TRUNC(revenue_src_28000.created_at, day) AS revenue_instance__ds__day
+            , DATETIME_TRUNC(revenue_src_28000.created_at, isoweek) AS revenue_instance__ds__week
+            , DATETIME_TRUNC(revenue_src_28000.created_at, month) AS revenue_instance__ds__month
+            , DATETIME_TRUNC(revenue_src_28000.created_at, quarter) AS revenue_instance__ds__quarter
+            , DATETIME_TRUNC(revenue_src_28000.created_at, year) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , IF(EXTRACT(dayofweek FROM revenue_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_28000.created_at) - 1) AS revenue_instance__ds__extract_dow
+            , EXTRACT(dayofyear FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > DATE_SUB(CAST(subq_2.revenue_instance__ds__day AS DATETIME), INTERVAL 2 month)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    revenue_instance__ds__day
+    , revenue_instance__ds__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS revenue_instance__ds__day
+    , DATETIME_TRUNC(ds, month) AS revenue_instance__ds__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    revenue_instance__ds__day
+    , revenue_instance__ds__month
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_9.revenue_instance__ds__day
+  ) AND (
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_9.revenue_instance__ds__day AS DATETIME), INTERVAL 2 month)
+  )
+GROUP BY
+  revenue_instance__ds__day
+  , revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.metric_time__day
+  , subq_6.metric_time__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.metric_time__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.metric_time__day AS metric_time__day
+        , subq_2.metric_time__month AS metric_time__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS metric_time__day
+          , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          metric_time__day
+          , metric_time__month
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATETIME_TRUNC(revenue_src_28000.created_at, day) AS ds__day
+            , DATETIME_TRUNC(revenue_src_28000.created_at, isoweek) AS ds__week
+            , DATETIME_TRUNC(revenue_src_28000.created_at, month) AS ds__month
+            , DATETIME_TRUNC(revenue_src_28000.created_at, quarter) AS ds__quarter
+            , DATETIME_TRUNC(revenue_src_28000.created_at, year) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , IF(EXTRACT(dayofweek FROM revenue_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_28000.created_at) - 1) AS ds__extract_dow
+            , EXTRACT(dayofyear FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATETIME_TRUNC(revenue_src_28000.created_at, day) AS revenue_instance__ds__day
+            , DATETIME_TRUNC(revenue_src_28000.created_at, isoweek) AS revenue_instance__ds__week
+            , DATETIME_TRUNC(revenue_src_28000.created_at, month) AS revenue_instance__ds__month
+            , DATETIME_TRUNC(revenue_src_28000.created_at, quarter) AS revenue_instance__ds__quarter
+            , DATETIME_TRUNC(revenue_src_28000.created_at, year) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , IF(EXTRACT(dayofweek FROM revenue_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM revenue_src_28000.created_at) - 1) AS revenue_instance__ds__extract_dow
+            , EXTRACT(dayofyear FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 2 month)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    metric_time__day
+    , metric_time__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.metric_time__day AS metric_time__day
+  , subq_9.metric_time__month AS metric_time__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS metric_time__day
+    , DATETIME_TRUNC(ds, month) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    metric_time__day
+    , metric_time__month
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_9.metric_time__day
+  ) AND (
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 month)
+  )
+GROUP BY
+  metric_time__day
+  , metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__month
+  , subq_6.metric_time__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__month
+      , subq_4.metric_time__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_2.metric_time__day AS metric_time__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+          , subq_3.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          DATE_TRUNC('month', subq_3.ds)
+          , subq_3.ds
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > DATEADD(month, -2, subq_2.metric_time__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , subq_9.metric_time__day AS metric_time__day
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+    , ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    DATE_TRUNC('month', ds)
+    , ds
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+  )
+GROUP BY
+  subq_9.revenue_instance__ds__month
+  , subq_9.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.revenue_instance__ds__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.revenue_instance__ds__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+          , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > DATEADD(month, -2, subq_2.revenue_instance__ds__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS revenue_instance__ds__day
+    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.revenue_instance__ds__day)
+  )
+GROUP BY
+  subq_9.revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.metric_time__day
+  , subq_6.metric_time__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.metric_time__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.metric_time__day AS metric_time__day
+        , subq_2.metric_time__month AS metric_time__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS metric_time__day
+          , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(DAYOFWEEK_ISO FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > DATEADD(month, -2, subq_2.metric_time__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.metric_time__day AS metric_time__day
+  , subq_9.metric_time__month AS metric_time__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+  )
+GROUP BY
+  subq_9.metric_time__day
+  , subq_9.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -1,0 +1,144 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__month
+  , subq_6.metric_time__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__month
+      , subq_4.metric_time__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.metric_time__day AS metric_time__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_3
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > subq_2.metric_time__day - INTERVAL 2 month
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -18,7 +18,8 @@ FROM (
     FROM (
       -- Join Self Over Time Range
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_2.metric_time__day AS metric_time__day
         , subq_1.ds__day AS ds__day
         , subq_1.ds__week AS ds__week
         , subq_1.ds__month AS ds__month
@@ -32,7 +33,6 @@ FROM (
         , subq_1.ds__extract_doy AS ds__extract_doy
         , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
         , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
-        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
         , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
         , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
         , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
@@ -57,8 +57,12 @@ FROM (
       FROM (
         -- Time Spine
         SELECT
-          subq_3.ds AS metric_time__day
+          DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+          , subq_3.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          DATE_TRUNC('month', subq_3.ds)
+          , subq_3.ds
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -1,0 +1,20 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+  , subq_10.ds AS metric_time__day
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM ***************************.mf_time_spine subq_10
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - INTERVAL 2 month
+  )
+GROUP BY
+  DATE_TRUNC('month', revenue_src_28000.created_at)
+  , subq_10.ds

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -3,18 +3,27 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
-  , subq_10.ds AS metric_time__day
+  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , subq_9.metric_time__day AS metric_time__day
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM ***************************.mf_time_spine subq_10
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+    , ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    DATE_TRUNC('month', ds)
+    , ds
+) subq_9
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - INTERVAL 2 month
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.metric_time__day - INTERVAL 2 month
   )
 GROUP BY
-  DATE_TRUNC('month', revenue_src_28000.created_at)
-  , subq_10.ds
+  subq_9.revenue_instance__ds__month
+  , subq_9.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -1,0 +1,144 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.revenue_instance__ds__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.revenue_instance__ds__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+        FROM ***************************.mf_time_spine subq_3
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > subq_2.revenue_instance__ds__day - INTERVAL 2 month
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -19,6 +19,7 @@ FROM (
       -- Join Self Over Time Range
       SELECT
         subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
         , subq_1.ds__day AS ds__day
         , subq_1.ds__week AS ds__week
         , subq_1.ds__month AS ds__month
@@ -31,7 +32,6 @@ FROM (
         , subq_1.ds__extract_dow AS ds__extract_dow
         , subq_1.ds__extract_doy AS ds__extract_doy
         , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
-        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
         , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
         , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
         , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
@@ -58,7 +58,11 @@ FROM (
         -- Time Spine
         SELECT
           subq_3.ds AS revenue_instance__ds__day
+          , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
         FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -3,18 +3,27 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.ds AS revenue_instance__ds__day
-  , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM ***************************.mf_time_spine subq_10
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS revenue_instance__ds__day
+    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - INTERVAL 2 month
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.revenue_instance__ds__day - INTERVAL 2 month
   )
 GROUP BY
-  subq_10.ds
-  , DATE_TRUNC('month', revenue_src_28000.created_at)
+  subq_9.revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,20 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.ds AS revenue_instance__ds__day
+  , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM ***************************.mf_time_spine subq_10
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - INTERVAL 2 month
+  )
+GROUP BY
+  subq_10.ds
+  , DATE_TRUNC('month', revenue_src_28000.created_at)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -1,0 +1,144 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.metric_time__day
+  , subq_6.metric_time__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.metric_time__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.metric_time__day AS metric_time__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_3
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > subq_2.metric_time__day - INTERVAL 2 month
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -19,6 +19,7 @@ FROM (
       -- Join Self Over Time Range
       SELECT
         subq_2.metric_time__day AS metric_time__day
+        , subq_2.metric_time__month AS metric_time__month
         , subq_1.ds__day AS ds__day
         , subq_1.ds__week AS ds__week
         , subq_1.ds__month AS ds__month
@@ -42,7 +43,6 @@ FROM (
         , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
         , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
         , subq_1.metric_time__week AS metric_time__week
-        , subq_1.metric_time__month AS metric_time__month
         , subq_1.metric_time__quarter AS metric_time__quarter
         , subq_1.metric_time__year AS metric_time__year
         , subq_1.metric_time__extract_year AS metric_time__extract_year
@@ -58,7 +58,11 @@ FROM (
         -- Time Spine
         SELECT
           subq_3.ds AS metric_time__day
+          , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
         FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -3,18 +3,27 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.ds AS metric_time__day
-  , DATE_TRUNC('month', revenue_src_28000.created_at) AS metric_time__month
+  subq_9.metric_time__day AS metric_time__day
+  , subq_9.metric_time__month AS metric_time__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM ***************************.mf_time_spine subq_10
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - INTERVAL 2 month
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.metric_time__day - INTERVAL 2 month
   )
 GROUP BY
-  subq_10.ds
-  , DATE_TRUNC('month', revenue_src_28000.created_at)
+  subq_9.metric_time__day
+  , subq_9.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,20 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.ds AS metric_time__day
+  , DATE_TRUNC('month', revenue_src_28000.created_at) AS metric_time__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM ***************************.mf_time_spine subq_10
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - INTERVAL 2 month
+  )
+GROUP BY
+  subq_10.ds
+  , DATE_TRUNC('month', revenue_src_28000.created_at)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__month
+  , subq_6.metric_time__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__month
+      , subq_4.metric_time__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_2.metric_time__day AS metric_time__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+          , subq_3.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          DATE_TRUNC('month', subq_3.ds)
+          , subq_3.ds
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > subq_2.metric_time__day - MAKE_INTERVAL(months => 2)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , subq_9.metric_time__day AS metric_time__day
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+    , ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    DATE_TRUNC('month', ds)
+    , ds
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.metric_time__day - MAKE_INTERVAL(months => 2)
+  )
+GROUP BY
+  subq_9.revenue_instance__ds__month
+  , subq_9.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.revenue_instance__ds__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.revenue_instance__ds__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+          , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > subq_2.revenue_instance__ds__day - MAKE_INTERVAL(months => 2)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS revenue_instance__ds__day
+    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.revenue_instance__ds__day - MAKE_INTERVAL(months => 2)
+  )
+GROUP BY
+  subq_9.revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.metric_time__day
+  , subq_6.metric_time__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.metric_time__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.metric_time__day AS metric_time__day
+        , subq_2.metric_time__month AS metric_time__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS metric_time__day
+          , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(isodow FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > subq_2.metric_time__day - MAKE_INTERVAL(months => 2)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.metric_time__day AS metric_time__day
+  , subq_9.metric_time__month AS metric_time__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.metric_time__day - MAKE_INTERVAL(months => 2)
+  )
+GROUP BY
+  subq_9.metric_time__day
+  , subq_9.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__month
+  , subq_6.metric_time__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__month
+      , subq_4.metric_time__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_2.metric_time__day AS metric_time__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+          , subq_3.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          DATE_TRUNC('month', subq_3.ds)
+          , subq_3.ds
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM revenue_src_28000.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_28000.created_at) END AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM revenue_src_28000.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_28000.created_at) END AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > DATEADD(month, -2, subq_2.metric_time__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , subq_9.metric_time__day AS metric_time__day
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+    , ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    DATE_TRUNC('month', ds)
+    , ds
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+  )
+GROUP BY
+  subq_9.revenue_instance__ds__month
+  , subq_9.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.revenue_instance__ds__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.revenue_instance__ds__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+          , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM revenue_src_28000.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_28000.created_at) END AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM revenue_src_28000.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_28000.created_at) END AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > DATEADD(month, -2, subq_2.revenue_instance__ds__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS revenue_instance__ds__day
+    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.revenue_instance__ds__day)
+  )
+GROUP BY
+  subq_9.revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.metric_time__day
+  , subq_6.metric_time__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.metric_time__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.metric_time__day AS metric_time__day
+        , subq_2.metric_time__month AS metric_time__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS metric_time__day
+          , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM revenue_src_28000.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_28000.created_at) END AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , CASE WHEN EXTRACT(dow FROM revenue_src_28000.created_at) = 0 THEN EXTRACT(dow FROM revenue_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM revenue_src_28000.created_at) END AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > DATEADD(month, -2, subq_2.metric_time__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.metric_time__day AS metric_time__day
+  , subq_9.metric_time__month AS metric_time__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+  )
+GROUP BY
+  subq_9.metric_time__day
+  , subq_9.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__month
+  , subq_6.metric_time__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__month
+      , subq_4.metric_time__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_2.metric_time__day AS metric_time__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+          , subq_3.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          DATE_TRUNC('month', subq_3.ds)
+          , subq_3.ds
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(dayofweekiso FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(dayofweekiso FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > DATEADD(month, -2, subq_2.metric_time__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , subq_9.metric_time__day AS metric_time__day
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+    , ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    DATE_TRUNC('month', ds)
+    , ds
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+  )
+GROUP BY
+  subq_9.revenue_instance__ds__month
+  , subq_9.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.revenue_instance__ds__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.revenue_instance__ds__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+          , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(dayofweekiso FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(dayofweekiso FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > DATEADD(month, -2, subq_2.revenue_instance__ds__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS revenue_instance__ds__day
+    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.revenue_instance__ds__day)
+  )
+GROUP BY
+  subq_9.revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.metric_time__day
+  , subq_6.metric_time__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.metric_time__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.metric_time__day AS metric_time__day
+        , subq_2.metric_time__month AS metric_time__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS metric_time__day
+          , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(dayofweekiso FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(dayofweekiso FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > DATEADD(month, -2, subq_2.metric_time__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.metric_time__day AS metric_time__day
+  , subq_9.metric_time__month AS metric_time__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+  )
+GROUP BY
+  subq_9.metric_time__day
+  , subq_9.metric_time__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__month
+  , subq_6.metric_time__day
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__month
+      , subq_4.metric_time__day
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_2.metric_time__day AS metric_time__day
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+          , subq_3.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          DATE_TRUNC('month', subq_3.ds)
+          , subq_3.ds
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > DATE_ADD('month', -2, subq_2.metric_time__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__month
+    , subq_5.metric_time__day
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , subq_9.metric_time__day AS metric_time__day
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+    , ds AS metric_time__day
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    DATE_TRUNC('month', ds)
+    , ds
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_9.metric_time__day)
+  )
+GROUP BY
+  subq_9.revenue_instance__ds__month
+  , subq_9.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.revenue_instance__ds__day
+  , subq_6.revenue_instance__ds__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+    SELECT
+      subq_4.revenue_instance__ds__day
+      , subq_4.revenue_instance__ds__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_2.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__day AS metric_time__day
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__month AS metric_time__month
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS revenue_instance__ds__day
+          , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.revenue_instance__ds__day <= subq_2.revenue_instance__ds__day
+        ) AND (
+          subq_1.revenue_instance__ds__day > DATE_ADD('month', -2, subq_2.revenue_instance__ds__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.revenue_instance__ds__day
+    , subq_5.revenue_instance__ds__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'revenue_instance__ds__day', 'revenue_instance__ds__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS revenue_instance__ds__day
+    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_9.revenue_instance__ds__day)
+  )
+GROUP BY
+  subq_9.revenue_instance__ds__day
+  , subq_9.revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -1,0 +1,148 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_6.metric_time__day
+  , subq_6.metric_time__month
+  , subq_6.txn_revenue AS trailing_2_months_revenue
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+    , SUM(subq_5.txn_revenue) AS txn_revenue
+  FROM (
+    -- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+    SELECT
+      subq_4.metric_time__day
+      , subq_4.metric_time__month
+      , subq_4.txn_revenue
+    FROM (
+      -- Join Self Over Time Range
+      SELECT
+        subq_2.metric_time__day AS metric_time__day
+        , subq_2.metric_time__month AS metric_time__month
+        , subq_1.ds__day AS ds__day
+        , subq_1.ds__week AS ds__week
+        , subq_1.ds__month AS ds__month
+        , subq_1.ds__quarter AS ds__quarter
+        , subq_1.ds__year AS ds__year
+        , subq_1.ds__extract_year AS ds__extract_year
+        , subq_1.ds__extract_quarter AS ds__extract_quarter
+        , subq_1.ds__extract_month AS ds__extract_month
+        , subq_1.ds__extract_day AS ds__extract_day
+        , subq_1.ds__extract_dow AS ds__extract_dow
+        , subq_1.ds__extract_doy AS ds__extract_doy
+        , subq_1.revenue_instance__ds__day AS revenue_instance__ds__day
+        , subq_1.revenue_instance__ds__week AS revenue_instance__ds__week
+        , subq_1.revenue_instance__ds__month AS revenue_instance__ds__month
+        , subq_1.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
+        , subq_1.revenue_instance__ds__year AS revenue_instance__ds__year
+        , subq_1.revenue_instance__ds__extract_year AS revenue_instance__ds__extract_year
+        , subq_1.revenue_instance__ds__extract_quarter AS revenue_instance__ds__extract_quarter
+        , subq_1.revenue_instance__ds__extract_month AS revenue_instance__ds__extract_month
+        , subq_1.revenue_instance__ds__extract_day AS revenue_instance__ds__extract_day
+        , subq_1.revenue_instance__ds__extract_dow AS revenue_instance__ds__extract_dow
+        , subq_1.revenue_instance__ds__extract_doy AS revenue_instance__ds__extract_doy
+        , subq_1.metric_time__week AS metric_time__week
+        , subq_1.metric_time__quarter AS metric_time__quarter
+        , subq_1.metric_time__year AS metric_time__year
+        , subq_1.metric_time__extract_year AS metric_time__extract_year
+        , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+        , subq_1.metric_time__extract_month AS metric_time__extract_month
+        , subq_1.metric_time__extract_day AS metric_time__extract_day
+        , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+        , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+        , subq_1.user AS user
+        , subq_1.revenue_instance__user AS revenue_instance__user
+        , subq_1.txn_revenue AS txn_revenue
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_3.ds AS metric_time__day
+          , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
+        FROM ***************************.mf_time_spine subq_3
+        GROUP BY
+          subq_3.ds
+          , DATE_TRUNC('month', subq_3.ds)
+      ) subq_2
+      INNER JOIN (
+        -- Metric Time Dimension 'ds'
+        SELECT
+          subq_0.ds__day
+          , subq_0.ds__week
+          , subq_0.ds__month
+          , subq_0.ds__quarter
+          , subq_0.ds__year
+          , subq_0.ds__extract_year
+          , subq_0.ds__extract_quarter
+          , subq_0.ds__extract_month
+          , subq_0.ds__extract_day
+          , subq_0.ds__extract_dow
+          , subq_0.ds__extract_doy
+          , subq_0.revenue_instance__ds__day
+          , subq_0.revenue_instance__ds__week
+          , subq_0.revenue_instance__ds__month
+          , subq_0.revenue_instance__ds__quarter
+          , subq_0.revenue_instance__ds__year
+          , subq_0.revenue_instance__ds__extract_year
+          , subq_0.revenue_instance__ds__extract_quarter
+          , subq_0.revenue_instance__ds__extract_month
+          , subq_0.revenue_instance__ds__extract_day
+          , subq_0.revenue_instance__ds__extract_dow
+          , subq_0.revenue_instance__ds__extract_doy
+          , subq_0.ds__day AS metric_time__day
+          , subq_0.ds__week AS metric_time__week
+          , subq_0.ds__month AS metric_time__month
+          , subq_0.ds__quarter AS metric_time__quarter
+          , subq_0.ds__year AS metric_time__year
+          , subq_0.ds__extract_year AS metric_time__extract_year
+          , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+          , subq_0.ds__extract_month AS metric_time__extract_month
+          , subq_0.ds__extract_day AS metric_time__extract_day
+          , subq_0.ds__extract_dow AS metric_time__extract_dow
+          , subq_0.ds__extract_doy AS metric_time__extract_doy
+          , subq_0.user
+          , subq_0.revenue_instance__user
+          , subq_0.txn_revenue
+        FROM (
+          -- Read Elements From Semantic Model 'revenue'
+          SELECT
+            revenue_src_28000.revenue AS txn_revenue
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM revenue_src_28000.created_at) AS ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS ds__extract_doy
+            , DATE_TRUNC('day', revenue_src_28000.created_at) AS revenue_instance__ds__day
+            , DATE_TRUNC('week', revenue_src_28000.created_at) AS revenue_instance__ds__week
+            , DATE_TRUNC('month', revenue_src_28000.created_at) AS revenue_instance__ds__month
+            , DATE_TRUNC('quarter', revenue_src_28000.created_at) AS revenue_instance__ds__quarter
+            , DATE_TRUNC('year', revenue_src_28000.created_at) AS revenue_instance__ds__year
+            , EXTRACT(year FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_year
+            , EXTRACT(quarter FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_quarter
+            , EXTRACT(month FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_month
+            , EXTRACT(day FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_day
+            , EXTRACT(DAY_OF_WEEK FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_dow
+            , EXTRACT(doy FROM revenue_src_28000.created_at) AS revenue_instance__ds__extract_doy
+            , revenue_src_28000.user_id AS user
+            , revenue_src_28000.user_id AS revenue_instance__user
+          FROM ***************************.fct_revenue revenue_src_28000
+        ) subq_0
+      ) subq_1
+      ON
+        (
+          subq_1.metric_time__day <= subq_2.metric_time__day
+        ) AND (
+          subq_1.metric_time__day > DATE_ADD('month', -2, subq_2.metric_time__day)
+        )
+    ) subq_4
+  ) subq_5
+  GROUP BY
+    subq_5.metric_time__day
+    , subq_5.metric_time__month
+) subq_6

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -1,0 +1,29 @@
+-- Join Self Over Time Range
+-- Pass Only Elements: ['txn_revenue', 'metric_time__day', 'metric_time__month']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_9.metric_time__day AS metric_time__day
+  , subq_9.metric_time__month AS metric_time__month
+  , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+FROM (
+  -- Time Spine
+  SELECT
+    ds AS metric_time__day
+    , DATE_TRUNC('month', ds) AS metric_time__month
+  FROM ***************************.mf_time_spine subq_10
+  GROUP BY
+    ds
+    , DATE_TRUNC('month', ds)
+) subq_9
+INNER JOIN
+  ***************************.fct_revenue revenue_src_28000
+ON
+  (
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+  ) AND (
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_9.metric_time__day)
+  )
+GROUP BY
+  subq_9.metric_time__day
+  , subq_9.metric_time__month

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_no_window_or_grain_with_metric_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_no_window_or_grain_with_metric_time__dfp_0.xml
@@ -18,6 +18,8 @@
                     <JoinOverTimeRangeNode>
                         <!-- description = 'Join Self Over Time Range' -->
                         <!-- node_id = NodeId(id_str='jotr_0') -->
+                        <!-- queried_agg_time_dimension_specs =                                       -->
+                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
                             <!-- node_id = NodeId(id_str='sma_28007') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_window__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_window__dfp_0.xml
@@ -18,6 +18,9 @@
                     <JoinOverTimeRangeNode>
                         <!-- description = 'Join Self Over Time Range' -->
                         <!-- node_id = NodeId(id_str='jotr_0') -->
+                        <!-- queried_agg_time_dimension_specs =                                       -->
+                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                        <!-- window = PydanticMetricTimeWindow(count=2, granularity=MONTH) -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
                             <!-- node_id = NodeId(id_str='sma_28007') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -37,6 +37,9 @@
                             <JoinOverTimeRangeNode>
                                 <!-- description = 'Join Self Over Time Range' -->
                                 <!-- node_id = NodeId(id_str='jotr_0') -->
+                                <!-- queried_agg_time_dimension_specs =                                       -->
+                                <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                                <!-- window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
                                     <!-- node_id = NodeId(id_str='sma_28002') -->


### PR DESCRIPTION
First commit here demonstrates the bug. If you query multiple instances of metric time or the agg time dimension with a cumulative metric, only the one with the smallest requested grain will be selected from the time spine. This results in a weird result where `metric_time__day` might have values for every row, but `metric_time__month` might not (and similar issues). This update ensures that all agg time dimensions queried with cumulative metrics will be selected from the time spine table.