### PR TITLE
Update API for requesting dataflow plan optimization

### DIFF
--- a/metricflow/dataflow/optimizer/dataflow_optimizer_factory.py
+++ b/metricflow/dataflow/optimizer/dataflow_optimizer_factory.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Sequence
+
+from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+
+from metricflow.dataflow.optimizer.dataflow_plan_optimizer import DataflowPlanOptimizer
+from metricflow.dataflow.optimizer.predicate_pushdown_optimizer import PredicatePushdownOptimizer
+from metricflow.dataflow.optimizer.source_scan.source_scan_optimizer import SourceScanOptimizer
+
+
+class DataflowPlanOptimization(Enum):
+    """Enumeration of optimization types available for execution."""
+
+    PREDICATE_PUSHDOWN = "predicate_pushdown"
+    SOURCE_SCAN = "source_scan"
+
+
+class DataflowPlanOptimizerFactory:
+    """Factory class for initializing an enumerated set of optimizers.
+
+    This allows us to centralize initialization and, most importantly, share class instances with cached high cost
+    processing between the DataflowPlanBuilder and the optimizer instances requiring that functionality.
+    """
+
+    def get_optimizers(self, optimizations: Sequence[DataflowPlanOptimization]) -> Sequence[DataflowPlanOptimizer]:
+        """Initializes and returns a sequence of optimizers matching the input optimization requests."""
+        optimizers: List[DataflowPlanOptimizer] = []
+        for optimization in optimizations:
+            if optimization is DataflowPlanOptimization.SOURCE_SCAN:
+                optimizers.append(SourceScanOptimizer())
+            elif optimization is DataflowPlanOptimization.PREDICATE_PUSHDOWN:
+                optimizers.append(PredicatePushdownOptimizer())
+            else:
+                assert_values_exhausted(optimization)
+
+        return tuple(optimizers)

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -39,9 +39,7 @@ from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilde
 from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
 from metricflow.dataflow.builder.source_node import SourceNodeBuilder
 from metricflow.dataflow.dataflow_plan import DataflowPlan
-from metricflow.dataflow.optimizer.source_scan.source_scan_optimizer import (
-    SourceScanOptimizer,
-)
+from metricflow.dataflow.optimizer.dataflow_optimizer_factory import DataflowPlanOptimization
 from metricflow.dataset.convert_semantic_model import SemanticModelToDataSetConverter
 from metricflow.dataset.dataset_classes import DataSet
 from metricflow.dataset.semantic_model_adapter import SemanticModelDataSet
@@ -502,7 +500,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             dataflow_plan = self._dataflow_plan_builder.build_plan(
                 query_spec=query_spec,
                 output_selection_specs=output_selection_specs,
-                optimizers=(SourceScanOptimizer(),),
+                optimizations=(DataflowPlanOptimization.SOURCE_SCAN,),
             )
         else:
             dataflow_plan = self._dataflow_plan_builder.build_plan_for_distinct_values(query_spec=query_spec)

--- a/tests_metricflow/query_rendering/compare_rendered_query.py
+++ b/tests_metricflow/query_rendering/compare_rendered_query.py
@@ -8,7 +8,7 @@ from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.dataflow.optimizer.predicate_pushdown_optimizer import PredicatePushdownOptimizer
+from metricflow.dataflow.optimizer.dataflow_optimizer_factory import DataflowPlanOptimization
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
@@ -52,11 +52,11 @@ def render_and_check(
     )
 
     # Run dataflow -> sql conversion with all optimizers
+    optimizations = (DataflowPlanOptimization.PREDICATE_PUSHDOWN,)
     if is_distinct_values_plan:
-        # TODO: Make optimization available for distinct values plans
-        optimized_plan = base_plan
+        optimized_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec, optimizations=optimizations)
     else:
-        optimized_plan = dataflow_plan_builder.build_plan(query_spec, optimizers=(PredicatePushdownOptimizer(),))
+        optimized_plan = dataflow_plan_builder.build_plan(query_spec, optimizations=optimizations)
     conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=optimized_plan.sink_node,

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_19.listing__bookings AS listing__bookings
+    , subq_23.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    ) subq_20
     GROUP BY
       listing
-  ) subq_19
+  ) subq_23
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_19.listing
-) subq_20
+    lux_listing_mapping_src_28000.listing_id = subq_23.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_19.listing__bookings AS listing__bookings
+    , subq_23.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    ) subq_20
     GROUP BY
       listing
-  ) subq_19
+  ) subq_23
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_19.listing
-) subq_20
+    lux_listing_mapping_src_28000.listing_id = subq_23.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_19.listing__bookings AS listing__bookings
+    , subq_23.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    ) subq_20
     GROUP BY
       listing
-  ) subq_19
+  ) subq_23
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_19.listing
-) subq_20
+    lux_listing_mapping_src_28000.listing_id = subq_23.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_19.listing__bookings AS listing__bookings
+    , subq_23.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    ) subq_20
     GROUP BY
       listing
-  ) subq_19
+  ) subq_23
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_19.listing
-) subq_20
+    lux_listing_mapping_src_28000.listing_id = subq_23.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_19.listing__bookings AS listing__bookings
+    , subq_23.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    ) subq_20
     GROUP BY
       listing
-  ) subq_19
+  ) subq_23
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_19.listing
-) subq_20
+    lux_listing_mapping_src_28000.listing_id = subq_23.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_19.listing__bookings AS listing__bookings
+    , subq_23.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    ) subq_20
     GROUP BY
       listing
-  ) subq_19
+  ) subq_23
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_19.listing
-) subq_20
+    lux_listing_mapping_src_28000.listing_id = subq_23.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Join Standard Outputs
   SELECT
     lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_19.listing__bookings AS listing__bookings
+    , subq_23.listing__bookings AS listing__bookings
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures
@@ -23,13 +23,13 @@ FROM (
         listing_id AS listing
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_16
+    ) subq_20
     GROUP BY
       listing
-  ) subq_19
+  ) subq_23
   ON
-    lux_listing_mapping_src_28000.listing_id = subq_19.listing
-) subq_20
+    lux_listing_mapping_src_28000.listing_id = subq_23.listing
+) subq_24
 WHERE listing__bookings > 2
 GROUP BY
   listing


### PR DESCRIPTION
In order to fully support predicate pushdown via the DataflowPlanOptimizer
framework we need two things:

1. Support for optimization in distinct values queries
2. The ability to share components between the DataflowPlanBuilder
and the PredicatePushdownOptimizer

This update addresses both of these concerns by doing a small restructure
of the DataflowPlanBuilder interface for accepting optimizers. Instead of
accepting a sequence of optimizer instances, the build_plan method will now
accept a sequence of optimization enumerations. Those will then be converted
to instances via the factory class added in this change.

From there the update to the distinct values plan method signature was
a trivial addition.

Note - snapshot updates should be limited to ID numbers due to the added
call to the DataflowPlanNodeOutputDataSetResolver in the distinct values
plan.