### PR TITLE
Store a list of input WhereFilterSpecs in the WhereConstraintNode

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -634,8 +634,7 @@ class DataflowPlanBuilder:
             )
 
             if len(metric_spec.filter_specs) > 0:
-                merged_where_filter = WhereFilterSpec.merge_iterable(metric_spec.filter_specs)
-                output_node = WhereConstraintNode(parent_node=output_node, where_constraint=merged_where_filter)
+                output_node = WhereConstraintNode(parent_node=output_node, where_specs=metric_spec.filter_specs)
             if not extraneous_linkable_specs.is_subset_of(queried_linkable_specs):
                 output_node = FilterElementsNode(
                     parent_node=output_node,
@@ -776,9 +775,7 @@ class DataflowPlanBuilder:
             output_node = JoinOnEntitiesNode(left_node=output_node, join_targets=dataflow_recipe.join_targets)
 
         if len(query_level_filter_specs) > 0:
-            output_node = WhereConstraintNode(
-                parent_node=output_node, where_constraint=WhereFilterSpec.merge_iterable(query_level_filter_specs)
-            )
+            output_node = WhereConstraintNode(parent_node=output_node, where_specs=query_level_filter_specs)
         if query_spec.time_range_constraint:
             output_node = ConstrainTimeRangeNode(
                 parent_node=output_node, time_range_constraint=query_spec.time_range_constraint
@@ -1524,12 +1521,11 @@ class DataflowPlanBuilder:
             )
 
         pre_aggregate_node: DataflowPlanNode = cumulative_metric_constrained_node or unaggregated_measure_node
-        merged_where_filter_spec = WhereFilterSpec.merge_iterable(metric_input_measure_spec.filter_specs)
         if len(metric_input_measure_spec.filter_specs) > 0:
             # Apply where constraint on the node
             pre_aggregate_node = WhereConstraintNode(
                 parent_node=pre_aggregate_node,
-                where_constraint=merged_where_filter_spec,
+                where_specs=metric_input_measure_spec.filter_specs,
             )
 
         if non_additive_dimension_spec is not None:
@@ -1598,9 +1594,7 @@ class DataflowPlanBuilder:
                 if set(filter_spec.linkable_specs).issubset(set(queried_linkable_specs.as_tuple))
             ]
             if len(queried_filter_specs) > 0:
-                output_node = WhereConstraintNode(
-                    parent_node=output_node, where_constraint=WhereFilterSpec.merge_iterable(queried_filter_specs)
-                )
+                output_node = WhereConstraintNode(parent_node=output_node, where_specs=queried_filter_specs)
 
             # TODO: this will break if you query by agg_time_dimension but apply a time constraint on metric_time.
             # To fix when enabling time range constraints for agg_time_dimension.

--- a/metricflow/dataflow/optimizer/predicate_pushdown_optimizer.py
+++ b/metricflow/dataflow/optimizer/predicate_pushdown_optimizer.py
@@ -255,8 +255,8 @@ class PredicatePushdownOptimizer(
         """
         self._log_visit_node_type(node)
         current_pushdown_state = self._predicate_pushdown_tracker.last_pushdown_state
-        # TODO: update WhereConstraintNode to hold a list of specs instead of merging them all before initialization
-        where_specs = (node.where,)
+        # TODO: short-circuit cases where pushdown is disabled for where constraints
+        where_specs = node.input_where_specs
         pushdown_eligible_specs: List[WhereFilterSpec] = []
         for spec in where_specs:
             semantic_models = self._models_for_spec(spec)

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -378,9 +378,8 @@ class PreJoinNodeProcessor:
                 if len(matching_filter_specs) == 0:
                     filtered_nodes.append(source_node)
                 else:
-                    where_constraint = WhereFilterSpec.merge_iterable(matching_filter_specs)
                     filtered_nodes.append(
-                        WhereConstraintNode(parent_node=source_node, where_constraint=where_constraint)
+                        WhereConstraintNode(parent_node=source_node, where_specs=matching_filter_specs)
                     )
             else:
                 filtered_nodes.append(source_node)

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -190,27 +190,29 @@ def test_filter_with_where_constraint_node(
     )  # need to include ds_spec because where constraint operates on ds
     where_constraint_node = WhereConstraintNode(
         parent_node=filter_node,
-        where_constraint=WhereFilterSpec(
-            where_sql="booking__ds__day = '2020-01-01'",
-            bind_parameters=SqlBindParameters(),
-            linkable_specs=(
-                TimeDimensionSpec(
-                    element_name="ds",
-                    entity_links=(EntityReference(element_name="booking"),),
-                    time_granularity=TimeGranularity.DAY,
+        where_specs=(
+            WhereFilterSpec(
+                where_sql="booking__ds__day = '2020-01-01'",
+                bind_parameters=SqlBindParameters(),
+                linkable_specs=(
+                    TimeDimensionSpec(
+                        element_name="ds",
+                        entity_links=(EntityReference(element_name="booking"),),
+                        time_granularity=TimeGranularity.DAY,
+                    ),
                 ),
-            ),
-            linkable_elements=(
-                LinkableDimension(
-                    defined_in_semantic_model=SemanticModelReference("bookings_source"),
-                    element_name="ds",
-                    dimension_type=DimensionType.TIME,
-                    entity_links=(EntityReference(element_name="booking"),),
-                    properties=frozenset(),
-                    time_granularity=TimeGranularity.DAY,
-                    date_part=None,
-                    join_path=SemanticModelJoinPath(
-                        left_semantic_model_reference=SemanticModelReference("bookings_source"),
+                linkable_elements=(
+                    LinkableDimension(
+                        defined_in_semantic_model=SemanticModelReference("bookings_source"),
+                        element_name="ds",
+                        dimension_type=DimensionType.TIME,
+                        entity_links=(EntityReference(element_name="booking"),),
+                        properties=frozenset(),
+                        time_granularity=TimeGranularity.DAY,
+                        date_part=None,
+                        join_path=SemanticModelJoinPath(
+                            left_semantic_model_reference=SemanticModelReference("bookings_source"),
+                        ),
                     ),
                 ),
             ),


### PR DESCRIPTION
Up until now we've been merging sets of WhereFilterSpec instances
into a single instance and then storing that in the WhereConstraintNode.

This made sense for rendering, but when trying to do predicate pushdown
having the specs all merged together limits the space of filter pushdown
opporunities. In order to allow for the same breadth of predicate pushdown
opportunities we have at dataflow plan build time we keep the specs separate,
and encapsulate the merging of these specs into the WhereConstraintNode itself.