### PR TITLE
Verify column sets match in optimizer pushdown evaluation

### DIFF
--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -228,7 +228,7 @@ class DataflowPlanBuilder:
         return self._optimize_plan(plan, optimizations)
 
     def _optimize_plan(self, plan: DataflowPlan, optimizations: Sequence[DataflowPlanOptimization]) -> DataflowPlan:
-        optimizer_factory = DataflowPlanOptimizerFactory()
+        optimizer_factory = DataflowPlanOptimizerFactory(self._node_data_set_resolver)
         for optimizer in optimizer_factory.get_optimizers(optimizations):
             logger.info(f"Applying {optimizer.__class__.__name__}")
             try:

--- a/metricflow/dataflow/optimizer/dataflow_optimizer_factory.py
+++ b/metricflow/dataflow/optimizer/dataflow_optimizer_factory.py
@@ -5,6 +5,7 @@ from typing import List, Sequence
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 
+from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
 from metricflow.dataflow.optimizer.dataflow_plan_optimizer import DataflowPlanOptimizer
 from metricflow.dataflow.optimizer.predicate_pushdown_optimizer import PredicatePushdownOptimizer
 from metricflow.dataflow.optimizer.source_scan.source_scan_optimizer import SourceScanOptimizer
@@ -24,6 +25,13 @@ class DataflowPlanOptimizerFactory:
     processing between the DataflowPlanBuilder and the optimizer instances requiring that functionality.
     """
 
+    def __init__(self, node_data_set_resolver: DataflowPlanNodeOutputDataSetResolver) -> None:
+        """Initializer.
+
+        This collects all of the initialization requirements for the optimizers it manages.
+        """
+        self._node_data_set_resolver = node_data_set_resolver
+
     def get_optimizers(self, optimizations: Sequence[DataflowPlanOptimization]) -> Sequence[DataflowPlanOptimizer]:
         """Initializes and returns a sequence of optimizers matching the input optimization requests."""
         optimizers: List[DataflowPlanOptimizer] = []
@@ -31,7 +39,7 @@ class DataflowPlanOptimizerFactory:
             if optimization is DataflowPlanOptimization.SOURCE_SCAN:
                 optimizers.append(SourceScanOptimizer())
             elif optimization is DataflowPlanOptimization.PREDICATE_PUSHDOWN:
-                optimizers.append(PredicatePushdownOptimizer())
+                optimizers.append(PredicatePushdownOptimizer(self._node_data_set_resolver))
             else:
                 assert_values_exhausted(optimization)
 


### PR DESCRIPTION
The PredicatePushdownOptimizer did not have access to the node
dataset resolver necessary to do the comparison between the linkable
specs referenced in the where filter and the linkable specs available
from the DataflowPlanNode targeted by predicate pushdown.

This change makes the node dataset resolver available in the optimizer.
It uses the one from the DataflowPlanBuilder in order to take advantage
of the cached resolutions available from the build process. The optimizer
is then used to evaluate the column matches in the same manner as the
original build-time pushdown evaluation.

This change was tested by running one of the predicate pushdown rendering
tests with the --log-cli-level=DEBUG confugration set, and observing the
debug output including the same entry for "Filter specs to add:" as in
the preceding commit.