### PR TITLE
Include group by metrics in `MatchingLinkableSpecsTransform`

### DIFF
--- a/metricflow/dataflow/optimizer/source_scan/matching_linkable_specs.py
+++ b/metricflow/dataflow/optimizer/source_scan/matching_linkable_specs.py
@@ -14,4 +14,5 @@ class MatchingLinkableSpecsTransform(InstanceSpecSetTransform[bool]):
             set(self._left_spec_set.dimension_specs) == set(spec_set.dimension_specs)
             and set(self._left_spec_set.time_dimension_specs) == set(spec_set.time_dimension_specs)
             and set(self._left_spec_set.entity_specs) == set(spec_set.entity_specs)
+            and set(self._left_spec_set.group_by_metric_specs) == set(spec_set.group_by_metric_specs)
         )


### PR DESCRIPTION
Tiny cleanup item that was previously missed.