### PR TITLE
Update DWH validator to include filters + saved query support

### DIFF
--- a/.changes/unreleased/Under the Hood-20240612-233459.yaml
+++ b/.changes/unreleased/Under the Hood-20240612-233459.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Added filtering for DWH validation tasks and saved query support
+time: 2024-06-12T23:34:59.094903-04:00
+custom:
+  Author: WilliamDee
+  Issue: "1271"

--- a/metricflow/validation/data_warehouse_model_validator.py
+++ b/metricflow/validation/data_warehouse_model_validator.py
@@ -135,10 +135,14 @@ class DataWarehouseTaskBuilder:
         return (rendered_plan.sql, rendered_plan.bind_parameters)
 
     @classmethod
-    def gen_semantic_model_tasks(cls, manifest: SemanticManifest) -> List[DataWarehouseValidationTask]:
+    def gen_semantic_model_tasks(
+        cls, manifest: SemanticManifest, filter_by_semantic_models: Optional[Sequence[str]] = None
+    ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the semantic models of the manifest."""
         tasks: List[DataWarehouseValidationTask] = []
         for semantic_model in manifest.semantic_models:
+            if filter_by_semantic_models is not None and semantic_model.name not in filter_by_semantic_models:
+                continue
             tasks.append(
                 DataWarehouseValidationTask(
                     query_and_params_callable=partial(
@@ -159,7 +163,10 @@ class DataWarehouseTaskBuilder:
 
     @classmethod
     def gen_dimension_tasks(
-        cls, manifest: SemanticManifest, sql_client: SqlClient
+        cls,
+        manifest: SemanticManifest,
+        sql_client: SqlClient,
+        filter_by_semantic_models: Optional[Sequence[str]] = None,
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the dimensions of the manifest.
 
@@ -174,6 +181,9 @@ class DataWarehouseTaskBuilder:
         tasks: List[DataWarehouseValidationTask] = []
         for semantic_model in manifest.semantic_models:
             if not semantic_model.dimensions:
+                continue
+
+            if filter_by_semantic_models is not None and semantic_model.name not in filter_by_semantic_models:
                 continue
 
             source_node = cls._semantic_model_nodes(render_tools=render_tools, semantic_model=semantic_model)[0]
@@ -257,7 +267,12 @@ class DataWarehouseTaskBuilder:
         return tasks
 
     @classmethod
-    def gen_entity_tasks(cls, manifest: SemanticManifest, sql_client: SqlClient) -> List[DataWarehouseValidationTask]:
+    def gen_entity_tasks(
+        cls,
+        manifest: SemanticManifest,
+        sql_client: SqlClient,
+        filter_by_semantic_models: Optional[Sequence[str]] = None,
+    ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the entities of the manifest.
 
         The high level tasks returned are "short cut" queries which try to
@@ -272,6 +287,9 @@ class DataWarehouseTaskBuilder:
         for semantic_model in manifest.semantic_models:
             if not semantic_model.entities:
                 continue
+            if filter_by_semantic_models is not None and semantic_model.name not in filter_by_semantic_models:
+                continue
+
             source_node = cls._semantic_model_nodes(render_tools=render_tools, semantic_model=semantic_model)[0]
 
             semantic_model_sub_tasks: List[DataWarehouseValidationTask] = []
@@ -329,7 +347,12 @@ class DataWarehouseTaskBuilder:
         return tasks
 
     @classmethod
-    def gen_measure_tasks(cls, manifest: SemanticManifest, sql_client: SqlClient) -> List[DataWarehouseValidationTask]:
+    def gen_measure_tasks(
+        cls,
+        manifest: SemanticManifest,
+        sql_client: SqlClient,
+        filter_by_semantic_models: Optional[Sequence[str]] = None,
+    ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the measures of the manifest.
 
         The high level tasks returned are "short cut" queries which try to
@@ -343,6 +366,9 @@ class DataWarehouseTaskBuilder:
         tasks: List[DataWarehouseValidationTask] = []
         for semantic_model in manifest.semantic_models:
             if not semantic_model.measures:
+                continue
+
+            if filter_by_semantic_models is not None and semantic_model.name not in filter_by_semantic_models:
                 continue
 
             source_nodes = cls._semantic_model_nodes(render_tools=render_tools, semantic_model=semantic_model)
@@ -423,7 +449,12 @@ class DataWarehouseTaskBuilder:
         return (explain_result.rendered_sql.sql_query, explain_result.rendered_sql.bind_parameters)
 
     @classmethod
-    def gen_metric_tasks(cls, manifest: SemanticManifest, sql_client: SqlClient) -> List[DataWarehouseValidationTask]:
+    def gen_metric_tasks(
+        cls,
+        manifest: SemanticManifest,
+        sql_client: SqlClient,
+        filter_by_metrics: Optional[Sequence[str]] = None,
+    ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the metrics of the manifest."""
         mf_engine = MetricFlowEngine(
             semantic_manifest_lookup=SemanticManifestLookup(semantic_manifest=manifest),
@@ -431,6 +462,8 @@ class DataWarehouseTaskBuilder:
         )
         tasks: List[DataWarehouseValidationTask] = []
         for metric in manifest.metrics:
+            if filter_by_metrics is not None and metric.name not in filter_by_metrics:
+                continue
             tasks.append(
                 DataWarehouseValidationTask(
                     query_and_params_callable=partial(

--- a/metricflow/validation/data_warehouse_model_validator.py
+++ b/metricflow/validation/data_warehouse_model_validator.py
@@ -8,7 +8,6 @@ from math import floor
 from time import perf_counter
 from typing import Callable, DefaultDict, Dict, List, Optional, Sequence, Tuple, TypeVar
 
-from dbt_semantic_interfaces.protocols.metric import Metric
 from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
@@ -19,6 +18,8 @@ from dbt_semantic_interfaces.references import (
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
     MetricContext,
+    SavedQueryContext,
+    SavedQueryElementType,
     SemanticManifestValidationResults,
     SemanticModelContext,
     SemanticModelElementContext,
@@ -441,12 +442,14 @@ class DataWarehouseTaskBuilder:
         return tasks
 
     @staticmethod
-    def _gen_metric_task_query_and_params(metric: Metric, mf_engine: MetricFlowEngine) -> Tuple[str, SqlBindParameters]:
-        mf_query = MetricFlowQueryRequest.create_with_random_request_id(
-            metric_names=[metric.name], group_by_names=[DataSet.metric_time_dimension_name()]
+    def _gen_explain_query_task_query_and_params(
+        mf_engine: MetricFlowEngine, mf_request: MetricFlowQueryRequest
+    ) -> Tuple[str, SqlBindParameters]:
+        explain_result: MetricFlowExplainResult = mf_engine.explain(mf_request=mf_request)
+        return (
+            explain_result.rendered_sql_without_descriptions.sql_query,
+            explain_result.rendered_sql_without_descriptions.bind_parameters,
         )
-        explain_result: MetricFlowExplainResult = mf_engine.explain(mf_request=mf_query)
-        return (explain_result.rendered_sql.sql_query, explain_result.rendered_sql.bind_parameters)
 
     @classmethod
     def gen_metric_tasks(
@@ -467,15 +470,52 @@ class DataWarehouseTaskBuilder:
             tasks.append(
                 DataWarehouseValidationTask(
                     query_and_params_callable=partial(
-                        cls._gen_metric_task_query_and_params,
-                        metric=metric,
+                        cls._gen_explain_query_task_query_and_params,
                         mf_engine=mf_engine,
+                        mf_request=MetricFlowQueryRequest.create_with_random_request_id(
+                            metric_names=[metric.name], group_by_names=[DataSet.metric_time_dimension_name()]
+                        ),
                     ),
                     context=MetricContext(
                         file_context=FileContext.from_metadata(metadata=metric.metadata),
                         metric=MetricModelReference(metric_name=metric.name),
                     ),
                     error_message=f"Unable to query metric `{metric.name}`.",
+                )
+            )
+        return tasks
+
+    @classmethod
+    def gen_saved_query_tasks(
+        cls,
+        manifest: SemanticManifest,
+        sql_client: SqlClient,
+        filter_by_saved_queries: Optional[Sequence[str]] = None,
+    ) -> List[DataWarehouseValidationTask]:
+        """Generates a list of tasks for validating the saved queries of the manifest."""
+        mf_engine = MetricFlowEngine(
+            semantic_manifest_lookup=SemanticManifestLookup(semantic_manifest=manifest),
+            sql_client=sql_client,
+        )
+        tasks: List[DataWarehouseValidationTask] = []
+        for saved_query in manifest.saved_queries:
+            if filter_by_saved_queries is not None and saved_query.name not in filter_by_saved_queries:
+                continue
+            tasks.append(
+                DataWarehouseValidationTask(
+                    query_and_params_callable=partial(
+                        cls._gen_explain_query_task_query_and_params,
+                        mf_engine=mf_engine,
+                        mf_request=MetricFlowQueryRequest.create_with_random_request_id(
+                            saved_query_name=saved_query.name
+                        ),
+                    ),
+                    context=SavedQueryContext(
+                        file_context=FileContext.from_metadata(metadata=saved_query.metadata),
+                        element_type=SavedQueryElementType.METRIC,
+                        element_value=saved_query.name,
+                    ),
+                    error_message=f"Unable to query saved query `{saved_query.name}`.",
                 )
             )
         return tasks

--- a/metricflow/validation/data_warehouse_model_validator.py
+++ b/metricflow/validation/data_warehouse_model_validator.py
@@ -137,12 +137,12 @@ class DataWarehouseTaskBuilder:
 
     @classmethod
     def gen_semantic_model_tasks(
-        cls, manifest: SemanticManifest, filter_by_semantic_models: Optional[Sequence[str]] = None
+        cls, manifest: SemanticManifest, semantic_model_filters: Optional[Sequence[str]] = None
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the semantic models of the manifest."""
         tasks: List[DataWarehouseValidationTask] = []
         for semantic_model in manifest.semantic_models:
-            if filter_by_semantic_models is not None and semantic_model.name not in filter_by_semantic_models:
+            if semantic_model_filters is not None and semantic_model.name not in semantic_model_filters:
                 continue
             tasks.append(
                 DataWarehouseValidationTask(
@@ -167,7 +167,7 @@ class DataWarehouseTaskBuilder:
         cls,
         manifest: SemanticManifest,
         sql_client: SqlClient,
-        filter_by_semantic_models: Optional[Sequence[str]] = None,
+        semantic_model_filters: Optional[Sequence[str]] = None,
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the dimensions of the manifest.
 
@@ -184,7 +184,7 @@ class DataWarehouseTaskBuilder:
             if not semantic_model.dimensions:
                 continue
 
-            if filter_by_semantic_models is not None and semantic_model.name not in filter_by_semantic_models:
+            if semantic_model_filters is not None and semantic_model.name not in semantic_model_filters:
                 continue
 
             source_node = cls._semantic_model_nodes(render_tools=render_tools, semantic_model=semantic_model)[0]
@@ -272,7 +272,7 @@ class DataWarehouseTaskBuilder:
         cls,
         manifest: SemanticManifest,
         sql_client: SqlClient,
-        filter_by_semantic_models: Optional[Sequence[str]] = None,
+        semantic_model_filters: Optional[Sequence[str]] = None,
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the entities of the manifest.
 
@@ -288,7 +288,7 @@ class DataWarehouseTaskBuilder:
         for semantic_model in manifest.semantic_models:
             if not semantic_model.entities:
                 continue
-            if filter_by_semantic_models is not None and semantic_model.name not in filter_by_semantic_models:
+            if semantic_model_filters is not None and semantic_model.name not in semantic_model_filters:
                 continue
 
             source_node = cls._semantic_model_nodes(render_tools=render_tools, semantic_model=semantic_model)[0]
@@ -352,7 +352,7 @@ class DataWarehouseTaskBuilder:
         cls,
         manifest: SemanticManifest,
         sql_client: SqlClient,
-        filter_by_semantic_models: Optional[Sequence[str]] = None,
+        semantic_model_filters: Optional[Sequence[str]] = None,
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the measures of the manifest.
 
@@ -369,7 +369,7 @@ class DataWarehouseTaskBuilder:
             if not semantic_model.measures:
                 continue
 
-            if filter_by_semantic_models is not None and semantic_model.name not in filter_by_semantic_models:
+            if semantic_model_filters is not None and semantic_model.name not in semantic_model_filters:
                 continue
 
             source_nodes = cls._semantic_model_nodes(render_tools=render_tools, semantic_model=semantic_model)
@@ -456,7 +456,7 @@ class DataWarehouseTaskBuilder:
         cls,
         manifest: SemanticManifest,
         sql_client: SqlClient,
-        filter_by_metrics: Optional[Sequence[str]] = None,
+        metric_filters: Optional[Sequence[str]] = None,
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the metrics of the manifest."""
         mf_engine = MetricFlowEngine(
@@ -465,7 +465,7 @@ class DataWarehouseTaskBuilder:
         )
         tasks: List[DataWarehouseValidationTask] = []
         for metric in manifest.metrics:
-            if filter_by_metrics is not None and metric.name not in filter_by_metrics:
+            if metric_filters is not None and metric.name not in metric_filters:
                 continue
             tasks.append(
                 DataWarehouseValidationTask(
@@ -490,7 +490,7 @@ class DataWarehouseTaskBuilder:
         cls,
         manifest: SemanticManifest,
         sql_client: SqlClient,
-        filter_by_saved_queries: Optional[Sequence[str]] = None,
+        saved_query_filters: Optional[Sequence[str]] = None,
     ) -> List[DataWarehouseValidationTask]:
         """Generates a list of tasks for validating the saved queries of the manifest."""
         mf_engine = MetricFlowEngine(
@@ -499,7 +499,7 @@ class DataWarehouseTaskBuilder:
         )
         tasks: List[DataWarehouseValidationTask] = []
         for saved_query in manifest.saved_queries:
-            if filter_by_saved_queries is not None and saved_query.name not in filter_by_saved_queries:
+            if saved_query_filters is not None and saved_query.name not in saved_query_filters:
                 continue
             tasks.append(
                 DataWarehouseValidationTask(

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATETIME_TRUNC(ds, day) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_saved_query_tasks__query0.sql
@@ -11,7 +11,7 @@ FROM (
     , subq_2.instant_bookings AS instant_bookings
   FROM (
     SELECT
-      DATE_TRUNC(ds, day) AS metric_time__day
+      DATETIME_TRUNC(ds, day) AS metric_time__day
       , listing_id AS listing
       , 1 AS bookings
       , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_saved_query_tasks__query0.sql
@@ -1,23 +1,15 @@
--- Constrain Output with WHERE
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , listing__capacity_latest
   , SUM(bookings) AS bookings
   , SUM(instant_bookings) AS instant_bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
   SELECT
     subq_2.metric_time__day AS metric_time__day
     , listings_latest_src_10000.capacity AS listing__capacity_latest
     , subq_2.bookings AS bookings
     , subq_2.instant_bookings AS instant_bookings
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
     SELECT
       DATE_TRUNC(ds, day) AS metric_time__day
       , listing_id AS listing

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,36 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC(ds, day) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Databricks/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Databricks/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Databricks/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Databricks/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,36 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Databricks/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Databricks/test_build_saved_query_tasks__query0.sql
@@ -1,23 +1,15 @@
--- Constrain Output with WHERE
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , listing__capacity_latest
   , SUM(bookings) AS bookings
   , SUM(instant_bookings) AS instant_bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
   SELECT
     subq_2.metric_time__day AS metric_time__day
     , listings_latest_src_10000.capacity AS listing__capacity_latest
     , subq_2.bookings AS bookings
     , subq_2.instant_bookings AS instant_bookings
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/DuckDB/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/DuckDB/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/DuckDB/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/DuckDB/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,36 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/DuckDB/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/DuckDB/test_build_saved_query_tasks__query0.sql
@@ -1,23 +1,15 @@
--- Constrain Output with WHERE
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , listing__capacity_latest
   , SUM(bookings) AS bookings
   , SUM(instant_bookings) AS instant_bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
   SELECT
     subq_2.metric_time__day AS metric_time__day
     , listings_latest_src_10000.capacity AS listing__capacity_latest
     , subq_2.bookings AS bookings
     , subq_2.instant_bookings AS instant_bookings
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Postgres/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Postgres/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Postgres/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Postgres/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,36 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Postgres/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Postgres/test_build_saved_query_tasks__query0.sql
@@ -1,23 +1,15 @@
--- Constrain Output with WHERE
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , listing__capacity_latest
   , SUM(bookings) AS bookings
   , SUM(instant_bookings) AS instant_bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
   SELECT
     subq_2.metric_time__day AS metric_time__day
     , listings_latest_src_10000.capacity AS listing__capacity_latest
     , subq_2.bookings AS bookings
     , subq_2.instant_bookings AS instant_bookings
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Redshift/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Redshift/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Redshift/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Redshift/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,36 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Redshift/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Redshift/test_build_saved_query_tasks__query0.sql
@@ -1,23 +1,15 @@
--- Constrain Output with WHERE
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , listing__capacity_latest
   , SUM(bookings) AS bookings
   , SUM(instant_bookings) AS instant_bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
   SELECT
     subq_2.metric_time__day AS metric_time__day
     , listings_latest_src_10000.capacity AS listing__capacity_latest
     , subq_2.bookings AS bookings
     , subq_2.instant_bookings AS instant_bookings
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Snowflake/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Snowflake/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Snowflake/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Snowflake/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,36 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Snowflake/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Snowflake/test_build_saved_query_tasks__query0.sql
@@ -1,23 +1,15 @@
--- Constrain Output with WHERE
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , listing__capacity_latest
   , SUM(bookings) AS bookings
   , SUM(instant_bookings) AS instant_bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
   SELECT
     subq_2.metric_time__day AS metric_time__day
     , listings_latest_src_10000.capacity AS listing__capacity_latest
     , subq_2.bookings AS bookings
     , subq_2.instant_bookings AS instant_bookings
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Trino/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Trino/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Trino/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Trino/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,36 @@
+-- Constrain Output with WHERE
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Trino/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Trino/test_build_saved_query_tasks__query0.sql
@@ -1,23 +1,15 @@
--- Constrain Output with WHERE
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , listing__capacity_latest
   , SUM(bookings) AS bookings
   , SUM(instant_bookings) AS instant_bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'instant_bookings', 'listing__capacity_latest', 'metric_time__day']
   SELECT
     subq_2.metric_time__day AS metric_time__day
     , listings_latest_src_10000.capacity AS listing__capacity_latest
     , subq_2.bookings AS bookings
     , subq_2.instant_bookings AS instant_bookings
   FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'instant_bookings', 'metric_time__day', 'listing']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , listing_id AS listing

--- a/tests_metricflow/validation/test_data_warehouse_tasks.py
+++ b/tests_metricflow/validation/test_data_warehouse_tasks.py
@@ -51,7 +51,7 @@ def test_build_semantic_model_tasks(  # noqa: D103
     assert len(tasks) == len(data_warehouse_validation_model.semantic_models)
 
     tasks = DataWarehouseTaskBuilder.gen_semantic_model_tasks(
-        manifest=data_warehouse_validation_model, filter_by_semantic_models=[]
+        manifest=data_warehouse_validation_model, semantic_model_filters=[]
     )
     assert len(tasks) == 0
 
@@ -123,7 +123,7 @@ def test_build_dimension_tasks(  # noqa: D103
     tasks = DataWarehouseTaskBuilder.gen_dimension_tasks(
         manifest=data_warehouse_validation_model,
         sql_client=sql_client,
-        filter_by_semantic_models=[],
+        semantic_model_filters=[],
     )
     assert len(tasks) == 0
 
@@ -162,7 +162,7 @@ def test_build_entities_tasks(  # noqa: D103
     assert len(tasks[0].on_fail_subtasks) == 1  # a sub task for each entity on the semantic model
 
     tasks = DataWarehouseTaskBuilder.gen_entity_tasks(
-        manifest=data_warehouse_validation_model, sql_client=sql_client, filter_by_semantic_models=[]
+        manifest=data_warehouse_validation_model, sql_client=sql_client, semantic_model_filters=[]
     )
     assert len(tasks) == 0
 
@@ -201,7 +201,7 @@ def test_build_measure_tasks(  # noqa: D103
     assert len(tasks[0].on_fail_subtasks) == 1  # a sub task for each measure on the semantic model
 
     tasks = DataWarehouseTaskBuilder.gen_measure_tasks(
-        manifest=data_warehouse_validation_model, sql_client=sql_client, filter_by_semantic_models=[]
+        manifest=data_warehouse_validation_model, sql_client=sql_client, semantic_model_filters=[]
     )
     assert len(tasks) == 0
 
@@ -253,7 +253,7 @@ def test_build_metric_tasks(  # noqa: D103
     tasks = DataWarehouseTaskBuilder.gen_metric_tasks(
         manifest=data_warehouse_validation_model,
         sql_client=sql_client,
-        filter_by_metrics=[],
+        metric_filters=[],
     )
     assert len(tasks) == 0
 
@@ -305,7 +305,7 @@ def test_build_saved_query_tasks(  # noqa: D103
     assert len(tasks) == 2
 
     tasks = DataWarehouseTaskBuilder.gen_saved_query_tasks(
-        manifest=simple_semantic_manifest, sql_client=sql_client, filter_by_saved_queries=["p0_booking"]
+        manifest=simple_semantic_manifest, sql_client=sql_client, saved_query_filters=["p0_booking"]
     )
     assert len(tasks) == 1
     (query_string, _params) = tasks[0].query_and_params_callable()

--- a/tests_metricflow/validation/test_data_warehouse_tasks.py
+++ b/tests_metricflow/validation/test_data_warehouse_tasks.py
@@ -50,6 +50,11 @@ def test_build_semantic_model_tasks(  # noqa: D103
     tasks = DataWarehouseTaskBuilder.gen_semantic_model_tasks(manifest=data_warehouse_validation_model)
     assert len(tasks) == len(data_warehouse_validation_model.semantic_models)
 
+    tasks = DataWarehouseTaskBuilder.gen_semantic_model_tasks(
+        manifest=data_warehouse_validation_model, filter_by_semantic_models=[]
+    )
+    assert len(tasks) == 0
+
 
 def test_task_runner(sql_client: SqlClient, mf_test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D103
     dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
@@ -115,6 +120,13 @@ def test_build_dimension_tasks(  # noqa: D103
     # 1 categorical dimension task, 1 time dimension task, 4 granularity based time dimension tasks, 6 date_part tasks
     assert len(tasks[0].on_fail_subtasks) == 12
 
+    tasks = DataWarehouseTaskBuilder.gen_dimension_tasks(
+        manifest=data_warehouse_validation_model,
+        sql_client=sql_client,
+        filter_by_semantic_models=[],
+    )
+    assert len(tasks) == 0
+
 
 def test_validate_dimensions(  # noqa: D103
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
@@ -149,6 +161,11 @@ def test_build_entities_tasks(  # noqa: D103
     assert len(tasks) == 1  # on semantic model query with all entities
     assert len(tasks[0].on_fail_subtasks) == 1  # a sub task for each entity on the semantic model
 
+    tasks = DataWarehouseTaskBuilder.gen_entity_tasks(
+        manifest=data_warehouse_validation_model, sql_client=sql_client, filter_by_semantic_models=[]
+    )
+    assert len(tasks) == 0
+
 
 def test_validate_entities(  # noqa: D103
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
@@ -182,6 +199,11 @@ def test_build_measure_tasks(  # noqa: D103
     )
     assert len(tasks) == 1  # on semantic model query with all measures
     assert len(tasks[0].on_fail_subtasks) == 1  # a sub task for each measure on the semantic model
+
+    tasks = DataWarehouseTaskBuilder.gen_measure_tasks(
+        manifest=data_warehouse_validation_model, sql_client=sql_client, filter_by_semantic_models=[]
+    )
+    assert len(tasks) == 0
 
 
 def test_validate_measures(  # noqa: D103
@@ -227,6 +249,13 @@ def test_build_metric_tasks(  # noqa: D103
         sql=query_string,
         sql_engine=sql_client.sql_engine_type,
     )
+
+    tasks = DataWarehouseTaskBuilder.gen_metric_tasks(
+        manifest=data_warehouse_validation_model,
+        sql_client=sql_client,
+        filter_by_metrics=[],
+    )
+    assert len(tasks) == 0
 
 
 def test_validate_metrics(  # noqa: D103


### PR DESCRIPTION
## Context
We want to add support for filtering to certain semantic models when validating measures/dimensions/entities/semantic_models, certain metrics when validating metrics, certain saved queries when validating saved queries.

Additionally, we want to add support to generating SQL for validating saved queries

Resolves SL-2375